### PR TITLE
fix: register types and functions from mod blocks in first pass

### DIFF
--- a/codebase/compiler/src/typechecker/checker.rs
+++ b/codebase/compiler/src/typechecker/checker.rs
@@ -448,6 +448,77 @@ impl TypeChecker {
                         self.env.define_fn(qualified_name, sig);
                     }
                 }
+                ItemKind::ModBlock { name: mod_name, items: mod_items, .. } => {
+                    // First pass: register types and functions within mod block.
+                    // These are namespaced under the module name.
+                    for mod_item in mod_items {
+                        match &mod_item.node {
+                            ItemKind::TypeDecl { name, type_expr, .. } => {
+                                let mut ty = self.resolve_type_expr(&type_expr.node, type_expr.span);
+                                if let Ty::Struct { name: ref mut sname, .. } = ty {
+                                    if sname.is_empty() {
+                                        *sname = name.clone();
+                                    }
+                                }
+                                // Register with qualified name: mod_name::type_name
+                                let qualified_name = format!("{}::{}", mod_name, name);
+                                self.env.define_type_alias(qualified_name.clone(), ty.clone());
+                                // Also register unqualified for internal use within the mod
+                                self.env.define_type_alias(name.clone(), ty);
+                            }
+                            ItemKind::EnumDecl { name, type_params, variants, .. } => {
+                                let saved_type_params =
+                                    std::mem::replace(&mut self.active_type_params, type_params.clone());
+                                let mut ty_variants = Vec::new();
+                                for v in variants {
+                                    let field_ty: Option<Ty> = v.fields.as_ref().map(|fields| {
+                                        let tys: Vec<Ty> = fields
+                                            .iter()
+                                            .map(|f| match f {
+                                                VariantField::Named { type_expr, .. } => {
+                                                    self.resolve_type_expr(&type_expr.node, type_expr.span)
+                                                }
+                                                VariantField::Anonymous(type_expr) => {
+                                                    self.resolve_type_expr(&type_expr.node, type_expr.span)
+                                                }
+                                            })
+                                            .collect();
+                                        if tys.len() == 1 {
+                                            tys.into_iter().next().unwrap()
+                                        } else {
+                                            Ty::Tuple(tys)
+                                        }
+                                    });
+                                    ty_variants.push((v.name.clone(), field_ty));
+                                }
+                                self.active_type_params = saved_type_params;
+                                
+                                // Build enum type with variants
+                                let enum_ty = Ty::Enum {
+                                    name: name.clone(),
+                                    variants: ty_variants.clone(),
+                                };
+
+                                // Register with qualified name
+                                let qualified_name = format!("{}::{}", mod_name, name);
+                                self.env.define_enum(qualified_name.clone(), enum_ty.clone());
+                                self.env.define_type_alias(qualified_name.clone(), enum_ty.clone());
+
+                                // Also register unqualified for internal use
+                                self.env.define_enum(name.clone(), enum_ty.clone());
+                                self.env.define_type_alias(name.clone(), enum_ty);
+                            }
+                            ItemKind::FnDef(fn_def) => {
+                                let sig = self.fn_def_to_sig(fn_def);
+                                let qualified_name = format!("{}::{}", mod_name, fn_def.name);
+                                self.env.define_fn(qualified_name, sig.clone());
+                                // Also register unqualified for internal use
+                                self.env.define_fn(fn_def.name.clone(), sig);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
## Summary
Fixes type resolution within mod blocks (work item #7 from AGENT_HANDOFF.md).

ModBlock items were falling through to the catch-all _ => {} in the first pass of check_module(), meaning types and functions defined inside mod blocks were never registered in the type environment.

## Changes
- Added explicit handling for ItemKind::ModBlock in the first pass of check_module()
- Types defined in mod blocks are registered with qualified names (mod_name::type_name)
- Enum declarations are registered with their variants
- Function definitions are registered with qualified names
- Both qualified and unqualified names are registered to support external access and internal use

## Testing
- All 1091 existing tests pass
- No new tests added (qualified name syntax mod::Type requires parser support, which is a separate work item)

## Related Issues
Related to work item #7 in AGENT_HANDOFF.md