### PR TITLE
chore(wasm): clippy clean for --features wasm + gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,9 @@ jobs:
       - name: Build compiler with WASM feature
         working-directory: codebase
         run: cargo build -p gradient-compiler --features wasm
+      - name: Clippy with WASM feature
+        working-directory: codebase
+        run: cargo clippy -p gradient-compiler --features wasm -- -D warnings
       - name: Run WASM unit tests
         working-directory: codebase
         run: cargo test -p gradient-compiler --features wasm --test wasm_tests

--- a/codebase/compiler/src/backend/wasm.rs
+++ b/codebase/compiler/src/backend/wasm.rs
@@ -32,7 +32,7 @@ use std::collections::HashMap;
 use wasm_encoder::{
     BlockType, CodeSection, ConstExpr, DataSection, ExportKind, ExportSection, Function,
     FunctionSection, GlobalSection, GlobalType, ImportSection, Instruction as WasmInstr, MemArg,
-    MemorySection, MemoryType, Module, Section, ValType,
+    MemorySection, MemoryType, Section, ValType,
 };
 
 /// Unique identifier for data segments (string literals, etc.)
@@ -76,6 +76,7 @@ impl From<&str> for WasmCodegenError {
 /// - Global variables (including heap pointer for bump allocator)
 /// - WASI imports for I/O operations
 /// - Function compilation
+#[allow(dead_code)] // wasi_proc_exit_idx, type_indices, type_section_bytes are scaffolding
 pub struct WasmBackend {
     /// String data storage: DataId -> (offset, bytes)
     /// The offset is the position in memory where the string will be placed.
@@ -142,12 +143,12 @@ impl WasmBackend {
     /// - WASI imports for fd_write and proc_exit
     pub fn new() -> Result<Self, WasmCodegenError> {
         let mut exports = ExportSection::new();
-        let mut functions = FunctionSection::new();
-        let mut code = CodeSection::new();
+        let functions = FunctionSection::new();
+        let code = CodeSection::new();
         let mut imports = ImportSection::new();
         let mut globals = GlobalSection::new();
         let mut memories = MemorySection::new();
-        let mut data = DataSection::new();
+        let data = DataSection::new();
 
         // Memory: 1 page (64KB) minimum, no maximum
         memories.memory(MemoryType {
@@ -390,7 +391,7 @@ impl WasmBackend {
 
         // Export the function
         self.exports
-            .export("println", ExportKind::Func, func_idx as u32);
+            .export("println", ExportKind::Func, func_idx);
 
         // Map function name
         self.func_name_to_idx
@@ -456,7 +457,7 @@ impl WasmBackend {
         let mut func = Function::new(locals);
 
         // Compile each block
-        for (_block_idx, block) in function.blocks.iter().enumerate() {
+        for block in function.blocks.iter() {
             // In a real implementation, we'd track block labels for branching
             // For now, we just compile sequentially
 
@@ -471,7 +472,7 @@ impl WasmBackend {
         // Export main function
         if function.name == "main" {
             self.exports
-                .export("main", ExportKind::Func, func_idx as u32);
+                .export("main", ExportKind::Func, func_idx);
         }
 
         Ok(())

--- a/codebase/compiler/src/codegen/mod.rs
+++ b/codebase/compiler/src/codegen/mod.rs
@@ -122,6 +122,10 @@ pub fn llvm_available() -> bool {
 /// let backend = BackendWrapper::new(true)?; // true = use LLVM if available
 /// // Use backend via CodegenBackend trait
 /// ```
+// CraneliftCodegen is intentionally inline (~6KB) — there's only ever one
+// active backend and boxing it would force allocation on the hot path for
+// every compile. The size disparity is acceptable.
+#[allow(clippy::large_enum_variant)]
 pub enum BackendWrapper {
     #[cfg(feature = "llvm")]
     Llvm {

--- a/codebase/compiler/src/codegen/wasm.rs
+++ b/codebase/compiler/src/codegen/wasm.rs
@@ -36,6 +36,7 @@ pub struct StringId(pub u32);
 
 /// WASI import function descriptor.
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // `name` is informational; only `module`/`field`/types are wired through encoder
 struct WasiImport {
     name: String,
     module: String,
@@ -49,6 +50,7 @@ struct WasiImport {
 /// This struct holds the state for WASM code generation, including the
 /// underlying `wasm-encoder::Module`, function mappings, and local variable
 /// tracking.
+#[allow(dead_code)] // function_map / exports are scaffolding for upcoming codegen passes
 pub struct WasmBackend {
     /// The WASM module being constructed.
     module: Module,
@@ -90,6 +92,7 @@ pub struct WasmBackend {
     println_idx: Option<u32>,
 }
 
+#[allow(dead_code)] // helpers staged for upcoming codegen passes
 impl WasmBackend {
     /// Create a new WASM backend with WASI imports and memory setup.
     pub fn new() -> Result<Self, CodegenError> {
@@ -144,7 +147,7 @@ impl WasmBackend {
         let bytes = s.as_bytes().to_vec();
         let offset = self.data_offset;
         // Align to 8 bytes for safe memory access
-        let aligned_len = ((bytes.len() + 7) / 8) * 8;
+        let aligned_len = bytes.len().div_ceil(8) * 8;
 
         // Security: Check for data section overflow
         let new_offset = self
@@ -212,7 +215,7 @@ impl WasmBackend {
     pub fn encode_data_section(&self) -> wasm_encoder::DataSection {
         let mut data_section = wasm_encoder::DataSection::new();
 
-        for (id, (offset, bytes)) in &self.strings {
+        for (offset, bytes) in self.strings.values() {
             // Add a data segment for each string at its offset
             data_section.active(
                 0, // memory index
@@ -930,7 +933,7 @@ impl CodegenBackend for WasmBackend {
             let f32_count = 0u32;
             let mut f64_count = 0u32;
 
-            for (value, _local_idx) in &self.value_map {
+            for value in self.value_map.keys() {
                 if let Some(ty) = func.value_types.get(value) {
                     match ty {
                         Type::I32 | Type::Ptr | Type::Bool => i32_count += 1,


### PR DESCRIPTION
## Summary
The WASM backend had ~15 clippy warnings that never failed CI because the workspace clippy job runs without \`--features wasm\`. This PR cleans them all up and adds a new CI step so it can't regress.

### Auto-fixed via \`cargo clippy --fix\`
unused \`Module\` import; three unused \`mut\` bindings; unused \`.enumerate()\`; two unnecessary \`u32 as u32\` casts; manual \`div_ceil\`; unused \`_id\` loop binding.

### Manual
- \`backend/wasm.rs\` and \`codegen/wasm.rs\`: \`#[allow(dead_code)]\` on \`WasmBackend\` and \`WasiImport\` whose fields are scaffolding for upcoming codegen passes
- \`codegen/wasm.rs\` impl block: \`#[allow(dead_code)]\` on staged helpers (\`data_section_size\`, \`get_local_index\`, \`allocate_local\`)
- \`encode_data_section\`: iterate via \`.values()\` (for_kv_map)
- \`BackendWrapper\` enum: \`#[allow(clippy::large_enum_variant)]\` — boxing \`CraneliftCodegen\` would force allocation on the hot path for the only ever active backend; size disparity is acceptable

### CI
New step in the \`wasm\` job:
\`\`\`yaml
- name: Clippy with WASM feature
  run: cargo clippy -p gradient-compiler --features wasm -- -D warnings
\`\`\`

## Test plan
- [x] \`cargo clippy -p gradient-compiler --features wasm\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo test --release -p gradient-compiler --lib\` — 1069 passing