### PR TITLE
fix(parser): support self-hosting compiler syntax (token.gr now parses)

### DIFF
--- a/codebase/compiler/src/parser/parser.rs
+++ b/codebase/compiler/src/parser/parser.rs
@@ -1331,6 +1331,15 @@ impl Parser {
             return self.parse_enum_variants(name, type_params, start, doc_comment);
         }
 
+        // Indented enum form after `=`:
+        //     type TokenKind =
+        //         | IntLit(Int)
+        //         | FloatLit(Float)
+        // Reuse the enum-block parser, which already tolerates a leading `|`.
+        if is_assign && self.is_indented_enum_rhs() {
+            return self.parse_enum_block_from_type(name, type_params, start, doc_comment);
+        }
+
         let type_expr = self.parse_type_expr();
         let end = type_expr.span;
 
@@ -1492,6 +1501,14 @@ impl Parser {
             self.skip_newlines();
             if matches!(self.peek(), TokenKind::Dedent | TokenKind::Eof) {
                 break;
+            }
+
+            // Tolerate a leading `|` before the first/next variant
+            // (lets `type T =\n    | A\n    | B` parse the same as the
+            // pipe-separated form).
+            if matches!(self.peek(), TokenKind::Pipe) {
+                self.advance();
+                self.skip_newlines();
             }
 
             // Parse a variant
@@ -1737,6 +1754,32 @@ impl Parser {
             }
         }
         false
+    }
+
+    /// Check if the right-hand side of `type Name =` is an indented enum
+    /// block, i.e. `=` followed by NEWLINE INDENT (optional `|`) Ident.
+    fn is_indented_enum_rhs(&self) -> bool {
+        if !matches!(self.peek(), TokenKind::Newline) {
+            return false;
+        }
+        let mut offset = 1;
+        if matches!(self.peek_ahead(offset), TokenKind::Indent) {
+            offset += 1;
+        } else {
+            return false;
+        }
+        // Skip blank lines
+        while matches!(self.peek_ahead(offset), TokenKind::Newline) {
+            offset += 1;
+        }
+        // Optional leading `|`
+        if matches!(self.peek_ahead(offset), TokenKind::Pipe) {
+            offset += 1;
+            while matches!(self.peek_ahead(offset), TokenKind::Newline) {
+                offset += 1;
+            }
+        }
+        matches!(self.peek_ahead(offset), TokenKind::Ident(_))
     }
 
     /// Check if the right-hand side of `type Name:` (with newline) is an enum block.
@@ -3607,6 +3650,66 @@ impl Parser {
     }
     /// field_def  <- IDENT ':' expr NEWLINE
     /// ```
+    /// Look ahead from `{` to confirm this is a brace-form record literal
+    /// rather than something else (e.g. a stray brace). We require the
+    /// shape `{ Ident = ...` (or `{ }` for an empty record).
+    fn peek_brace_record_literal(&self) -> bool {
+        if !matches!(self.peek(), TokenKind::LBrace) {
+            return false;
+        }
+        // `{}` empty record
+        if matches!(self.peek_ahead(1), TokenKind::RBrace) {
+            return true;
+        }
+        // `{ Ident = ...`
+        matches!(self.peek_ahead(1), TokenKind::Ident(_))
+            && matches!(self.peek_ahead(2), TokenKind::Assign)
+    }
+
+    /// Parse a brace-form record literal: `Type { field = value, ... }`.
+    /// Used by the self-hosted compiler sources.
+    fn parse_brace_record_literal(&mut self, type_name: String, start: Span) -> Expr {
+        let _ = self.expect(TokenKind::LBrace);
+
+        let mut fields = Vec::new();
+        // Allow optional newlines after `{`
+        while matches!(self.peek(), TokenKind::Newline) {
+            self.advance();
+        }
+
+        while !matches!(self.peek(), TokenKind::RBrace | TokenKind::Eof) {
+            let field_name = match self.peek().clone() {
+                TokenKind::Ident(name) => {
+                    self.advance();
+                    name
+                }
+                _ => {
+                    self.error_expected(&["field name"]);
+                    break;
+                }
+            };
+
+            if self.expect(TokenKind::Assign).is_err() {
+                break;
+            }
+
+            let value = self.parse_expr();
+            fields.push((field_name, value));
+
+            // Field separator: comma and/or newlines
+            while matches!(self.peek(), TokenKind::Comma | TokenKind::Newline) {
+                self.advance();
+            }
+        }
+
+        let _ = self.expect(TokenKind::RBrace);
+        let end = self.prev_span();
+        Spanned::new(
+            ExprKind::RecordLit { type_name, fields },
+            merge_spans(&start, &end),
+        )
+    }
+
     fn parse_record_literal(&mut self, type_name: String, start: Span) -> Expr {
         let _ = self.expect(TokenKind::Colon); // consume ':' after type name
 
@@ -3744,6 +3847,12 @@ impl Parser {
                 }
                 
                 self.advance();
+                // Brace-form record literal: TypeName { field = value, field2 = value2 }
+                if matches!(self.peek(), TokenKind::LBrace)
+                    && self.peek_brace_record_literal()
+                {
+                    return self.parse_brace_record_literal(name, start);
+                }
                 // Check for record literal syntax: TypeName: field: value field2: value2
                 if matches!(self.peek(), TokenKind::Colon) {
                     // Check if next token after colon is a field name (identifier or keyword) followed by colon
@@ -4255,11 +4364,22 @@ impl Parser {
             if self.expect(TokenKind::Colon).is_err() {
                 // error already recorded
             }
-            if matches!(self.peek(), TokenKind::Newline) {
-                self.advance();
-            }
 
-            let body = self.parse_block();
+            // Match arm body: either a newline-indented block, or an
+            // inline single statement on the same line as the colon
+            // (`Pattern: ret expr`).
+            let body = if matches!(self.peek(), TokenKind::Newline) {
+                self.advance();
+                self.parse_block()
+            } else {
+                let stmt_start = self.current_span();
+                let stmt = self.parse_stmt();
+                let stmt_span = stmt.span;
+                if matches!(self.peek(), TokenKind::Newline) {
+                    self.advance();
+                }
+                Spanned::new(vec![stmt], merge_spans(&stmt_start, &stmt_span))
+            };
             let arm_end = body.span;
 
             arms.push(MatchArm {

--- a/codebase/compiler/src/parser/parser.rs
+++ b/codebase/compiler/src/parser/parser.rs
@@ -3648,11 +3648,10 @@ impl Parser {
             }
         }
     }
-    /// field_def  <- IDENT ':' expr NEWLINE
-    /// ```
-    /// Look ahead from `{` to confirm this is a brace-form record literal
-    /// rather than something else (e.g. a stray brace). We require the
-    /// shape `{ Ident = ...` (or `{ }` for an empty record).
+    /// Look ahead from a left brace to confirm this is a brace-form record
+    /// literal rather than something else (e.g. a stray brace). We require
+    /// the shape `LBrace Ident Assign ...` (or `LBrace RBrace` for an empty
+    /// record).
     fn peek_brace_record_literal(&self) -> bool {
         if !matches!(self.peek(), TokenKind::LBrace) {
             return false;

--- a/codebase/compiler/src/parser/tests.rs
+++ b/codebase/compiler/src/parser/tests.rs
@@ -4891,6 +4891,57 @@ fn working():
     assert!(has_fn, "expected function to be parsed despite type error");
 }
 
+// ============================================================================
+// Self-hosting parser regressions
+// ============================================================================
+
+#[test]
+fn self_hosting_indented_enum_after_assign() {
+    // `type T =\n    | A\n    | B(Int)` form used in compiler/token.gr
+    let src = r#"
+type Color =
+    | Red
+    | Green
+    | Blue
+"#;
+    let (module, errors) = parse_source_with_errors(src);
+    assert!(errors.is_empty(), "unexpected parse errors: {:?}", errors);
+    let has_enum = module.items.iter().any(|item| {
+        matches!(&item.node, ItemKind::EnumDecl { name, .. } if name == "Color")
+    });
+    assert!(has_enum, "expected EnumDecl for Color");
+}
+
+#[test]
+fn self_hosting_brace_record_literal() {
+    // `Type { field = value, ... }` form
+    let src = r#"
+type Point:
+    x: Int
+    y: Int
+
+fn make_point(x: Int, y: Int) -> Point:
+    ret Point { x = x, y = y }
+"#;
+    let (_module, errors) = parse_source_with_errors(src);
+    assert!(errors.is_empty(), "unexpected parse errors: {:?}", errors);
+}
+
+#[test]
+fn self_hosting_inline_match_arm_body() {
+    // `Variant: ret expr` (single-line arm body)
+    let src = r#"
+type Light = Red | Green | Yellow
+
+fn is_go(c: Light) -> Bool:
+    match c:
+        Green: ret true
+        _: ret false
+"#;
+    let (_module, errors) = parse_source_with_errors(src);
+    assert!(errors.is_empty(), "unexpected parse errors: {:?}", errors);
+}
+
 #[test]
 fn error_recovery_preserves_multiple_diagnostics() {
     // Test that multiple errors are all reported


### PR DESCRIPTION
## Summary
Three parser gaps blocked the self-hosted compiler source `compiler/token.gr`. After this PR it parses and typechecks with **zero errors** (was: failed at line 23 with 700+ cascading errors).

### 1. Indented enum after \`=\`
\`\`\`gradient
type TokenKind =
    | IntLit(Int)
    | FloatLit(Float)
\`\`\`
\`is_enum_rhs\` only inspected the immediate next token; a Newline fell through to \`parse_type_expr\`. Added \`is_indented_enum_rhs\` that looks past Newline+Indent+optional Pipe, and routed into the existing \`parse_enum_block_from_type\` (now tolerant of a leading \`|\`).

### 2. Brace-form record literal
\`\`\`gradient
ret Position { line = line, col = col, offset = offset }
\`\`\`
Only the colon-form (\`Position: line: ..., col: ...\`) existed. Added \`parse_brace_record_literal\` as a sibling form lit-up via a \`{ Ident =\` lookahead.

### 3. Inline match arm body
\`\`\`gradient
match kind:
    Fn: ret true
    Let: ret true
\`\`\`
\`parse_block\` requires INDENT, so single-line arm bodies failed. Match arms now accept either an indented block or a single inline statement after the colon.

## Test plan
- [x] 3 new regression tests in \`parser/tests.rs\` (\`self_hosting_*\`)
- [x] \`compiler/token.gr\` parses + typechecks clean via \`gradient-compiler --agent\`
- [x] \`cargo test --release -p gradient-compiler --lib\` — 1069 passing (+3)
- [x] \`cargo clippy --workspace -- -D warnings\` clean