### PR TITLE
feat(self-hosting): add lexer.gr — Gradient-implemented lexer

### DIFF
--- a/codebase/compiler/lexer.gr
+++ b/codebase/compiler/lexer.gr
@@ -1,0 +1,383 @@
+// compiler/lexer.gr
+// Self-hosted lexer for the Gradient programming language.
+//
+// Mirrors a subset of codebase/compiler/src/lexer/lexer.rs sufficient for
+// the self-hosting milestone. Depends on the types and constructors defined
+// in compiler/token.gr (TokenKind, Token, Position, Span, make_position,
+// make_span, make_token, make_error, make_eof).
+//
+// v0.1 design constraint: the typechecker does not yet support reading
+// fields off record values, so all lexer state is held in `let mut` locals
+// inside `tokenize`. Helper scanners take and return tuples.
+//
+// In scope:
+//   - integer and float literals (no exponents, no hex/bin/oct)
+//   - string literals with \n \t \\ \" escapes (no interpolation)
+//   - identifiers and keywords (fn let mut if else for while match ret type
+//     actor spawn send ask use mod extern export comptime, plus bool/and/or/not)
+//   - operators: + - * / % == != < > <= >= = -> |> . .. and or not
+//   - punctuation: ( ) [ ] { } : ,
+//   - // line comments
+//   - Newline, Indent, Dedent (Python-style), Eof
+//
+// Out of scope: f-strings, doc comments, block comments, hex/bin/oct,
+// float exponents, char literals, @, ?, !, and other advanced tokens.
+
+// ============================================================================
+// Character classification helpers
+// ============================================================================
+
+fn is_digit(c: String) -> Bool:
+    ret c == "0" or c == "1" or c == "2" or c == "3" or c == "4" or c == "5" or c == "6" or c == "7" or c == "8" or c == "9"
+
+fn is_lower(c: String) -> Bool:
+    ret c == "a" or c == "b" or c == "c" or c == "d" or c == "e" or c == "f" or c == "g" or c == "h" or c == "i" or c == "j" or c == "k" or c == "l" or c == "m" or c == "n" or c == "o" or c == "p" or c == "q" or c == "r" or c == "s" or c == "t" or c == "u" or c == "v" or c == "w" or c == "x" or c == "y" or c == "z"
+
+fn is_upper(c: String) -> Bool:
+    ret c == "A" or c == "B" or c == "C" or c == "D" or c == "E" or c == "F" or c == "G" or c == "H" or c == "I" or c == "J" or c == "K" or c == "L" or c == "M" or c == "N" or c == "O" or c == "P" or c == "Q" or c == "R" or c == "S" or c == "T" or c == "U" or c == "V" or c == "W" or c == "X" or c == "Y" or c == "Z"
+
+fn is_alpha(c: String) -> Bool:
+    ret is_lower(c) or is_upper(c) or c == "_"
+
+fn is_alnum(c: String) -> Bool:
+    ret is_alpha(c) or is_digit(c)
+
+// Safe char_at that returns "" when out of bounds.
+fn char_at_or_empty(s: String, i: Int) -> String:
+    if i < 0 or i >= s.length():
+        ret ""
+    ret s.char_at(i)
+
+// ============================================================================
+// Keyword lookup
+// ============================================================================
+
+fn keyword_lookup(name: String) -> TokenKind:
+    match name:
+        "fn": ret Fn
+        "let": ret Let
+        "mut": ret Mut
+        "if": ret If
+        "else": ret Else
+        "for": ret For
+        "while": ret While
+        "match": ret Match
+        "ret": ret Ret
+        "type": ret Type
+        "actor": ret Actor
+        "spawn": ret Spawn
+        "send": ret Send
+        "ask": ret Ask
+        "use": ret Use
+        "mod": ret Mod
+        "extern": ret Extern
+        "export": ret Export
+        "comptime": ret Comptime
+        "true": ret BoolLit(true)
+        "false": ret BoolLit(false)
+        "and": ret And
+        "or": ret Or
+        "not": ret Not
+        _: ret Ident(name)
+
+// ============================================================================
+// Sub-scanners
+//
+// Each sub-scanner takes `(source, pos)` and returns a tuple whose first
+// element is the new byte offset. Line/col bookkeeping stays in `tokenize`
+// since none of these sub-scanners cross a newline (strings intentionally
+// reject raw newlines; comments are consumed up to but not including \n).
+// ============================================================================
+
+// Scan digits [0-9]*. Returns new pos.
+fn scan_digits(source: String, start: Int) -> Int:
+    let mut i = start
+    while i < source.length() and is_digit(source.char_at(i)):
+        i = i + 1
+    ret i
+
+// Scan a number starting at `start`. Returns (new_pos, token_kind).
+fn scan_number(source: String, start: Int) -> (Int, TokenKind):
+    let after_int = scan_digits(source, start)
+    // Float? Require `. digit`
+    let dot = char_at_or_empty(source, after_int)
+    let next = char_at_or_empty(source, after_int + 1)
+    if dot == "." and is_digit(next):
+        let after_frac = scan_digits(source, after_int + 1)
+        let text = source.substring(start, after_frac)
+        ret (after_frac, FloatLit(parse_float(text)))
+    let text2 = source.substring(start, after_int)
+    ret (after_int, IntLit(parse_int(text2)))
+
+// Scan an identifier/keyword. Returns (new_pos, token_kind).
+fn scan_ident(source: String, start: Int) -> (Int, TokenKind):
+    let mut i = start
+    while i < source.length() and is_alnum(source.char_at(i)):
+        i = i + 1
+    let text = source.substring(start, i)
+    ret (i, keyword_lookup(text))
+
+// Scan a string literal starting at the opening quote.
+// Returns (new_pos, token_kind). On error, kind is Error(...).
+fn scan_string(source: String, start: Int) -> (Int, TokenKind):
+    // start points at opening "
+    let mut i = start + 1
+    let mut buf = ""
+    let mut done = false
+    let mut errored = false
+    while not done:
+        if i >= source.length():
+            done = true
+            errored = true
+        else:
+            let c = source.char_at(i)
+            if c == "\"":
+                i = i + 1
+                done = true
+            else:
+                if c == "\n":
+                    done = true
+                    errored = true
+                else:
+                    if c == "\\":
+                        if i + 1 >= source.length():
+                            done = true
+                            errored = true
+                        else:
+                            let e = source.char_at(i + 1)
+                            if e == "n":
+                                buf = buf + "\n"
+                            else:
+                                if e == "t":
+                                    buf = buf + "\t"
+                                else:
+                                    if e == "\\":
+                                        buf = buf + "\\"
+                                    else:
+                                        if e == "\"":
+                                            buf = buf + "\""
+                                        else:
+                                            buf = buf + e
+                            i = i + 2
+                    else:
+                        buf = buf + c
+                        i = i + 1
+    if errored:
+        ret (i, Error("unterminated string literal"))
+    ret (i, StringLit(buf))
+
+// Count leading spaces at position `p` (which must be at line start).
+fn count_leading_spaces(source: String, p: Int) -> Int:
+    let mut i = 0
+    while p + i < source.length() and source.char_at(p + i) == " ":
+        i = i + 1
+    ret i
+
+// Skip to end of line (not including the newline itself). Returns new pos.
+fn skip_line_comment(source: String, start: Int) -> Int:
+    let mut i = start
+    while i < source.length() and source.char_at(i) != "\n":
+        i = i + 1
+    ret i
+
+// Peek the top of an indent stack (last element). Returns 0 if empty.
+fn indent_top(stack: List[Int]) -> Int:
+    if stack.length() == 0:
+        ret 0
+    ret list_get(stack, stack.length() - 1)
+
+// Pop the last element of an indent stack. Returns a new stack.
+fn indent_pop(stack: List[Int]) -> List[Int]:
+    let mut out: List[Int] = []
+    let mut i = 0
+    let last = stack.length() - 1
+    while i < last:
+        out = out.push(list_get(stack, i))
+        i = i + 1
+    ret out
+
+// ============================================================================
+// Main driver
+// ============================================================================
+
+fn tokenize(source: String) -> List[Token]:
+    let mut pos = 0
+    let mut line = 1
+    let mut col = 1
+    let mut at_line_start = true
+    let mut indent_stack: List[Int] = [0]
+    let mut tokens: List[Token] = []
+    let file_id = 0
+
+    while pos < source.length():
+        // -- Handle start-of-line indentation -----------------------------
+        if at_line_start:
+            let spaces = count_leading_spaces(source, pos)
+            let after = pos + spaces
+            if after >= source.length():
+                // Trailing spaces at EOF: consume and fall through.
+                pos = after
+                col = col + spaces
+                at_line_start = false
+            else:
+                let lead = source.char_at(after)
+                // Blank line or comment-only line: skip indentation logic.
+                let is_blank = lead == "\n"
+                let is_cmt = lead == "/" and char_at_or_empty(source, after + 1) == "/"
+                if is_blank or is_cmt:
+                    pos = after
+                    col = col + spaces
+                    at_line_start = false
+                else:
+                    pos = after
+                    col = col + spaces
+                    at_line_start = false
+                    let top = indent_top(indent_stack)
+                    if spaces > top:
+                        indent_stack = indent_stack.push(spaces)
+                        let p = make_position(line, col, pos)
+                        let sp = make_span(file_id, p, p)
+                        tokens = tokens.push(make_token(Indent, sp))
+                    else:
+                        while spaces < indent_top(indent_stack):
+                            indent_stack = indent_pop(indent_stack)
+                            let p = make_position(line, col, pos)
+                            let sp = make_span(file_id, p, p)
+                            tokens = tokens.push(make_token(Dedent, sp))
+        else:
+            let c = source.char_at(pos)
+            // -- Whitespace (non-newline) -----------------------------------
+            if c == " " or c == "\t" or c == "\r":
+                pos = pos + 1
+                col = col + 1
+            else:
+                if c == "\n":
+                    let startp = make_position(line, col, pos)
+                    pos = pos + 1
+                    line = line + 1
+                    col = 1
+                    at_line_start = true
+                    let endp = make_position(line, col, pos)
+                    let sp = make_span(file_id, startp, endp)
+                    tokens = tokens.push(make_token(Newline, sp))
+                else:
+                    if c == "/" and char_at_or_empty(source, pos + 1) == "/":
+                        let np = skip_line_comment(source, pos)
+                        col = col + (np - pos)
+                        pos = np
+                    else:
+                        if is_digit(c):
+                            let startp = make_position(line, col, pos)
+                            let (np, kind) = scan_number(source, pos)
+                            col = col + (np - pos)
+                            pos = np
+                            let endp = make_position(line, col, pos)
+                            let sp = make_span(file_id, startp, endp)
+                            tokens = tokens.push(make_token(kind, sp))
+                        else:
+                            if is_alpha(c):
+                                let startp = make_position(line, col, pos)
+                                let (np, kind) = scan_ident(source, pos)
+                                col = col + (np - pos)
+                                pos = np
+                                let endp = make_position(line, col, pos)
+                                let sp = make_span(file_id, startp, endp)
+                                tokens = tokens.push(make_token(kind, sp))
+                            else:
+                                if c == "\"":
+                                    let startp = make_position(line, col, pos)
+                                    let (np, kind) = scan_string(source, pos)
+                                    col = col + (np - pos)
+                                    pos = np
+                                    let endp = make_position(line, col, pos)
+                                    let sp = make_span(file_id, startp, endp)
+                                    tokens = tokens.push(make_token(kind, sp))
+                                else:
+                                    // Operators and punctuation.
+                                    let startp = make_position(line, col, pos)
+                                    let c2 = char_at_or_empty(source, pos + 1)
+                                    let mut width = 1
+                                    let mut kind: TokenKind = Error("unexpected character")
+                                    if c == "+":
+                                        kind = Plus
+                                    if c == "-":
+                                        if c2 == ">":
+                                            kind = Arrow
+                                            width = 2
+                                        else:
+                                            kind = Minus
+                                    if c == "*":
+                                        kind = Star
+                                    if c == "/":
+                                        kind = Slash
+                                    if c == "%":
+                                        kind = Percent
+                                    if c == "=":
+                                        if c2 == "=":
+                                            kind = Eq
+                                            width = 2
+                                        else:
+                                            kind = Assign
+                                    if c == "!":
+                                        if c2 == "=":
+                                            kind = Ne
+                                            width = 2
+                                        else:
+                                            kind = Error("unexpected character '!'")
+                                    if c == "<":
+                                        if c2 == "=":
+                                            kind = Le
+                                            width = 2
+                                        else:
+                                            kind = Lt
+                                    if c == ">":
+                                        if c2 == "=":
+                                            kind = Ge
+                                            width = 2
+                                        else:
+                                            kind = Gt
+                                    if c == "|":
+                                        if c2 == ">":
+                                            kind = Pipe
+                                            width = 2
+                                        else:
+                                            kind = Error("unexpected character '|'")
+                                    if c == ".":
+                                        if c2 == ".":
+                                            kind = DotDot
+                                            width = 2
+                                        else:
+                                            kind = Dot
+                                    if c == "(":
+                                        kind = LParen
+                                    if c == ")":
+                                        kind = RParen
+                                    if c == "[":
+                                        kind = LBracket
+                                    if c == "]":
+                                        kind = RBracket
+                                    if c == "{":
+                                        kind = LBrace
+                                    if c == "}":
+                                        kind = RBrace
+                                    if c == ":":
+                                        kind = Colon
+                                    if c == ",":
+                                        kind = Comma
+                                    pos = pos + width
+                                    col = col + width
+                                    let endp = make_position(line, col, pos)
+                                    let sp = make_span(file_id, startp, endp)
+                                    tokens = tokens.push(make_token(kind, sp))
+
+    // -- EOF: drain remaining indents and emit Eof ---------------------------
+    while indent_top(indent_stack) > 0:
+        indent_stack = indent_pop(indent_stack)
+        let p = make_position(line, col, pos)
+        let sp = make_span(file_id, p, p)
+        tokens = tokens.push(make_token(Dedent, sp))
+
+    let endp = make_position(line, col, pos)
+    let sp = make_span(file_id, endp, endp)
+    tokens = tokens.push(make_token(Eof, sp))
+    ret tokens


### PR DESCRIPTION
## Summary
Adds the second self-hosted compiler module: `compiler/lexer.gr`, a Gradient-implemented lexer that consumes the types and constructors from `compiler/token.gr` and produces a `List[Token]`. Mirrors a scoped-down subset of `compiler/src/lexer/lexer.rs`.

## Scope (lexed)
- Integer literals (`123`, `0`) and simple float literals (`1.5`, digit-dot-digit, no exponent)
- String literals with `\n`, `\t`, `\\`, `\"` escapes (no interpolation)
- Boolean literals (`true`, `false`)
- Identifiers and all keywords: `fn let mut if else for while match ret type actor spawn send ask use mod extern export comptime`, plus `and or not`
- Operators: `+ - * / % == != < > <= >= = -> |> . ..`
- Punctuation: `( ) [ ] { } : ,`
- `//` line comments (skipped)
- `Newline`, plus Python-style `Indent` / `Dedent` driven by a leading-space stack
- `Eof`

Unknown characters emit `TokenKind::Error(message)` and recovery continues.

## Out of scope (explicitly deferred)
- f-string interpolation, doc comments, block comments
- Hex/bin/oct literals, float exponents
- Char literals
- `@`, `?`, standalone `!`, and other advanced tokens

## Design notes — v0.1 language constraints
- **No record field reads yet.** `compiler/src/typechecker/checker.rs` line ~1617 emits `field access ... is not supported in v0.1`. This means no `state.pos`-style access, even for types defined in the same file. All mutable lexer state (pos, line, col, `at_line_start`, indent stack, token list) is therefore held as `let mut` locals inside `tokenize`, and sub-scanners (`scan_number`, `scan_ident`, `scan_string`, etc.) take and return tuples.
- **No module/import system.** `lexer.gr` references `TokenKind`, `Token`, `Position`, `Span`, and the `make_*` constructors from `token.gr`. The `--agent load` handler is single-file, so `lexer.gr` in isolation reports 105 diagnostics, all of which are 12× `unknown type` and 93× `undefined variable` for symbols owned by `token.gr`. Concatenated with `token.gr` as a single source it parses and typechecks cleanly (`ok=True`, 0 errors, 0 warnings).
- **Multi-line record literals do not parse.** An earlier draft of this file used the indented form `LexState {\n    source = source,\n    ...\n}`; the parser reported `expected expression` at every field-name line. All record literals are consequently kept to single-line form, matching `token.gr`'s style. (Not reported as a separate bug here — worth filing if intentional.)

## Validation
- [x] `token.gr` + `lexer.gr` concatenated: `ok=True  total_err=0` (0 warnings)
- [x] `lexer.gr` alone: 105 errors, 100% `unknown type` / `undefined variable` for token.gr symbols — no genuine errors
- [x] `cargo test --release -p gradient-compiler --lib` → **1069 passed**, 0 failed, 1 ignored
- [x] `cargo clippy --workspace -- -D warnings` clean
- [ ] Future: add `parses_self_hosted_lexer` integration test that feeds `token.gr + lexer.gr` through `Session::from_source`

## Follow-ups surfaced
1. Record field reads (`typechecker/checker.rs:1617`). Unblocks any record-shaped state; currently forces a single-function style.
2. Multi-line record literal parsing.
3. Cross-file `use`/`mod` resolution so `lexer.gr` can depend on `token.gr` without concatenation.