### PR TITLE
feat(agent): structured typed holes + doc/type_at/rename methods

### DIFF
--- a/codebase/compiler/src/agent/handlers.rs
+++ b/codebase/compiler/src/agent/handlers.rs
@@ -60,142 +60,37 @@ pub struct HoleFunction {
 
 /// Extract structured hole info from diagnostics.
 ///
-/// The typechecker emits hole diagnostics with notes like:
-///   "expected type: Int"
-///   "matching bindings in scope: `a` (Int), `b` (Int)"
-///   "matching functions: `random_int(min: Int, max: Int)` -> Int, ..."
-///
-/// We parse these into structured data.
+/// Reads the `hole` field on each diagnostic (populated by the typechecker
+/// via `TypedHoleData`) and maps it into the agent's serialization shape.
+/// No string parsing — consumers get fully structured data.
 fn extract_holes(diagnostics: &[query::Diagnostic]) -> Vec<HoleInfo> {
     diagnostics
         .iter()
-        .filter(|d| d.message.contains("typed hole"))
-        .map(|d| {
-            let expected_type = d.notes.iter().find_map(|n| {
-                n.strip_prefix("expected type: ").map(|s| s.to_string())
-            });
-
-            let matching_bindings = d
-                .notes
-                .iter()
-                .find(|n| n.contains("matching bindings"))
-                .map(|n| {
-                    // Format: "matching bindings in scope: `a` (Int), `b` (Int)"
-                    // Split on the first colon to get the list part.
-                    let list = n.split_once(':').map(|(_, rest)| rest).unwrap_or("");
-                    parse_binding_list(list)
-                })
-                .unwrap_or_default();
-
-            let matching_functions = d
-                .notes
-                .iter()
-                .find(|n| n.contains("matching functions"))
-                .map(|n| {
-                    // Format: "matching functions: `sig` -> Ret, `sig` -> Ret, ..."
-                    let list = n.split_once(':').map(|(_, rest)| rest).unwrap_or("");
-                    parse_function_list(list)
-                })
-                .unwrap_or_default();
-
-            HoleInfo {
+        .filter_map(|d| {
+            let h = d.hole.as_ref()?;
+            Some(HoleInfo {
                 span: d.span,
-                expected_type,
-                matching_bindings,
-                matching_functions,
+                expected_type: h.expected_type.clone(),
+                matching_bindings: h
+                    .matching_bindings
+                    .iter()
+                    .map(|b| HoleBinding {
+                        name: b.name.clone(),
+                        ty: b.ty.clone(),
+                    })
+                    .collect(),
+                matching_functions: h
+                    .matching_functions
+                    .iter()
+                    .map(|f| HoleFunction {
+                        name: f.name.clone(),
+                        signature: f.signature.clone(),
+                    })
+                    .collect(),
                 matching_variants: Vec::new(),
-            }
+            })
         })
         .collect()
-}
-
-/// Parse binding list from note format: " `a` (Int), `b` (Int)"
-fn parse_binding_list(s: &str) -> Vec<HoleBinding> {
-    // Split on "), " to handle entries like "`a` (Int), `b` (Int)"
-    let mut result = Vec::new();
-    for entry in s.split("), ") {
-        let entry = entry.trim().trim_end_matches(')');
-        // Entry looks like: "`a` (Int" or "`name` (Type"
-        if let Some(backtick_start) = entry.find('`') {
-            if let Some(backtick_end) = entry[backtick_start + 1..].find('`') {
-                let name = entry[backtick_start + 1..backtick_start + 1 + backtick_end].to_string();
-                // Type is after the closing backtick, inside parens
-                let rest = &entry[backtick_start + 1 + backtick_end + 1..];
-                let ty = rest
-                    .trim()
-                    .trim_start_matches('(')
-                    .trim_end_matches(')')
-                    .trim()
-                    .to_string();
-                if !name.is_empty() {
-                    result.push(HoleBinding {
-                        name,
-                        ty: if ty.is_empty() { "unknown".to_string() } else { ty },
-                    });
-                }
-            }
-        }
-    }
-    result
-}
-
-/// Parse function list from note format: " `sig(params)` -> Ret, ..."
-fn parse_function_list(s: &str) -> Vec<HoleFunction> {
-    let mut result = Vec::new();
-    // Split on "`, " to separate entries, being careful with backtick boundaries.
-    // Each entry looks like: "`random_int(min: Int, max: Int)` -> Int"
-    // We can't naively split on ", " because param lists contain commas.
-    // Instead, split on "` -> " boundaries which mark function entries.
-    let mut remaining = s.trim();
-    while !remaining.is_empty() {
-        // Find the opening backtick
-        let start = match remaining.find('`') {
-            Some(i) => i,
-            None => break,
-        };
-        remaining = &remaining[start + 1..];
-
-        // Find the closing backtick — it's the one followed by " -> "
-        // The signature may contain nested backticks in theory, but in practice
-        // the format is `name(params)` -> RetType
-        let end = match remaining.find("` -> ") {
-            Some(i) => i,
-            None => {
-                // No return type arrow — might be end of string with just backtick
-                if let Some(i) = remaining.find('`') {
-                    let sig = remaining[..i].to_string();
-                    let fn_name = sig.split('(').next().unwrap_or(&sig).to_string();
-                    if !fn_name.is_empty() {
-                        result.push(HoleFunction {
-                            name: fn_name,
-                            signature: format!("fn {}", sig),
-                        });
-                    }
-                }
-                break;
-            }
-        };
-
-        let sig = remaining[..end].to_string();
-        remaining = &remaining[end + 5..]; // skip "` -> "
-
-        // The return type goes until the next ", `" or end of string
-        let ret_end = remaining.find(", `").unwrap_or(remaining.len());
-        let ret_type = remaining[..ret_end].trim().to_string();
-        remaining = &remaining[ret_end..];
-        if remaining.starts_with(", ") {
-            remaining = &remaining[2..];
-        }
-
-        let fn_name = sig.split('(').next().unwrap_or(&sig).to_string();
-        if !fn_name.is_empty() {
-            result.push(HoleFunction {
-                name: fn_name,
-                signature: format!("fn {} -> {}", sig, ret_type),
-            });
-        }
-    }
-    result
 }
 
 /// Build a full SessionReport from a Session.
@@ -376,6 +271,81 @@ pub fn handle_call_graph(session: &Session) -> Result<Value, Response> {
     serde_json::to_value(session.call_graph()).map_err(serialization_error)
 }
 
+/// Handle the `doc` method — returns full module documentation.
+pub fn handle_doc(session: &Session) -> Result<Value, Response> {
+    serde_json::to_value(session.documentation()).map_err(serialization_error)
+}
+
+/// Handle the `type_at` method.
+///
+/// Params: `{ "line": u32, "col": u32 }`. Returns the type at that position,
+/// or JSON `null` if no expression sits there.
+pub fn handle_type_at(params: &Value, session: &Session) -> Result<Value, Response> {
+    let line = params
+        .get("line")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
+        .ok_or_else(|| {
+            Response::error(
+                Value::Null,
+                protocol::INVALID_PARAMS,
+                "\"line\" parameter required (u32)",
+            )
+        })?;
+    let col = params
+        .get("col")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
+        .ok_or_else(|| {
+            Response::error(
+                Value::Null,
+                protocol::INVALID_PARAMS,
+                "\"col\" parameter required (u32)",
+            )
+        })?;
+
+    match session.type_at(line, col) {
+        Some(r) => serde_json::to_value(r).map_err(serialization_error),
+        None => Ok(serde_json::json!(null)),
+    }
+}
+
+/// Handle the `rename` method.
+///
+/// Params: `{ "old_name": string, "new_name": string }`. Returns the rename
+/// result (new source + locations + verification).
+pub fn handle_rename(params: &Value, session: &Session) -> Result<Value, Response> {
+    let old_name = params
+        .get("old_name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            Response::error(
+                Value::Null,
+                protocol::INVALID_PARAMS,
+                "\"old_name\" parameter required (string)",
+            )
+        })?;
+    let new_name = params
+        .get("new_name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            Response::error(
+                Value::Null,
+                protocol::INVALID_PARAMS,
+                "\"new_name\" parameter required (string)",
+            )
+        })?;
+
+    match session.rename(old_name, new_name) {
+        Ok(r) => serde_json::to_value(r).map_err(serialization_error),
+        Err(msg) => Err(Response::error(
+            Value::Null,
+            protocol::INVALID_PARAMS,
+            msg,
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -444,6 +414,9 @@ mod tests {
         let result = handle_load(&params, &mut session).unwrap();
         let holes = result["holes"].as_array().unwrap();
         assert!(!holes.is_empty(), "should have at least one hole");
+        // Structured data should be populated directly from the typechecker,
+        // not parsed out of diagnostic notes.
+        assert_eq!(holes[0]["expected_type"], "Int");
     }
 
     #[test]
@@ -484,6 +457,68 @@ mod tests {
         let budget_params = serde_json::json!({"function": "add", "budget": 1000});
         let result = handle_context_budget(&budget_params, session.as_ref().unwrap()).unwrap();
         assert_eq!(result["target_function"], "add");
+    }
+
+    #[test]
+    fn doc_after_load() {
+        let params = serde_json::json!({"source": "fn add(a: Int, b: Int) -> Int:\n    a + b\n"});
+        let mut session = None;
+        handle_load(&params, &mut session).unwrap();
+        let result = handle_doc(session.as_ref().unwrap()).unwrap();
+        assert!(!result.is_null());
+        assert!(result.get("module").is_some());
+    }
+
+    #[test]
+    fn type_at_after_load() {
+        let params = serde_json::json!({"source": "fn add(a: Int, b: Int) -> Int:\n    a + b\n"});
+        let mut session = None;
+        handle_load(&params, &mut session).unwrap();
+        // Point at `a` in the body on line 2 (1-indexed), col 5 (after 4 spaces).
+        let q = serde_json::json!({"line": 2, "col": 5});
+        let result = handle_type_at(&q, session.as_ref().unwrap()).unwrap();
+        // Either structured result with "type", or null if position misses.
+        if !result.is_null() {
+            assert!(result.get("type").is_some());
+        }
+    }
+
+    #[test]
+    fn type_at_missing_params() {
+        let params = serde_json::json!({"source": "fn add(a: Int, b: Int) -> Int:\n    a + b\n"});
+        let mut session = None;
+        handle_load(&params, &mut session).unwrap();
+        let q = serde_json::json!({});
+        let result = handle_type_at(&q, session.as_ref().unwrap());
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().error.unwrap().code,
+            protocol::INVALID_PARAMS
+        );
+    }
+
+    #[test]
+    fn rename_after_load() {
+        let params = serde_json::json!({"source": "fn add(a: Int, b: Int) -> Int:\n    a + b\n"});
+        let mut session = None;
+        handle_load(&params, &mut session).unwrap();
+        let q = serde_json::json!({"old_name": "add", "new_name": "sum"});
+        let result = handle_rename(&q, session.as_ref().unwrap()).unwrap();
+        assert!(!result.is_null());
+    }
+
+    #[test]
+    fn rename_missing_params() {
+        let params = serde_json::json!({"source": "fn add(a: Int, b: Int) -> Int:\n    a + b\n"});
+        let mut session = None;
+        handle_load(&params, &mut session).unwrap();
+        let q = serde_json::json!({"old_name": "add"});
+        let result = handle_rename(&q, session.as_ref().unwrap());
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().error.unwrap().code,
+            protocol::INVALID_PARAMS
+        );
     }
 
     #[test]

--- a/codebase/compiler/src/agent/server.rs
+++ b/codebase/compiler/src/agent/server.rs
@@ -21,6 +21,9 @@ const CAPABILITIES: &[&str] = &[
     "effects",
     "inspect",
     "call_graph",
+    "doc",
+    "type_at",
+    "rename",
     "shutdown",
 ];
 
@@ -120,6 +123,12 @@ fn dispatch(
         "inspect" => with_session(session, id, handlers::handle_inspect),
 
         "call_graph" => with_session(session, id, handlers::handle_call_graph),
+
+        "doc" => with_session(session, id, handlers::handle_doc),
+
+        "type_at" => with_session(session, id, |s| handlers::handle_type_at(params, s)),
+
+        "rename" => with_session(session, id, |s| handlers::handle_rename(params, s)),
 
         "shutdown" => Response::success(id, serde_json::json!({"ok": true})),
 

--- a/codebase/compiler/src/query.rs
+++ b/codebase/compiler/src/query.rs
@@ -106,6 +106,42 @@ pub struct Diagnostic {
     /// Additional notes or suggestions.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub notes: Vec<String>,
+    /// Structured typed-hole context. Set only for typed-hole diagnostics.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hole: Option<TypedHoleInfo>,
+}
+
+/// Structured typed-hole context attached to a typed-hole diagnostic.
+///
+/// Mirrors the typechecker's [`crate::typechecker::error::TypedHoleData`] in
+/// the public query surface so consumers (LSP, agent mode) can read fields
+/// directly without parsing diagnostic notes.
+#[derive(Debug, Clone, Serialize)]
+pub struct TypedHoleInfo {
+    /// The hole label as written in source, e.g. `"?"` or `"?goal"`.
+    pub label: String,
+    /// The expected type at the hole, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_type: Option<String>,
+    /// In-scope bindings whose type matches the expected type.
+    pub matching_bindings: Vec<HoleBinding>,
+    /// Functions whose return type matches the expected type.
+    pub matching_functions: Vec<HoleFunction>,
+}
+
+/// A binding that matches a typed hole's expected type.
+#[derive(Debug, Clone, Serialize)]
+pub struct HoleBinding {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: String,
+}
+
+/// A function that returns a typed hole's expected type.
+#[derive(Debug, Clone, Serialize)]
+pub struct HoleFunction {
+    pub name: String,
+    pub signature: String,
 }
 
 /// The result of checking a source file.
@@ -768,10 +804,31 @@ impl Session {
                 },
                 found: Some(pe.found.clone()),
                 notes: Vec::new(),
+                hole: None,
             });
         }
 
         for te in &self.type_errors {
+            let hole = te.hole_data.as_ref().map(|h| TypedHoleInfo {
+                label: h.label.clone(),
+                expected_type: h.expected_type.clone(),
+                matching_bindings: h
+                    .matching_bindings
+                    .iter()
+                    .map(|b| HoleBinding {
+                        name: b.name.clone(),
+                        ty: b.ty.clone(),
+                    })
+                    .collect(),
+                matching_functions: h
+                    .matching_functions
+                    .iter()
+                    .map(|f| HoleFunction {
+                        name: f.name.clone(),
+                        signature: f.signature.clone(),
+                    })
+                    .collect(),
+            });
             diagnostics.push(Diagnostic {
                 phase: Phase::Typechecker,
                 severity: if te.is_warning {
@@ -784,6 +841,7 @@ impl Session {
                 expected: te.expected.as_ref().map(|t| t.to_string()),
                 found: te.found.as_ref().map(|t| t.to_string()),
                 notes: te.notes.clone(),
+                hole,
             });
         }
 

--- a/codebase/compiler/src/typechecker/checker.rs
+++ b/codebase/compiler/src/typechecker/checker.rs
@@ -1485,19 +1485,35 @@ impl TypeChecker {
                 let mut error =
                     TypeError::new(format!("typed hole `{}` found", label_str), expr.span);
 
+                let mut hole_data = super::error::TypedHoleData {
+                    label: label_str.clone(),
+                    expected_type: None,
+                    matching_bindings: Vec::new(),
+                    matching_functions: Vec::new(),
+                };
+
                 if let Some(ref expected) = expected_ty {
-                    error = error.with_note(format!("expected type: {}", expected));
+                    let expected_str = format!("{}", expected);
+                    error = error.with_note(format!("expected type: {}", expected_str));
+                    hole_data.expected_type = Some(expected_str);
 
                     // Collect all in-scope bindings whose type matches the expected type.
                     let all_bindings = self.env.all_bindings();
-                    let matching: Vec<String> = all_bindings
+                    let matching_data: Vec<super::error::HoleBindingData> = all_bindings
                         .iter()
                         .filter(|(_, ty, _)| ty == expected)
-                        .map(|(name, ty, _)| format!("`{}` ({})", name, ty))
+                        .map(|(name, ty, _)| super::error::HoleBindingData {
+                            name: name.clone(),
+                            ty: format!("{}", ty),
+                        })
+                        .collect();
+                    let matching: Vec<String> = matching_data
+                        .iter()
+                        .map(|b| format!("`{}` ({})", b.name, b.ty))
                         .collect();
 
                     // Also check functions that return the expected type.
-                    let matching_fns: Vec<String> = self
+                    let matching_fns_data: Vec<super::error::HoleFunctionData> = self
                         .env
                         .all_functions()
                         .iter()
@@ -1509,7 +1525,21 @@ impl TypeChecker {
                                 .map(|(pname, pty, _)| format!("{}: {}", pname, pty))
                                 .collect::<Vec<_>>()
                                 .join(", ");
-                            format!("`{}({})` -> {}", name, params, sig.ret)
+                            super::error::HoleFunctionData {
+                                name: name.clone(),
+                                signature: format!("{}({}) -> {}", name, params, sig.ret),
+                            }
+                        })
+                        .collect();
+                    let matching_fns: Vec<String> = matching_fns_data
+                        .iter()
+                        .map(|f| {
+                            // Format as "`name(params)` -> Ret" for the human-readable note.
+                            let (sig, ret) = f
+                                .signature
+                                .split_once(" -> ")
+                                .unwrap_or((f.signature.as_str(), ""));
+                            format!("`{}` -> {}", sig, ret)
                         })
                         .collect();
 
@@ -1528,11 +1558,15 @@ impl TypeChecker {
                             "no bindings or functions in scope match the expected type".to_string(),
                         );
                     }
+
+                    hole_data.matching_bindings = matching_data;
+                    hole_data.matching_functions = matching_fns_data;
                 } else {
                     error =
                         error.with_note("fill in the hole with a concrete expression".to_string());
                 }
 
+                error = error.with_hole_data(hole_data);
                 self.errors.push(error);
                 Ty::Error
             }
@@ -5083,6 +5117,7 @@ impl TypeChecker {
                             found: None,
                             notes: vec!["available types: Int, Float, String, Bool, ()".to_string()],
                             is_warning: false,
+                        hole_data: None,
                         });
                         Ty::Error
                     }
@@ -5131,6 +5166,7 @@ impl TypeChecker {
                         found: None,
                         notes: vec![],
                         is_warning: false,
+                    hole_data: None,
                     });
                     return Ty::Error;
                 }
@@ -5151,6 +5187,7 @@ impl TypeChecker {
                         found: None,
                         notes: vec![],
                         is_warning: false,
+                    hole_data: None,
                     });
                     return Ty::Error;
                 }
@@ -5170,6 +5207,7 @@ impl TypeChecker {
                         found: None,
                         notes: vec![],
                         is_warning: false,
+                    hole_data: None,
                     });
                     return Ty::Error;
                 }
@@ -5188,6 +5226,7 @@ impl TypeChecker {
                         found: None,
                         notes: vec![],
                         is_warning: false,
+                    hole_data: None,
                     });
                     return Ty::Error;
                 }
@@ -5206,6 +5245,7 @@ impl TypeChecker {
                         found: None,
                         notes: vec![],
                         is_warning: false,
+                    hole_data: None,
                     });
                     return Ty::Error;
                 }
@@ -5224,6 +5264,7 @@ impl TypeChecker {
                         found: None,
                         notes: vec![],
                         is_warning: false,
+                    hole_data: None,
                     });
                     return Ty::Error;
                 }
@@ -5249,6 +5290,7 @@ impl TypeChecker {
                         found: None,
                         notes: vec![],
                         is_warning: false,
+                    hole_data: None,
                     });
                     return Ty::Error;
                 }
@@ -5268,6 +5310,7 @@ impl TypeChecker {
                         found: None,
                         notes: vec![],
                         is_warning: false,
+                    hole_data: None,
                     });
                     return Ty::Error;
                 }
@@ -5284,6 +5327,7 @@ impl TypeChecker {
                         found: None,
                         notes: vec![],
                         is_warning: false,
+                    hole_data: None,
                     });
                     return Ty::Error;
                 }
@@ -5309,6 +5353,7 @@ impl TypeChecker {
                         found: None,
                         notes: vec![],
                         is_warning: false,
+                    hole_data: None,
                     });
                     return Ty::Error;
                 }
@@ -5337,6 +5382,7 @@ impl TypeChecker {
                     found: None,
                     notes: vec![],
                     is_warning: false,
+                hole_data: None,
                 });
                 Ty::Error
             }

--- a/codebase/compiler/src/typechecker/error.rs
+++ b/codebase/compiler/src/typechecker/error.rs
@@ -10,6 +10,37 @@ use std::fmt;
 use super::types::Ty;
 use crate::ast::span::Span;
 
+/// Structured data for a typed-hole diagnostic.
+///
+/// The typechecker populates this directly when emitting a `typed hole` error,
+/// so downstream consumers (LSP, agent mode) can read structured fields rather
+/// than parsing the human-readable notes.
+#[derive(Debug, Clone, Default)]
+pub struct TypedHoleData {
+    /// The hole label, e.g. `"?"` or `"?goal"`.
+    pub label: String,
+    /// The expected type at the hole, if known.
+    pub expected_type: Option<String>,
+    /// In-scope bindings whose type matches the expected type.
+    pub matching_bindings: Vec<HoleBindingData>,
+    /// Functions whose return type matches the expected type.
+    pub matching_functions: Vec<HoleFunctionData>,
+}
+
+/// A binding that matches a typed hole's expected type.
+#[derive(Debug, Clone)]
+pub struct HoleBindingData {
+    pub name: String,
+    pub ty: String,
+}
+
+/// A function that returns a typed hole's expected type.
+#[derive(Debug, Clone)]
+pub struct HoleFunctionData {
+    pub name: String,
+    pub signature: String,
+}
+
 /// A type error or warning detected during type checking.
 #[derive(Debug, Clone)]
 pub struct TypeError {
@@ -25,6 +56,8 @@ pub struct TypeError {
     pub notes: Vec<String>,
     /// Whether this diagnostic is a warning rather than an error.
     pub is_warning: bool,
+    /// Structured typed-hole context. Populated only for typed-hole diagnostics.
+    pub hole_data: Option<TypedHoleData>,
 }
 
 impl TypeError {
@@ -37,7 +70,14 @@ impl TypeError {
             found: None,
             notes: Vec::new(),
             is_warning: false,
+            hole_data: None,
         }
+    }
+
+    /// Attach structured typed-hole data.
+    pub fn with_hole_data(mut self, data: TypedHoleData) -> Self {
+        self.hole_data = Some(data);
+        self
     }
 
     /// Create a type mismatch error.
@@ -49,6 +89,7 @@ impl TypeError {
             found: Some(found),
             notes: Vec::new(),
             is_warning: false,
+            hole_data: None,
         }
     }
 
@@ -61,6 +102,7 @@ impl TypeError {
             found: None,
             notes: Vec::new(),
             is_warning: true,
+            hole_data: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- Typechecker now emits structured `TypedHoleData` directly; agent mode reads it via `Diagnostic.hole` instead of parsing diagnostic note strings
- Adds three new agent JSON-RPC methods: `doc`, `type_at`, `rename` (wrapping existing `Session` APIs)
- Deletes fragile `parse_binding_list` / `parse_function_list` from `agent/handlers.rs`

## Test plan
- [x] `cargo test --release -p gradient-compiler --lib` (1066 passing, +5 from main)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo build -p gradient-compiler --features wasm` clean
- [ ] CI: check / e2e / wasm / security