### PR TITLE
docs: add issue-first workflow and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: 'fix(scope): brief description'
+labels: bug
+assignees: ''
+
+---
+
+## Bug Description
+A clear description of what the bug is.
+
+## Steps to Reproduce
+1. Step one
+2. Step two
+3. Step three
+
+## Expected Behavior
+What you expected to happen.
+
+## Actual Behavior
+What actually happened.
+
+## Environment
+- OS: [e.g. Ubuntu 22.04]
+- Gradient version: [e.g. 0.1.0]
+- Rust version: [e.g. 1.75.0]
+
+## Code Example
+```gradient
+// Minimal code that reproduces the issue
+```
+
+## Related
+- Related issues: #XXX
+- Related PRs: #XXX

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: 'feat(scope): brief description'
+labels: enhancement
+assignees: ''
+
+---
+
+## Summary
+A clear and concise description of the feature request.
+
+## Motivation
+Why is this feature needed? What problem does it solve?
+
+## Proposed Solution
+Describe the solution you'd like to see.
+
+## Alternatives Considered
+Any alternative solutions or features you've considered.
+
+## Roadmap Alignment
+How does this align with the project roadmap?
+
+## Additional Context
+Add any other context, mockups, or examples here.
+
+## Related
+- Related issues: #XXX
+- Related PRs: #XXX
+- Related roadmap items: [link if applicable]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,27 @@ Fixes #XXX
 - Use 4 spaces for indentation
 - Maximum line length: 100 characters
 
+## Issue-First Workflow
+
+All bug fixes and substantial changes must follow the issue-first workflow:
+
+### For Bug Fixes
+1. **Create an issue first** describing the bug
+2. **Reference the issue** in your PR description with `Fixes #XXX`
+3. **Batch small fixes** - combine related small bugs into a single issue/PR
+4. Only merge after CI passes
+
+### For Features
+1. **Reference the roadmap** in your PR description
+2. Ensure alignment with project direction
+3. Update documentation with the feature
+
+### Issue Templates
+
+Use the appropriate template when creating issues:
+- **Bug Report**: For bugs and unexpected behavior
+- **Feature Request**: For new features and enhancements
+
 ## Testing
 
 All changes must include tests:
@@ -117,3 +138,13 @@ Run tests before submitting:
 ```bash
 cargo test --workspace
 ```
+
+## Documentation
+
+Update documentation with every change:
+- README.md (if user-facing changes)
+- API documentation (if public API changes)
+- Changelog (if applicable)
+- Any relevant guides or tutorials
+
+Never reference internal documents (agent handoffs, private notes) in public-facing PRs or issues.


### PR DESCRIPTION
## Summary
Adds issue-first workflow guidelines and GitHub issue templates to standardize how bugs and features are reported and fixed.

## Changes
- Added `.github/ISSUE_TEMPLATE/bug_report.md` for bug reports
- Added `.github/ISSUE_TEMPLATE/feature_request.md` for feature requests
- Updated CONTRIBUTING.md with issue-first workflow guidelines:
  - Bug fixes must create issues first
  - PRs must reference issues with `Fixes #XXX`
  - Features must reference roadmap
  - Batch small related fixes
  - Update docs with every change
- Never reference internal documents in public PRs

## Testing
- Validated templates render correctly
- Tested workflow commands locally
- All existing tests pass

## Related
References roadmap: Improving contributor experience and project governance