### PR TITLE
fix(compiler): harden panic-prone code paths

### DIFF
--- a/codebase/build-system/src/commands/add.rs
+++ b/codebase/build-system/src/commands/add.rs
@@ -12,6 +12,9 @@ use crate::project::Project;
 use crate::registry::{semver, GitHubClient};
 use std::path::Path;
 use std::process;
+use std::sync::OnceLock;
+
+static REGISTRY_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 /// The type of dependency being added.
 #[derive(Debug, Clone)]
@@ -28,19 +31,26 @@ pub enum DependencyType {
 }
 
 /// Detect the type of dependency from the argument string.
-fn detect_dependency_type(arg: &str) -> DependencyType {
+fn detect_dependency_type(arg: &str) -> Result<DependencyType, String> {
     if arg.contains('/') || arg.contains('\\') {
         // It's a path (contains slash or backslash)
-        DependencyType::Path(arg.to_string())
+        Ok(DependencyType::Path(arg.to_string()))
     } else if arg.starts_with("http") || arg.starts_with("git@") {
         // It's a git URL
-        DependencyType::Git(arg.to_string())
+        Ok(DependencyType::Git(arg.to_string()))
     } else {
         // Parse "package" or "package@version"
         let parts: Vec<&str> = arg.split('@').collect();
-        let name = parts[0].to_string();
+        let name = parts
+            .first()
+            .copied()
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| {
+                "Invalid dependency name: expected format 'name@version' or 'name'".to_string()
+            })?
+            .to_string();
         let version = parts.get(1).map(|s| s.to_string());
-        DependencyType::Registry { name, version }
+        Ok(DependencyType::Registry { name, version })
     }
 }
 
@@ -54,7 +64,13 @@ pub fn execute(arg: &str) {
         }
     };
 
-    let dep_type = detect_dependency_type(arg);
+    let dep_type = match detect_dependency_type(arg) {
+        Ok(dep_type) => dep_type,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+    };
 
     match dep_type {
         DependencyType::Path(path) => add_path_dependency(&project, &path),
@@ -221,11 +237,12 @@ async fn resolve_registry_version(name: &str) -> Result<String, String> {
         .collect();
 
     // Get the latest version
-    let latest = semver::latest_version(&versions)
-        .ok_or_else(|| format!(
+    let latest = semver::latest_version(&versions).ok_or_else(|| {
+        format!(
             "No valid semver tags found for package '{}' in repository '{}'",
             name, repo
-        ))?;
+        )
+    })?;
 
     Ok(semver::version_to_string(&latest))
 }
@@ -233,8 +250,19 @@ async fn resolve_registry_version(name: &str) -> Result<String, String> {
 /// Blocking wrapper for resolve_registry_version.
 /// Uses tokio runtime to execute the async function.
 fn resolve_registry_version_blocking(name: &str) -> Result<String, String> {
-    // Create a new runtime for the async operation
-    let rt =
-        tokio::runtime::Runtime::new().map_err(|e| format!("Failed to create runtime: {}", e))?;
+    let rt = registry_runtime()?;
     rt.block_on(resolve_registry_version(name))
+}
+
+fn registry_runtime() -> Result<&'static tokio::runtime::Runtime, String> {
+    if let Some(runtime) = REGISTRY_RUNTIME.get() {
+        return Ok(runtime);
+    }
+
+    let runtime =
+        tokio::runtime::Runtime::new().map_err(|e| format!("Failed to create runtime: {}", e))?;
+    let _ = REGISTRY_RUNTIME.set(runtime);
+    REGISTRY_RUNTIME
+        .get()
+        .ok_or_else(|| "Failed to initialize registry runtime".to_string())
 }

--- a/codebase/compiler/src/agent/handlers.rs
+++ b/codebase/compiler/src/agent/handlers.rs
@@ -99,7 +99,9 @@ fn build_report(session: &Session) -> SessionReport {
     let symbols = session.symbols();
     let holes = extract_holes(&check.diagnostics);
 
-    let effects = session.effect_summary().map(|s| serde_json::to_value(s).unwrap());
+    let effects = session
+        .effect_summary()
+        .and_then(|summary| serde_json::to_value(summary).ok());
 
     let function_count = symbols
         .iter()
@@ -146,10 +148,7 @@ fn serialization_error(e: serde_json::Error) -> Response {
 }
 
 /// Handle the `load` or `check` method.
-pub fn handle_load(
-    params: &Value,
-    session: &mut Option<Session>,
-) -> Result<Value, Response> {
+pub fn handle_load(params: &Value, session: &mut Option<Session>) -> Result<Value, Response> {
     let source = params.get("source").and_then(|v| v.as_str());
     let file = params.get("file").and_then(|v| v.as_str());
 
@@ -173,9 +172,8 @@ pub fn handle_load(
                     format!("Not a file: {}", p.display()),
                 ));
             }
-            Session::from_file(p).map_err(|e| {
-                Response::error(Value::Null, protocol::FILE_NOT_FOUND, e)
-            })?
+            Session::from_file(p)
+                .map_err(|e| Response::error(Value::Null, protocol::FILE_NOT_FOUND, e))?
         }
         (None, None) => {
             return Err(Response::error(
@@ -211,14 +209,22 @@ pub fn handle_complete(params: &Value, session: &Session) -> Result<Value, Respo
         .and_then(|v| v.as_u64())
         .map(|v| v as u32)
         .ok_or_else(|| {
-            Response::error(Value::Null, protocol::INVALID_PARAMS, "\"line\" parameter required (u32)")
+            Response::error(
+                Value::Null,
+                protocol::INVALID_PARAMS,
+                "\"line\" parameter required (u32)",
+            )
         })?;
     let col = params
         .get("col")
         .and_then(|v| v.as_u64())
         .map(|v| v as u32)
         .ok_or_else(|| {
-            Response::error(Value::Null, protocol::INVALID_PARAMS, "\"col\" parameter required (u32)")
+            Response::error(
+                Value::Null,
+                protocol::INVALID_PARAMS,
+                "\"col\" parameter required (u32)",
+            )
         })?;
 
     let ctx = session.completion_context(line, col);
@@ -338,11 +344,7 @@ pub fn handle_rename(params: &Value, session: &Session) -> Result<Value, Respons
 
     match session.rename(old_name, new_name) {
         Ok(r) => serde_json::to_value(r).map_err(serialization_error),
-        Err(msg) => Err(Response::error(
-            Value::Null,
-            protocol::INVALID_PARAMS,
-            msg,
-        )),
+        Err(msg) => Err(Response::error(Value::Null, protocol::INVALID_PARAMS, msg)),
     }
 }
 
@@ -386,7 +388,10 @@ mod tests {
         let mut session = None;
         let result = handle_load(&params, &mut session);
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err().error.unwrap().code, protocol::FILE_NOT_FOUND);
+        assert_eq!(
+            result.unwrap_err().error.unwrap().code,
+            protocol::FILE_NOT_FOUND
+        );
     }
 
     #[test]
@@ -430,8 +435,7 @@ mod tests {
 
     #[test]
     fn effects_after_load() {
-        let params =
-            serde_json::json!({"source": "fn greet() -> !{IO} ():\n    print(\"hi\")\n"});
+        let params = serde_json::json!({"source": "fn greet() -> !{IO} ():\n    print(\"hi\")\n"});
         let mut session = None;
         handle_load(&params, &mut session).unwrap();
         let result = handle_effects(session.as_ref().unwrap()).unwrap();
@@ -441,7 +445,8 @@ mod tests {
 
     #[test]
     fn call_graph_after_load() {
-        let params = serde_json::json!({"source": "fn a() -> Int:\n    b()\n\nfn b() -> Int:\n    42\n"});
+        let params =
+            serde_json::json!({"source": "fn a() -> Int:\n    b()\n\nfn b() -> Int:\n    42\n"});
         let mut session = None;
         handle_load(&params, &mut session).unwrap();
         let result = handle_call_graph(session.as_ref().unwrap()).unwrap();

--- a/codebase/compiler/src/agent/protocol.rs
+++ b/codebase/compiler/src/agent/protocol.rs
@@ -71,25 +71,20 @@ impl Response {
         }
     }
 
-    pub fn notification(method: &str, params: Value) -> String {
+    pub fn notification(method: &str, params: Value) -> Result<String, serde_json::Error> {
         let obj = serde_json::json!({
             "jsonrpc": "2.0",
             "method": method,
             "params": params,
         });
-        serde_json::to_string(&obj).unwrap()
+        serde_json::to_string(&obj)
     }
 }
 
 /// Parse a JSON line into a Request.
 pub fn parse_request(line: &str) -> Result<Request, Response> {
-    let req: Request = serde_json::from_str(line).map_err(|e| {
-        Response::error(
-            Value::Null,
-            PARSE_ERROR,
-            format!("Invalid JSON: {}", e),
-        )
-    })?;
+    let req: Request = serde_json::from_str(line)
+        .map_err(|e| Response::error(Value::Null, PARSE_ERROR, format!("Invalid JSON: {}", e)))?;
     if req.jsonrpc != "2.0" {
         return Err(Response::error(
             req.id.unwrap_or(Value::Null),
@@ -165,7 +160,8 @@ mod tests {
 
     #[test]
     fn notification_format() {
-        let notif = Response::notification("initialized", serde_json::json!({"version": "0.1.0"}));
+        let notif =
+            Response::notification("initialized", serde_json::json!({"version": "0.1.0"})).unwrap();
         let parsed: Value = serde_json::from_str(&notif).unwrap();
         assert_eq!(parsed["method"], "initialized");
         assert!(parsed.get("id").is_none());

--- a/codebase/compiler/src/agent/server.rs
+++ b/codebase/compiler/src/agent/server.rs
@@ -1,6 +1,8 @@
 //! Agent mode server: stdin/stdout JSON-RPC loop.
 
+use std::any::Any;
 use std::io::{self, BufRead, Write};
+use std::panic::{self, AssertUnwindSafe};
 
 use serde_json::Value;
 
@@ -39,13 +41,16 @@ pub fn run(pretty: bool) {
 
     // Send initialized notification.
     let caps: Vec<&str> = CAPABILITIES.to_vec();
-    let init = Response::notification(
+    let init = match Response::notification(
         "initialized",
         serde_json::json!({
             "version": VERSION,
             "capabilities": caps,
         }),
-    );
+    ) {
+        Ok(init) => init,
+        Err(_) => return,
+    };
     if writeln!(out, "{}", init).is_err() || out.flush().is_err() {
         return;
     }
@@ -79,7 +84,19 @@ pub fn run(pretty: bool) {
         let is_notification = req.id.is_none();
         let id = req.id.clone().unwrap_or(serde_json::Value::Null);
         let method = req.method.clone();
-        let response = dispatch(&req.method, &req.params, &mut session, id);
+        let response = match panic::catch_unwind(AssertUnwindSafe(|| {
+            dispatch(&req.method, &req.params, &mut session, id.clone())
+        })) {
+            Ok(response) => response,
+            Err(payload) => Response::error(
+                id.clone(),
+                protocol::INTERNAL_ERROR,
+                format!(
+                    "Compiler panicked during request processing{}",
+                    panic_suffix(&payload)
+                ),
+            ),
+        };
 
         if !is_notification && !write_response(&mut out, &response, pretty) {
             return;
@@ -93,12 +110,7 @@ pub fn run(pretty: bool) {
 }
 
 /// Dispatch a method call to the appropriate handler.
-fn dispatch(
-    method: &str,
-    params: &Value,
-    session: &mut Option<Session>,
-    id: Value,
-) -> Response {
+fn dispatch(method: &str, params: &Value, session: &mut Option<Session>, id: Value) -> Response {
     match method {
         "load" | "check" => match handlers::handle_load(params, session) {
             Ok(result) => Response::success(id, result),
@@ -132,7 +144,11 @@ fn dispatch(
 
         "shutdown" => Response::success(id, serde_json::json!({"ok": true})),
 
-        _ => Response::error(id, protocol::METHOD_NOT_FOUND, format!("Unknown method: {}", method)),
+        _ => Response::error(
+            id,
+            protocol::METHOD_NOT_FOUND,
+            format!("Unknown method: {}", method),
+        ),
     }
 }
 
@@ -171,6 +187,16 @@ fn write_response(out: &mut impl Write, response: &Response, pretty: bool) -> bo
     match json {
         Ok(json) => writeln!(out, "{}", json).is_ok() && out.flush().is_ok(),
         Err(_) => false,
+    }
+}
+
+fn panic_suffix(payload: &Box<dyn Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        format!(": {}", message)
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        format!(": {}", message)
+    } else {
+        String::new()
     }
 }
 
@@ -239,6 +265,10 @@ mod tests {
         // And null-id error responses (parse errors) should serialize id as null.
         let err = Response::error(Value::Null, protocol::PARSE_ERROR, "bad");
         let json = serde_json::to_string(&err).unwrap();
-        assert!(json.contains("\"id\":null"), "null id not serialized: {}", json);
+        assert!(
+            json.contains("\"id\":null"),
+            "null id not serialized: {}",
+            json
+        );
     }
 }

--- a/codebase/compiler/src/codegen/cranelift.rs
+++ b/codebase/compiler/src/codegen/cranelift.rs
@@ -6699,8 +6699,15 @@ impl CraneliftCodegen {
                                         );
                                         existing
                                     } else {
-                                        let target_func_id =
-                                            self.declared_functions.get(target_name).unwrap();
+                                        let target_func_id = self
+                                            .declared_functions
+                                            .get(target_name)
+                                            .ok_or_else(|| {
+                                                format!(
+                                                    "Undeclared function referenced during codegen: {}",
+                                                    target_name
+                                                )
+                                            })?;
                                         eprintln!("DEBUG: Declaring func '{}' in func '{}' -> FuncId({:?})", target_name, func.name, target_func_id);
                                         let fref = self
                                             .module
@@ -7258,12 +7265,10 @@ impl CraneliftCodegen {
                         // Uses the field_ty from IR to determine the Cranelift type
                         let obj_val = resolve_value(&value_map, object)?;
                         let cl_ty = ir_type_to_cl(field_ty);
-                        let loaded = builder.ins().load(
-                            cl_ty,
-                            MemFlags::new(),
-                            obj_val,
-                            *offset as i32,
-                        );
+                        let loaded =
+                            builder
+                                .ins()
+                                .load(cl_ty, MemFlags::new(), obj_val, *offset as i32);
                         value_map.insert(*result, loaded);
                     }
 
@@ -7280,12 +7285,9 @@ impl CraneliftCodegen {
                         let val = resolve_value(&value_map, value)?;
                         // Note: field_ty could be used here for type checking or conversion
                         let _cl_ty = ir_type_to_cl(field_ty);
-                        builder.ins().store(
-                            MemFlags::new(),
-                            val,
-                            obj_val,
-                            *offset as i32,
-                        );
+                        builder
+                            .ins()
+                            .store(MemFlags::new(), val, obj_val, *offset as i32);
                     }
                 }
             }

--- a/codebase/compiler/src/codegen/mod.rs
+++ b/codebase/compiler/src/codegen/mod.rs
@@ -128,12 +128,7 @@ pub fn llvm_available() -> bool {
 #[allow(clippy::large_enum_variant)]
 pub enum BackendWrapper {
     #[cfg(feature = "llvm")]
-    Llvm {
-        /// The LLVM context must outlive the codegen, so we keep it here.
-        /// Boxed to ensure stable address for the 'static transmute in new().
-        context: Box<inkwell::context::Context>,
-        codegen: llvm::LlvmCodegen<'static>,
-    },
+    Llvm(llvm::LlvmCodegen<'static>),
     #[cfg(feature = "wasm")]
     Wasm(wasm::WasmBackend),
     Cranelift(CraneliftCodegen),
@@ -152,14 +147,7 @@ impl BackendWrapper {
         if release_mode {
             #[cfg(feature = "llvm")]
             {
-                let context = Box::new(inkwell::context::Context::create());
-                // SAFETY: We transmute to 'static because the context is boxed and will
-                // live as long as the BackendWrapper (they are dropped together).
-                // The context address is stable because it's boxed.
-                let context_ref: &'static inkwell::context::Context =
-                    unsafe { std::mem::transmute(&*context) };
-                let codegen = llvm::LlvmCodegen::new(context_ref)?;
-                Ok(BackendWrapper::Llvm { context, codegen })
+                Self::new_llvm()
             }
             #[cfg(not(feature = "llvm"))]
             {
@@ -200,11 +188,7 @@ impl BackendWrapper {
             "llvm" => {
                 #[cfg(feature = "llvm")]
                 {
-                    let context = Box::new(inkwell::context::Context::create());
-                    let context_ref: &'static inkwell::context::Context =
-                        unsafe { std::mem::transmute(&*context) };
-                    let codegen = llvm::LlvmCodegen::new(context_ref)?;
-                    Ok(BackendWrapper::Llvm { context, codegen })
+                    Self::new_llvm()
                 }
                 #[cfg(not(feature = "llvm"))]
                 {
@@ -228,11 +212,19 @@ impl BackendWrapper {
     pub fn backend_name(&self) -> &str {
         match self {
             #[cfg(feature = "llvm")]
-            BackendWrapper::Llvm { codegen, .. } => codegen.name(),
+            BackendWrapper::Llvm(codegen) => codegen.name(),
             #[cfg(feature = "wasm")]
             BackendWrapper::Wasm(backend) => backend.name(),
             BackendWrapper::Cranelift(cg) => cg.name(),
         }
+    }
+
+    #[cfg(feature = "llvm")]
+    fn new_llvm() -> Result<Self, CodegenError> {
+        let context: &'static inkwell::context::Context =
+            Box::leak(Box::new(inkwell::context::Context::create()));
+        let codegen = llvm::LlvmCodegen::new(context)?;
+        Ok(BackendWrapper::Llvm(codegen))
     }
 }
 
@@ -240,7 +232,7 @@ impl CodegenBackend for BackendWrapper {
     fn compile_module(&mut self, module: &ir::Module) -> Result<(), CodegenError> {
         match self {
             #[cfg(feature = "llvm")]
-            BackendWrapper::Llvm { codegen, .. } => codegen.compile_module(module),
+            BackendWrapper::Llvm(codegen) => codegen.compile_module(module),
             #[cfg(feature = "wasm")]
             BackendWrapper::Wasm(backend) => backend.compile_module(module),
             BackendWrapper::Cranelift(cg) => cg.compile_module(module).map_err(CodegenError::from),
@@ -250,7 +242,7 @@ impl CodegenBackend for BackendWrapper {
     fn finish(self: Box<Self>) -> Result<Vec<u8>, CodegenError> {
         match *self {
             #[cfg(feature = "llvm")]
-            BackendWrapper::Llvm { codegen, .. } => {
+            BackendWrapper::Llvm(codegen) => {
                 // codegen is owned by self, so we can convert it to a box and finish
                 // Note: we can't easily box codegen separately because of lifetime
                 // So we use the trait method through the wrapper

--- a/codebase/compiler/src/codegen/wasm.rs
+++ b/codebase/compiler/src/codegen/wasm.rs
@@ -483,7 +483,10 @@ impl WasmBackend {
                 }
 
                 builder.instruction(&WasmInstr::Call(func_idx));
-                builder.instruction(&WasmInstr::LocalSet(*value_map.get(result).unwrap()));
+                let result_idx = *value_map
+                    .get(result)
+                    .ok_or_else(|| CodegenError::from("Undefined result value in Call"))?;
+                builder.instruction(&WasmInstr::LocalSet(result_idx));
             }
 
             // Return from function
@@ -995,12 +998,6 @@ impl CodegenBackend for WasmBackend {
 
     fn name(&self) -> &str {
         "wasm"
-    }
-}
-
-impl Default for WasmBackend {
-    fn default() -> Self {
-        Self::new().expect("Failed to create default WasmBackend")
     }
 }
 

--- a/codebase/compiler/src/ir/builder/mod.rs
+++ b/codebase/compiler/src/ir/builder/mod.rs
@@ -45,7 +45,13 @@ impl RecordLayout {
 
     /// Add a field to the layout.
     /// Returns the field index and offset assigned to this field.
-    pub fn add_field(&mut self, name: String, size: i64, align: i64, ty: super::Type) -> (u32, i64) {
+    pub fn add_field(
+        &mut self,
+        name: String,
+        size: i64,
+        align: i64,
+        ty: super::Type,
+    ) -> (u32, i64) {
         // Align the current offset to the field's alignment requirement
         let aligned_offset = (self.total_size + align - 1) & !(align - 1);
         let index = self.fields.len() as u32;
@@ -56,7 +62,9 @@ impl RecordLayout {
 
     /// Get the index and offset for a field by name.
     pub fn get_field(&self, name: &str) -> Option<(u32, i64)> {
-        self.fields.get(name).map(|(idx, offset, _)| (*idx, *offset))
+        self.fields
+            .get(name)
+            .map(|(idx, offset, _)| (*idx, *offset))
     }
 
     /// Get the index, offset, and type for a field by name.
@@ -207,6 +215,32 @@ impl IrBuilder {
             option_inner_types: HashMap::new(),
             defer_stack: vec![Vec::new()], // Initialize with root scope
         }
+    }
+
+    fn runtime_function(&mut self, name: &str) -> Option<FuncRef> {
+        self.function_refs.get(name).copied().or_else(|| {
+            self.errors
+                .push(format!("missing runtime function registration: '{}'", name));
+            None
+        })
+    }
+
+    fn zero_value(&mut self, ty: Type) -> Value {
+        let value = self.fresh_value(ty.clone());
+        let literal = match ty {
+            Type::F64 => Literal::Float(0.0),
+            Type::Bool => Literal::Bool(false),
+            _ => Literal::Int(0),
+        };
+        self.emit(Instruction::Const(value, literal));
+        value
+    }
+
+    fn error_string_value(&mut self, text: &str) -> Value {
+        let value = self.fresh_value(Type::Ptr);
+        self.emit(Instruction::Const(value, Literal::Str(text.to_string())));
+        self.string_values.insert(value);
+        value
     }
 
     // ── Entry point ──────────────────────────────────────────────────
@@ -1480,13 +1514,10 @@ impl IrBuilder {
         ));
         self.string_values.insert(msg_val);
 
-        let func_ref = self
-            .function_refs
-            .get("__gradient_contract_fail")
-            .copied()
-            .expect("__gradient_contract_fail should be pre-registered");
-        let call_result = self.fresh_value(Type::Void);
-        self.emit(Instruction::Call(call_result, func_ref, vec![msg_val]));
+        if let Some(func_ref) = self.runtime_function("__gradient_contract_fail") {
+            let call_result = self.fresh_value(Type::Void);
+            self.emit(Instruction::Call(call_result, func_ref, vec![msg_val]));
+        }
         // After the contract failure call, we abort (but emit a Ret for well-formedness).
         self.emit(Instruction::Ret(None));
         self.seal_block();
@@ -1737,14 +1768,11 @@ impl IrBuilder {
                 } else {
                     // Fallback: try to find layout by checking all known record types
                     // This handles cases where the record value comes from a variable
-                    let found =
-                        self.record_layouts
-                            .iter()
-                            .find_map(|(type_name, layout)| {
-                                layout
-                                    .get_field_with_type(field)
-                                    .map(|(idx, offset, ty)| (type_name.clone(), idx, offset, ty))
-                            });
+                    let found = self.record_layouts.iter().find_map(|(type_name, layout)| {
+                        layout
+                            .get_field_with_type(field)
+                            .map(|(idx, offset, ty)| (type_name.clone(), idx, offset, ty))
+                    });
 
                     if let Some((_, field_idx, offset, field_ty)) = found {
                         let result = self.fresh_value(field_ty.clone());
@@ -1789,15 +1817,14 @@ impl IrBuilder {
                 self.register_func(&func_name);
                 self.function_return_types
                     .insert(func_name.clone(), Type::Ptr);
-                let func_ref = self
-                    .function_refs
-                    .get(&func_name)
-                    .copied()
-                    .expect("list_literal_N should be registered");
-                let result = self.fresh_value(Type::Ptr);
-                self.emit(Instruction::Call(result, func_ref, elem_vals));
-                self.list_values.insert(result);
-                result
+                if let Some(func_ref) = self.runtime_function(&func_name) {
+                    let result = self.fresh_value(Type::Ptr);
+                    self.emit(Instruction::Call(result, func_ref, elem_vals));
+                    self.list_values.insert(result);
+                    result
+                } else {
+                    self.zero_value(Type::Ptr)
+                }
             }
             ast::ExprKind::Tuple(elems) => {
                 let mut elem_addrs = Vec::new();
@@ -1890,7 +1917,10 @@ impl IrBuilder {
                     base
                 }
             }
-            ast::ExprKind::TypedExpr { type_expr: _, value } => {
+            ast::ExprKind::TypedExpr {
+                type_expr: _,
+                value,
+            } => {
                 // Typed expressions are just the value with a type annotation.
                 // For now, we ignore the type annotation and just build the value.
                 // TODO: Use the type annotation for type checking/assertions.
@@ -1979,15 +2009,14 @@ impl IrBuilder {
                 let v2 = self.build_expr(right);
                 if self.string_values.contains(&v1) || self.string_values.contains(&v2) {
                     // String concatenation: call string_concat(a, b)
-                    let func_ref = self
-                        .function_refs
-                        .get("string_concat")
-                        .copied()
-                        .expect("string_concat should be pre-registered");
-                    let result = self.fresh_value(Type::Ptr);
-                    self.emit(Instruction::Call(result, func_ref, vec![v1, v2]));
-                    self.string_values.insert(result);
-                    result
+                    if let Some(func_ref) = self.runtime_function("string_concat") {
+                        let result = self.fresh_value(Type::Ptr);
+                        self.emit(Instruction::Call(result, func_ref, vec![v1, v2]));
+                        self.string_values.insert(result);
+                        result
+                    } else {
+                        self.error_string_value("<concat-error>")
+                    }
                 } else {
                     // Use the type of the left operand for the result.
                     let operand_ty = self.value_types.get(&v1).cloned().unwrap_or(Type::I64);
@@ -2063,22 +2092,20 @@ impl IrBuilder {
         let v2_is_str =
             self.string_values.contains(&v2) || self.value_types.get(&v2) == Some(&Type::Ptr);
         if (v1_is_str || v2_is_str) && (op == CmpOp::Eq || op == CmpOp::Ne) {
-            let func_ref = self
-                .function_refs
-                .get("string_eq")
-                .copied()
-                .expect("string_eq should be pre-registered");
-            let eq_result = self.fresh_value(Type::Bool);
-            self.emit(Instruction::Call(eq_result, func_ref, vec![v1, v2]));
-            if op == CmpOp::Ne {
-                // Negate: ne_result = (eq_result == false)
-                let false_val = self.fresh_value(Type::Bool);
-                self.emit(Instruction::Const(false_val, Literal::Bool(false)));
-                let neg = self.fresh_value(Type::Bool);
-                self.emit(Instruction::Cmp(neg, CmpOp::Eq, eq_result, false_val));
-                return neg;
+            if let Some(func_ref) = self.runtime_function("string_eq") {
+                let eq_result = self.fresh_value(Type::Bool);
+                self.emit(Instruction::Call(eq_result, func_ref, vec![v1, v2]));
+                if op == CmpOp::Ne {
+                    // Negate: ne_result = (eq_result == false)
+                    let false_val = self.fresh_value(Type::Bool);
+                    self.emit(Instruction::Const(false_val, Literal::Bool(false)));
+                    let neg = self.fresh_value(Type::Bool);
+                    self.emit(Instruction::Cmp(neg, CmpOp::Eq, eq_result, false_val));
+                    return neg;
+                }
+                return eq_result;
             }
-            return eq_result;
+            return self.zero_value(Type::Bool);
         }
 
         let result = self.fresh_value(Type::Bool);
@@ -2419,30 +2446,39 @@ impl IrBuilder {
                             }
                             Type::I64 => {
                                 // Call int_to_string.
-                                let func_ref =
-                                    self.function_refs.get("int_to_string").copied().unwrap();
-                                let result = self.fresh_value(Type::Ptr);
-                                self.emit(Instruction::Call(result, func_ref, vec![val]));
-                                self.string_values.insert(result);
-                                string_vals.push(result);
+                                if let Some(func_ref) = self.runtime_function("int_to_string") {
+                                    let result = self.fresh_value(Type::Ptr);
+                                    self.emit(Instruction::Call(result, func_ref, vec![val]));
+                                    self.string_values.insert(result);
+                                    string_vals.push(result);
+                                } else {
+                                    string_vals
+                                        .push(self.error_string_value("<int-to-string-error>"));
+                                }
                             }
                             Type::F64 => {
                                 // Call float_to_string.
-                                let func_ref =
-                                    self.function_refs.get("float_to_string").copied().unwrap();
-                                let result = self.fresh_value(Type::Ptr);
-                                self.emit(Instruction::Call(result, func_ref, vec![val]));
-                                self.string_values.insert(result);
-                                string_vals.push(result);
+                                if let Some(func_ref) = self.runtime_function("float_to_string") {
+                                    let result = self.fresh_value(Type::Ptr);
+                                    self.emit(Instruction::Call(result, func_ref, vec![val]));
+                                    self.string_values.insert(result);
+                                    string_vals.push(result);
+                                } else {
+                                    string_vals
+                                        .push(self.error_string_value("<float-to-string-error>"));
+                                }
                             }
                             Type::Bool => {
                                 // Call bool_to_string.
-                                let func_ref =
-                                    self.function_refs.get("bool_to_string").copied().unwrap();
-                                let result = self.fresh_value(Type::Ptr);
-                                self.emit(Instruction::Call(result, func_ref, vec![val]));
-                                self.string_values.insert(result);
-                                string_vals.push(result);
+                                if let Some(func_ref) = self.runtime_function("bool_to_string") {
+                                    let result = self.fresh_value(Type::Ptr);
+                                    self.emit(Instruction::Call(result, func_ref, vec![val]));
+                                    self.string_values.insert(result);
+                                    string_vals.push(result);
+                                } else {
+                                    string_vals
+                                        .push(self.error_string_value("<bool-to-string-error>"));
+                                }
                             }
                             _ => {
                                 self.errors.push(format!(
@@ -2472,11 +2508,16 @@ impl IrBuilder {
         }
 
         // Concatenate all parts left-to-right.
-        let mut acc = string_vals[0];
-        let concat_ref = self.function_refs.get("string_concat").copied().unwrap();
-        for val in &string_vals[1..] {
+        let mut values = string_vals.into_iter();
+        let Some(mut acc) = values.next() else {
+            return self.error_string_value("<empty-interpolation>");
+        };
+        let Some(concat_ref) = self.runtime_function("string_concat") else {
+            return acc;
+        };
+        for val in values {
             let result = self.fresh_value(Type::Ptr);
-            self.emit(Instruction::Call(result, concat_ref, vec![acc, *val]));
+            self.emit(Instruction::Call(result, concat_ref, vec![acc, val]));
             self.string_values.insert(result);
             acc = result;
         }
@@ -2793,11 +2834,9 @@ impl IrBuilder {
     /// ```
     fn build_for_list(&mut self, var: &str, list_val: Value, body: &ast::Block) -> Value {
         // Call list_length to get the length.
-        let len_func_ref = self
-            .function_refs
-            .get("list_length")
-            .copied()
-            .expect("list_length should be pre-registered");
+        let Some(len_func_ref) = self.runtime_function("list_length") else {
+            return self.zero_value(Type::Void);
+        };
         let len_val = self.fresh_value(Type::I64);
         self.emit(Instruction::Call(len_val, len_func_ref, vec![list_val]));
 
@@ -2828,11 +2867,10 @@ impl IrBuilder {
         self.current_block_label = loop_body;
         self.push_scope();
 
-        let get_func_ref = self
-            .function_refs
-            .get("list_get")
-            .copied()
-            .expect("list_get should be pre-registered");
+        let Some(get_func_ref) = self.runtime_function("list_get") else {
+            self.pop_scope();
+            return self.zero_value(Type::Void);
+        };
         let elem_val = self.fresh_value(Type::I64);
         self.emit(Instruction::Call(
             elem_val,
@@ -3087,18 +3125,17 @@ impl IrBuilder {
                     let lit_val = self.fresh_value(Type::Ptr);
                     self.emit(Instruction::Const(lit_val, Literal::Str(s.clone())));
                     self.string_values.insert(lit_val);
-                    let func_ref = self
-                        .function_refs
-                        .get("string_eq")
-                        .copied()
-                        .expect("string_eq should be pre-registered");
-                    let cmp = self.fresh_value(Type::Bool);
-                    self.emit(Instruction::Call(
-                        cmp,
-                        func_ref,
-                        vec![scrutinee_val, lit_val],
-                    ));
-                    cmp
+                    if let Some(func_ref) = self.runtime_function("string_eq") {
+                        let cmp = self.fresh_value(Type::Bool);
+                        self.emit(Instruction::Call(
+                            cmp,
+                            func_ref,
+                            vec![scrutinee_val, lit_val],
+                        ));
+                        cmp
+                    } else {
+                        self.zero_value(Type::Bool)
+                    }
                 }
                 ast::Pattern::Variable(var_name) => {
                     // A guarded variable pattern: the pattern always matches,
@@ -3466,14 +3503,10 @@ impl IrBuilder {
 
         // Emit scope entry: create a new scope context and track it
         let scope_id = self.fresh_value(Type::Ptr);
-        self.emit(Instruction::Call(
-            scope_id,
-            self.function_refs
-                .get("__concurrent_scope_enter")
-                .copied()
-                .expect("__concurrent_scope_enter should be registered"),
-            vec![],
-        ));
+        let Some(scope_enter) = self.runtime_function("__concurrent_scope_enter") else {
+            return self.zero_value(Type::Void);
+        };
+        self.emit(Instruction::Call(scope_id, scope_enter, vec![]));
 
         // Create labels for the scope body and cleanup
         let body_block = self.fresh_block();
@@ -3505,11 +3538,9 @@ impl IrBuilder {
         // Build cleanup block: cancel all spawned actors in this scope
         self.seal_block();
         self.current_block_label = cleanup_block;
-        let func_ref = self
-            .function_refs
-            .get("__concurrent_scope_exit")
-            .copied()
-            .expect("__concurrent_scope_exit should be registered");
+        let Some(func_ref) = self.runtime_function("__concurrent_scope_exit") else {
+            return self.zero_value(Type::Void);
+        };
         let result_val = self.fresh_value(Type::Void);
         self.emit(Instruction::Call(result_val, func_ref, vec![scope_id]));
         self.emit(Instruction::Jump(exit_block));
@@ -3569,11 +3600,11 @@ impl IrBuilder {
                 // Each child spec is represented as a runtime object
                 // containing actor type, restart policy, etc.
                 let spec_val = self.fresh_value(Type::Ptr);
-                let create_spec_func = self
-                    .function_refs
-                    .get("__supervisor_create_child_spec")
-                    .copied()
-                    .expect("__supervisor_create_child_spec should be registered");
+                let Some(create_spec_func) =
+                    self.runtime_function("__supervisor_create_child_spec")
+                else {
+                    return self.zero_value(Type::Ptr);
+                };
 
                 // Actor type name as string
                 let actor_type_val = self.fresh_value(Type::Ptr);
@@ -3620,11 +3651,9 @@ impl IrBuilder {
 
         // Create supervisor handle
         let supervisor_handle = self.fresh_value(Type::Ptr);
-        let create_func = self
-            .function_refs
-            .get("__supervisor_create")
-            .copied()
-            .expect("__supervisor_create should be registered");
+        let Some(create_func) = self.runtime_function("__supervisor_create") else {
+            return self.zero_value(Type::Ptr);
+        };
         self.emit(Instruction::Call(
             supervisor_handle,
             create_func,
@@ -3634,11 +3663,9 @@ impl IrBuilder {
         // Add child specs to supervisor
         for child_spec in child_specs {
             let result_val = self.fresh_value(Type::Void);
-            let add_child_func = self
-                .function_refs
-                .get("__supervisor_add_child")
-                .copied()
-                .expect("__supervisor_add_child should be registered");
+            let Some(add_child_func) = self.runtime_function("__supervisor_add_child") else {
+                return self.zero_value(Type::Ptr);
+            };
             self.emit(Instruction::Call(
                 result_val,
                 add_child_func,
@@ -3648,11 +3675,9 @@ impl IrBuilder {
 
         // Start the supervisor
         let start_result = self.fresh_value(Type::Void);
-        let start_func = self
-            .function_refs
-            .get("__supervisor_start")
-            .copied()
-            .expect("__supervisor_start should be registered");
+        let Some(start_func) = self.runtime_function("__supervisor_start") else {
+            return self.zero_value(Type::Ptr);
+        };
         self.emit(Instruction::Call(
             start_result,
             start_func,

--- a/codebase/compiler/src/lexer/lexer.rs
+++ b/codebase/compiler/src/lexer/lexer.rs
@@ -369,7 +369,14 @@ impl<'src> Lexer<'src> {
                 && self.peek_at(2) == Some('/');
 
             // Compare against indentation stack.
-            let current_indent = *self.indent_stack.last().unwrap();
+            let Some(&current_indent) = self.indent_stack.last() else {
+                let pos = self.current_position();
+                self.pending_tokens.push_back(Token::new(
+                    TokenKind::Error("invalid indentation state".into()),
+                    Span::point(self.file_id, pos),
+                ));
+                return;
+            };
 
             if indent > current_indent {
                 // Increased indentation: push and emit INDENT.
@@ -381,7 +388,7 @@ impl<'src> Lexer<'src> {
                 ));
             } else if indent < current_indent {
                 // Decreased indentation: pop and emit DEDENTs.
-                while *self.indent_stack.last().unwrap() > indent {
+                while matches!(self.indent_stack.last(), Some(&level) if level > indent) {
                     self.indent_stack.pop();
                     let pos = self.current_position();
                     self.pending_tokens.push_back(Token::new(
@@ -390,7 +397,7 @@ impl<'src> Lexer<'src> {
                     ));
                 }
                 // Verify we landed on a valid indentation level.
-                if *self.indent_stack.last().unwrap() != indent {
+                if !matches!(self.indent_stack.last(), Some(&level) if level == indent) {
                     let pos = self.current_position();
                     self.pending_tokens.push_back(Token::new(
                         TokenKind::Error(
@@ -690,12 +697,30 @@ impl<'src> Lexer<'src> {
             Some('\\') => {
                 self.advance(); // backslash
                 match self.peek() {
-                    Some('n') => { self.advance(); '\n' }
-                    Some('r') => { self.advance(); '\r' }
-                    Some('t') => { self.advance(); '\t' }
-                    Some('\\') => { self.advance(); '\\' }
-                    Some('\'') => { self.advance(); '\'' }
-                    Some('0') => { self.advance(); '\0' }
+                    Some('n') => {
+                        self.advance();
+                        '\n'
+                    }
+                    Some('r') => {
+                        self.advance();
+                        '\r'
+                    }
+                    Some('t') => {
+                        self.advance();
+                        '\t'
+                    }
+                    Some('\\') => {
+                        self.advance();
+                        '\\'
+                    }
+                    Some('\'') => {
+                        self.advance();
+                        '\''
+                    }
+                    Some('0') => {
+                        self.advance();
+                        '\0'
+                    }
                     Some(c) => {
                         let end = self.current_position();
                         self.advance();
@@ -730,10 +755,7 @@ impl<'src> Lexer<'src> {
         if self.peek() == Some('\'') {
             self.advance(); // closing '
             let end = self.current_position();
-            Token::new(
-                TokenKind::CharLit(c),
-                Span::new(self.file_id, start, end),
-            )
+            Token::new(TokenKind::CharLit(c), Span::new(self.file_id, start, end))
         } else {
             let end = self.current_position();
             Token::new(

--- a/codebase/compiler/src/main.rs
+++ b/codebase/compiler/src/main.rs
@@ -254,7 +254,13 @@ fn main() {
         return;
     }
 
-    let input_file = positional_args[0].as_str();
+    let input_file = positional_args
+        .first()
+        .map(|s| s.as_str())
+        .unwrap_or_else(|| {
+            eprintln!("Error: missing input file");
+            process::exit(1);
+        });
     let output_file = positional_args
         .get(1)
         .map(|s| s.as_str())
@@ -761,12 +767,7 @@ fn run_poc() {
 
 /// Compile source code from stdin instead of a file.
 /// Used for bootstrap testing and piping source code.
-fn compile_from_stdin(
-    output_file: &str,
-    parse_only: bool,
-    typecheck_only: bool,
-    emit_ir: bool,
-) {
+fn compile_from_stdin(output_file: &str, parse_only: bool, typecheck_only: bool, emit_ir: bool) {
     use std::io::{self, Read};
 
     // Read source from stdin
@@ -888,12 +889,11 @@ fn compile_from_stdin(
 
     // Generate code
     println!("[6/7] Generating code...");
-    let mut backend: Box<dyn CodegenBackend> = Box::new(
-        codegen::BackendWrapper::new(false).unwrap_or_else(|e| {
+    let mut backend: Box<dyn CodegenBackend> =
+        Box::new(codegen::BackendWrapper::new(false).unwrap_or_else(|e| {
             eprintln!("Codegen init error: {}", e);
             process::exit(1);
-        }),
-    );
+        }));
 
     backend.compile_module(&ir_module).unwrap_or_else(|e| {
         eprintln!("Codegen error: {}", e);

--- a/codebase/compiler/src/resolve.rs
+++ b/codebase/compiler/src/resolve.rs
@@ -308,6 +308,10 @@ impl ModuleResolver {
     fn resolve_module_path(&self, path_segments: &[String], from_file: &Path) -> Option<PathBuf> {
         let from_dir = from_file.parent().unwrap_or_else(|| Path::new("."));
 
+        if path_segments.is_empty() {
+            return None;
+        }
+
         if path_segments.len() == 1 {
             // Simple case: `use math` -> `math.gr` in the same directory
             let candidate = from_dir.join(format!("{}.gr", path_segments[0]));
@@ -325,7 +329,8 @@ impl ModuleResolver {
             for seg in &path_segments[..path_segments.len() - 1] {
                 rel_path.push(seg);
             }
-            rel_path.push(format!("{}.gr", path_segments.last().unwrap()));
+            let last_segment = path_segments.last()?;
+            rel_path.push(format!("{}.gr", last_segment));
 
             // Try from the importing file's directory
             let candidate = from_dir.join(&rel_path);


### PR DESCRIPTION
## Summary
Hardens several panic-prone compiler, agent, and build-system paths so malformed inputs and missing runtime wiring produce structured errors instead of crashing.

## Changes
- replace panic-prone runtime function lookups in IR builder with collected errors and safe fallback values
- harden Cranelift/WASM/CLI/module-resolution/lexer/build-system code paths that previously used fragile indexing or unwrap-style assumptions
- add agent server panic recovery and remove infallible JSON notification/default assumptions
- remove the unsafe LLVM backend transmute in favor of a safer leaked-context construction for wrapper-owned LLVM backends
- close stale issues #24, #37, and #38 after verifying the referenced production paths were already superseded on current main

## Testing
- `cargo test`
- exercised agent mode directly with JSON-RPC `load`, `context_budget`, and `shutdown` requests against `./target/debug/gradient-compiler --agent`

## Related
Fixes #23
Fixes #25
Fixes #26
Fixes #27
Fixes #29
Fixes #30
Fixes #31
Fixes #32
Fixes #33
Fixes #34
Fixes #35
Fixes #36
Fixes #39
Fixes #40
