### PR TITLE
feat(typechecker): record types with field reads

### DIFF
--- a/codebase/compiler/src/ast/types.rs
+++ b/codebase/compiler/src/ast/types.rs
@@ -80,6 +80,18 @@ pub enum TypeExpr {
     /// A tuple type, e.g. `(Int, String, Bool)`.
     Tuple(Vec<Spanned<TypeExpr>>),
 
+    /// A record type with named fields.
+    ///
+    /// Produced by the parser for record-style declarations:
+    /// ```text
+    /// type Position:
+    ///     line: Int
+    ///     col: Int
+    /// ```
+    /// The field names are preserved so the typechecker can resolve
+    /// `position.line` field reads.
+    Record(Vec<(String, Spanned<TypeExpr>)>),
+
     /// A linear type, written `!linear T` in source code.
     ///
     /// Linear types enforce "use exactly once" semantics. Values of linear

--- a/codebase/compiler/src/fmt.rs
+++ b/codebase/compiler/src/fmt.rs
@@ -423,6 +423,13 @@ impl Formatter {
                     .collect();
                 format!("({})", elem_strs.join(", "))
             }
+            TypeExpr::Record(fields) => {
+                let field_strs: Vec<String> = fields
+                    .iter()
+                    .map(|(n, ty)| format!("{}: {}", n, self.format_type_expr(&ty.node)))
+                    .collect();
+                format!("{{ {} }}", field_strs.join(", "))
+            }
             TypeExpr::Linear(inner) => {
                 format!("@linear {}", self.format_type_expr(&inner.node))
             }

--- a/codebase/compiler/src/ir/builder/mod.rs
+++ b/codebase/compiler/src/ir/builder/mod.rs
@@ -3634,6 +3634,11 @@ impl IrBuilder {
                 // Tuples are represented as a pointer to stack-allocated elements.
                 Type::Ptr
             }
+            ast::TypeExpr::Record(_) => {
+                // Records are represented as a pointer to stack-allocated fields,
+                // same as tuples.
+                Type::Ptr
+            }
             ast::TypeExpr::Linear(inner) => {
                 // Linear types are passed by value/reference like their inner type
                 self.resolve_type(&inner.node)

--- a/codebase/compiler/src/parser/parser.rs
+++ b/codebase/compiler/src/parser/parser.rs
@@ -1451,9 +1451,9 @@ impl Parser {
             self.prev_span()
         };
 
-        // Store record fields as type parameters with special naming
+        // Preserve field names so the typechecker can resolve field reads.
         let record_type_expr = Spanned::new(
-            crate::ast::types::TypeExpr::Tuple(fields.iter().map(|(_, ty)| ty.clone()).collect()),
+            crate::ast::types::TypeExpr::Record(fields.clone()),
             merge_spans(&start, &end),
         );
 

--- a/codebase/compiler/src/query.rs
+++ b/codebase/compiler/src/query.rs
@@ -776,6 +776,17 @@ impl Session {
                     .collect();
                 typechecker::Ty::Tuple(elem_tys)
             }
+            TypeExpr::Record(fields) => {
+                let field_tys: Vec<(String, typechecker::Ty)> = fields
+                    .iter()
+                    .map(|(n, ty)| (n.clone(), Self::resolve_type_expr_static(&ty.node)))
+                    .collect();
+                typechecker::Ty::Struct {
+                    name: String::new(),
+                    fields: field_tys,
+                    cap: typechecker::types::RefCap::default_struct(),
+                }
+            }
             TypeExpr::Linear(inner) => {
                 // Linear types resolve to their inner type for static resolution
                 Self::resolve_type_expr_static(&inner.node)
@@ -2937,6 +2948,14 @@ fn format_type_expr(te: &crate::ast::types::TypeExpr) -> String {
                 .collect::<Vec<_>>()
                 .join(", ");
             format!("({})", elem_strs)
+        }
+        crate::ast::types::TypeExpr::Record(fields) => {
+            let field_strs = fields
+                .iter()
+                .map(|(n, ty)| format!("{}: {}", n, format_type_expr(&ty.node)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{{ {} }}", field_strs)
         }
         crate::ast::types::TypeExpr::Linear(inner) => {
             format!("@linear {}", format_type_expr(&inner.node))

--- a/codebase/compiler/src/typechecker/checker.rs
+++ b/codebase/compiler/src/typechecker/checker.rs
@@ -250,7 +250,20 @@ impl TypeChecker {
                 ItemKind::TypeDecl {
                     name, type_expr, ..
                 } => {
-                    let ty = self.resolve_type_expr(&type_expr.node, type_expr.span);
+                    let mut ty = self.resolve_type_expr(&type_expr.node, type_expr.span);
+                    // If the RHS was a record body, the resolver gave us a
+                    // Struct with an empty name. Patch in the declared name
+                    // so it round-trips through error messages and matches
+                    // record-literal lookups.
+                    if let Ty::Struct {
+                        name: ref mut sname,
+                        ..
+                    } = ty
+                    {
+                        if sname.is_empty() {
+                            *sname = name.clone();
+                        }
+                    }
                     self.env.define_type_alias(name.clone(), ty);
                 }
                 ItemKind::EnumDecl {
@@ -1609,15 +1622,35 @@ impl TypeChecker {
                     }
                 }
 
-                let _obj_ty = self.check_expr(object);
-                // Field access is not supported in v0.1 beyond type checking
-                // the object. We report an error since there are no struct
-                // types yet.
-                self.errors.push(TypeError::new(
-                    format!("field access `.{}` is not supported in v0.1", field),
-                    expr.span,
-                ));
-                Ty::Error
+                let obj_ty = self.check_expr(object);
+                match &obj_ty {
+                    Ty::Struct { name, fields, .. } => {
+                        match fields.iter().find(|(n, _)| n == field) {
+                            Some((_, fty)) => fty.clone(),
+                            None => {
+                                self.errors.push(TypeError::new(
+                                    format!(
+                                        "struct `{}` has no field `{}`",
+                                        name, field
+                                    ),
+                                    expr.span,
+                                ));
+                                Ty::Error
+                            }
+                        }
+                    }
+                    Ty::Error => Ty::Error,
+                    _ => {
+                        self.errors.push(TypeError::new(
+                            format!(
+                                "field access `.{}` on non-record type `{}`",
+                                field, obj_ty
+                            ),
+                            expr.span,
+                        ));
+                        Ty::Error
+                    }
+                }
             }
 
             ExprKind::If {
@@ -1709,11 +1742,94 @@ impl TypeChecker {
                 let elem_types: Vec<Ty> = elems.iter().map(|e| self.check_expr(e)).collect();
                 Ty::Tuple(elem_types)
             }
-            ExprKind::RecordLit { type_name: _, fields } => {
-                // For now, treat record literals as a tuple of field types
-                // TODO: Implement proper record type lookup and field order matching
-                let field_types: Vec<Ty> = fields.iter().map(|(_, e)| self.check_expr(e)).collect();
-                Ty::Tuple(field_types)
+            ExprKind::RecordLit { type_name, fields } => {
+                // Look up the declared struct type by name. We always check
+                // every field expression so type errors inside field values
+                // are reported even if the surrounding type lookup fails.
+                let provided: Vec<(String, Ty)> = fields
+                    .iter()
+                    .map(|(fname, fexpr)| (fname.clone(), self.check_expr(fexpr)))
+                    .collect();
+
+                let declared = self
+                    .env
+                    .lookup_type_alias(type_name)
+                    .cloned();
+
+                match declared {
+                    Some(Ty::Struct {
+                        name: sname,
+                        fields: decl_fields,
+                        cap,
+                    }) => {
+                        // Validate that the provided field set matches the
+                        // declared field set (same names, no extras, no
+                        // missing). We don't require the same order — record
+                        // literals are by name.
+                        for (pname, pty) in &provided {
+                            match decl_fields.iter().find(|(n, _)| n == pname) {
+                                Some((_, expected)) => {
+                                    if expected != pty
+                                        && !matches!(pty, Ty::Error)
+                                        && !matches!(expected, Ty::Error)
+                                    {
+                                        self.errors.push(TypeError::mismatch(
+                                            format!(
+                                                "field `{}` of `{}` has wrong type",
+                                                pname, sname
+                                            ),
+                                            expr.span,
+                                            expected.clone(),
+                                            pty.clone(),
+                                        ));
+                                    }
+                                }
+                                None => {
+                                    self.errors.push(TypeError::new(
+                                        format!(
+                                            "struct `{}` has no field `{}`",
+                                            sname, pname
+                                        ),
+                                        expr.span,
+                                    ));
+                                }
+                            }
+                        }
+                        for (fname, _) in &decl_fields {
+                            if !provided.iter().any(|(n, _)| n == fname) {
+                                self.errors.push(TypeError::new(
+                                    format!(
+                                        "missing field `{}` in `{}` literal",
+                                        fname, sname
+                                    ),
+                                    expr.span,
+                                ));
+                            }
+                        }
+                        Ty::Struct {
+                            name: sname,
+                            fields: decl_fields,
+                            cap,
+                        }
+                    }
+                    Some(other) => {
+                        self.errors.push(TypeError::new(
+                            format!(
+                                "`{}` is not a record type (found `{}`)",
+                                type_name, other
+                            ),
+                            expr.span,
+                        ));
+                        Ty::Error
+                    }
+                    None => {
+                        self.errors.push(TypeError::new(
+                            format!("unknown record type `{}`", type_name),
+                            expr.span,
+                        ));
+                        Ty::Error
+                    }
+                }
             }
             ExprKind::Construct { name: _, fields } => {
                 // For now, treat constructor with named fields as a tuple of field types
@@ -5392,6 +5508,23 @@ impl TypeChecker {
                     .map(|e| self.resolve_type_expr(&e.node, e.span))
                     .collect();
                 Ty::Tuple(elem_tys)
+            }
+            TypeExpr::Record(fields) => {
+                // A record TypeExpr produced by `type Name:` declarations.
+                // The wrapping ItemKind::TypeDecl provides the name; here we
+                // only have anonymous fields, so we emit a Struct with an
+                // empty name. The TypeDecl handler patches the name in.
+                let field_tys: Vec<(String, Ty)> = fields
+                    .iter()
+                    .map(|(fname, fty)| {
+                        (fname.clone(), self.resolve_type_expr(&fty.node, fty.span))
+                    })
+                    .collect();
+                Ty::Struct {
+                    name: String::new(),
+                    fields: field_tys,
+                    cap: crate::typechecker::types::RefCap::default_struct(),
+                }
             }
             TypeExpr::Linear(inner) => {
                 let inner_ty = self.resolve_type_expr(&inner.node, inner.span);

--- a/codebase/compiler/src/typechecker/tests.rs
+++ b/codebase/compiler/src/typechecker/tests.rs
@@ -8446,3 +8446,79 @@ fn is_regression_test(mode: TestMode) -> Bool:
 ";
     assert_no_errors(src);
 }
+
+// ============================================================================
+// Record types: construction + field reads
+// ============================================================================
+
+#[test]
+fn record_field_read_returns_field_type() {
+    let src = r#"
+type Position:
+    line: Int
+    col: Int
+
+fn get_line(p: Position) -> Int:
+    ret p.line
+"#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn record_literal_validates_field_types() {
+    let src = r#"
+type Position:
+    line: Int
+    col: Int
+
+fn make() -> Position:
+    ret Position { line = "oops", col = 0 }
+"#;
+    assert_error_contains(src, "field `line`");
+}
+
+#[test]
+fn record_literal_rejects_unknown_field() {
+    let src = r#"
+type Position:
+    line: Int
+
+fn make() -> Position:
+    ret Position { line = 1, bogus = 2 }
+"#;
+    assert_error_contains(src, "no field `bogus`");
+}
+
+#[test]
+fn record_literal_rejects_missing_field() {
+    let src = r#"
+type Position:
+    line: Int
+    col: Int
+
+fn make() -> Position:
+    ret Position { line = 1 }
+"#;
+    assert_error_contains(src, "missing field `col`");
+}
+
+#[test]
+fn record_field_read_rejects_unknown_field() {
+    let src = r#"
+type Position:
+    line: Int
+
+fn bad(p: Position) -> Int:
+    ret p.bogus
+"#;
+    assert_error_contains(src, "no field `bogus`");
+}
+
+#[test]
+fn record_field_read_on_non_record_errors() {
+    let src = r#"
+fn bad(x: Int) -> Int:
+    ret x.line
+"#;
+    assert_error_contains(src, "non-record type");
+}

--- a/codebase/devtools/lsp/src/backend.rs
+++ b/codebase/devtools/lsp/src/backend.rs
@@ -406,6 +406,13 @@ fn format_type_expr(te: &gradient_compiler::ast::types::TypeExpr) -> String {
             let elem_strs: Vec<String> = elems.iter().map(|e| format_type_expr(&e.node)).collect();
             format!("({})", elem_strs.join(", "))
         }
+        TypeExpr::Record(fields) => {
+            let field_strs: Vec<String> = fields
+                .iter()
+                .map(|(n, ty)| format!("{}: {}", n, format_type_expr(&ty.node)))
+                .collect();
+            format!("{{ {} }}", field_strs.join(", "))
+        }
         TypeExpr::Linear(_) => "Linear".to_string(),
         TypeExpr::Type => "type".to_string(),
     }


### PR DESCRIPTION
## Summary
Records have been parseable since Phase H but were lossy on the way into the type system: \`parse_record_type_decl\` flattened them to \`TypeExpr::Tuple\`, dropping field names, and the typechecker punted on field access with \`field access \`.foo\` is not supported in v0.1\`. This blocks every self-hosted module that wants records as data — \`compiler/token.gr\` only shipped because none of its helpers actually read fields.

## Changes
- **ast**: add \`TypeExpr::Record(Vec<(String, Spanned<TypeExpr>)>)\`
- **parser**: \`parse_record_type_decl\` emits \`Record\` instead of \`Tuple\`, preserving field names
- **typechecker**:
  - \`resolve_type_expr\` handles \`Record\` by building \`Ty::Struct\`; the wrapping \`TypeDecl\` handler patches the declared name in
  - \`ExprKind::RecordLit\` looks up the named struct, validates field names (no extras, no missing) and types
  - \`ExprKind::FieldAccess\` on a struct returns the field's declared type
- **query, fmt, ir/builder, devtools/lsp**: handle the new variant

## Out of scope
IR generation and codegen — records still lower as opaque pointers. Enough to unblock typechecking the self-hosted compiler; real struct codegen comes when the self-hosted compiler is ready to be *compiled*.

## Test plan
- [x] 6 new typechecker tests (\`record_*\`)
- [x] \`compiler/token.gr\` still parses + typechecks via agent mode
- [x] Nested field access (\`s.start.line\`) verified end-to-end via agent mode
- [x] \`cargo test --release -p gradient-compiler --lib\` — 1075 (+6)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo clippy -p gradient-compiler --features wasm -- -D warnings\` clean