### PR TITLE
chore(tests): clean up dead code and unused imports

### DIFF
--- a/codebase/compiler/src/parser/recovery.rs
+++ b/codebase/compiler/src/parser/recovery.rs
@@ -170,17 +170,6 @@ pub fn discriminant_eq(a: &TokenKind, b: &TokenKind) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::span::{Position, Span};
-    use crate::lexer::token::Token;
-    use crate::parser::ParseError;
-
-    fn make_token(kind: TokenKind) -> Token {
-        Token::new(
-            kind,
-            Span::new(0, Position::new(1, 1, 0), Position::new(1, 2, 1)),
-        )
-    }
-
     #[test]
     fn test_discriminant_eq() {
         let a = TokenKind::Ident("foo".into());

--- a/codebase/compiler/tests/actual_bootstrap_execution.rs
+++ b/codebase/compiler/tests/actual_bootstrap_execution.rs
@@ -6,7 +6,6 @@
 // Note: This test uses CLI-based compilation via the `gradient` binary
 // rather than the library API directly
 use std::fs;
-use std::path::Path;
 use std::time::Instant;
 use std::process::Command;
 
@@ -24,6 +23,7 @@ const MODULES: &[(&str, &str)] = &[
 const BOOTSTRAP_OUT_DIR: &str = "./bootstrap_output";
 
 /// Result of compiling one module
+#[allow(dead_code)]
 struct ModuleBootstrapResult {
     name: String,
     source_path: String,
@@ -41,6 +41,7 @@ struct ModuleBootstrapResult {
 }
 
 /// Overall bootstrap execution result
+#[allow(dead_code)]
 struct BootstrapExecutionResult {
     success: bool,
     modules_attempted: usize,

--- a/codebase/compiler/tests/bootstrap_test.rs
+++ b/codebase/compiler/tests/bootstrap_test.rs
@@ -4,10 +4,9 @@
 //! correctly with the reference (Rust) compiler.
 
 use gradient_compiler::{
-    compile, parse_source, typecheck_module, generate_ir,
+    parse_source, typecheck_module, generate_ir,
 };
 use std::fs;
-use std::path::Path;
 use std::time::Instant;
 
 /// Module info for self-hosted compiler
@@ -21,6 +20,7 @@ const SELF_HOSTED_MODULES: &[(&str, &str)] = &[
 ];
 
 /// Result of testing a module
+#[allow(dead_code)]
 struct ModuleTestResult {
     name: String,
     parse_success: bool,

--- a/codebase/compiler/tests/memory_model_integration.rs
+++ b/codebase/compiler/tests/memory_model_integration.rs
@@ -72,6 +72,7 @@ fn compile_c_test(c_source: &str) -> (String, i32) {
 }
 
 /// Compile and run a Gradient test program
+#[allow(dead_code)]
 fn compile_gradient_test(source: &str) -> (String, i32) {
     let tmp = TempDir::new().expect("failed to create temp dir");
 

--- a/codebase/compiler/tests/phase_v_actor_integration.rs
+++ b/codebase/compiler/tests/phase_v_actor_integration.rs
@@ -70,7 +70,7 @@ fn compile_and_run_with_stdin(src: &str, stdin_input: Option<&[u8]>) -> (String,
 
     // 7. Run
     let mut run_cmd = Command::new(&bin_path);
-    if let Some(input) = stdin_input {
+    if let Some(_input) = stdin_input {
         run_cmd.stdin(Stdio::piped());
     }
 


### PR DESCRIPTION
## Summary
Quick janitor pass to silence the test-compile warnings visible in CI logs from PRs #6-#8. These never gated CI (only \`cargo clippy --workspace\` is gated, not \`cargo test --no-run\`), but they accumulated.

- Drop \`make_token\` helper in \`parser/recovery.rs\` — orphaned after the recovery toolkit deletion in #7
- \`#[allow(dead_code)]\` on three diagnostic result structs whose fields are populated for future readers but not currently consumed (\`ModuleBootstrapResult\`, \`BootstrapExecutionResult\`, \`ModuleTestResult\`, \`compile_gradient_test\`)
- Prefix unused \`input\` binding in \`phase_v_actor_integration.rs\`
- Drop two leftover unused imports in \`bootstrap_test.rs\`

## Test plan
- [x] \`cargo test --release -p gradient-compiler --no-run\` — zero warnings
- [x] \`cargo test --release -p gradient-compiler --lib\` — 1069 passing
- [x] \`cargo clippy --workspace -- -D warnings\` clean