### PR TITLE
docs(readme): add prerequisites and wasm32 target instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ Current LLM coding workflows waste tokens on generate-compile-fix loops. Gradien
 
 ## Quick Start
 
+### Prerequisites
+
+- **Rust** 1.75 or later
+- For WebAssembly builds: `wasm32-unknown-unknown` target
+
+```bash
+# Install Rust (if not already installed)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Add WASM target (for WebAssembly builds)
+rustup target add wasm32-unknown-unknown
+```
+
+### Building
+
 ```bash
 git clone https://github.com/Ontic-Systems/Gradient.git
 cd Gradient/codebase


### PR DESCRIPTION
## Summary
Adds missing prerequisites section to README.md with Rust version requirement and wasm32 target installation instructions.

## Changes
- Added Prerequisites subsection to Quick Start
- Documented minimum Rust version (1.75+)
- Added instructions for installing wasm32-unknown-unknown target
- Separated building instructions into their own subsection for clarity

## Testing
- Verified markdown renders correctly
- All existing tests pass

## Related
Fixes #21