### PR TITLE
fix(parser): support indented typed constructor exprs

### DIFF
--- a/codebase/compiler/src/parser/parser.rs
+++ b/codebase/compiler/src/parser/parser.rs
@@ -1143,8 +1143,7 @@ impl Parser {
             _ => {
                 // Check for assignment: Ident (or soft keyword) followed by
                 // '=' (but not '==').
-                if self.peek_soft_keyword_ident()
-                    && matches!(self.peek_ahead(1), TokenKind::Assign)
+                if self.peek_soft_keyword_ident() && matches!(self.peek_ahead(1), TokenKind::Assign)
                 {
                     return self.parse_assign_stmt();
                 }
@@ -2830,7 +2829,7 @@ impl Parser {
             // Check for | separator
             if matches!(self.peek(), TokenKind::Pipe) {
                 self.advance(); // consume '|'
-                // Continue to parse next variant
+                                // Continue to parse next variant
             }
 
             // If we see DEDENT or EOF, we're done
@@ -3453,12 +3452,12 @@ impl Parser {
                 TokenKind::LParen => {
                     // Function call or enum/struct constructor with named fields.
                     self.advance(); // consume '('
-                    
+
                     // Check if this is a constructor call with named fields
                     // Pattern: ConstructorName(field: value, field2: value2)
-                    let is_named_constructor = matches!(&expr.node, ExprKind::Ident(_)) 
+                    let is_named_constructor = matches!(&expr.node, ExprKind::Ident(_))
                         && self.peek_named_constructor_field();
-                    
+
                     if is_named_constructor {
                         // Parse as Construct with named fields
                         let name = match &expr.node {
@@ -3472,10 +3471,7 @@ impl Parser {
                             Err(_) => self.prev_span(),
                         };
                         let span = merge_spans(&expr.span, &end);
-                        expr = Spanned::new(
-                            ExprKind::Construct { name, fields },
-                            span,
-                        );
+                        expr = Spanned::new(ExprKind::Construct { name, fields }, span);
                     } else {
                         // Regular function call with positional arguments
                         let args = if !matches!(self.peek(), TokenKind::RParen) {
@@ -3740,7 +3736,11 @@ impl Parser {
                                         }
                                         // Statement keywords like 'ret' indicate this is NOT a record field
                                         // because record fields need expressions, not statements
-                                        TokenKind::Ret | TokenKind::Match | TokenKind::If | TokenKind::For | TokenKind::While => {
+                                        TokenKind::Ret
+                                        | TokenKind::Match
+                                        | TokenKind::If
+                                        | TokenKind::For
+                                        | TokenKind::While => {
                                             return false;
                                         }
                                         TokenKind::Dedent => {
@@ -3917,7 +3917,10 @@ impl Parser {
         let mut fields = Vec::new();
 
         // Parse at least one field
-        while !matches!(self.peek(), TokenKind::Dedent | TokenKind::Eof | TokenKind::Newline) {
+        while !matches!(
+            self.peek(),
+            TokenKind::Dedent | TokenKind::Eof | TokenKind::Newline
+        ) {
             // Parse field name
             let field_name = match self.peek().clone() {
                 TokenKind::Ident(name) => {
@@ -3979,6 +3982,67 @@ impl Parser {
         )
     }
 
+    fn peek_typed_expr_value(&self) -> bool {
+        if !matches!(self.peek(), TokenKind::Colon) {
+            return false;
+        }
+
+        let mut offset = 1;
+        while matches!(
+            self.peek_ahead(offset),
+            TokenKind::Newline | TokenKind::Indent
+        ) {
+            offset += 1;
+        }
+
+        match self.peek_ahead(offset) {
+            TokenKind::Ident(ref name) => name.starts_with(|c: char| c.is_uppercase()),
+            TokenKind::IntLit(_)
+            | TokenKind::FloatLit(_)
+            | TokenKind::StringLit(_)
+            | TokenKind::True
+            | TokenKind::False
+            | TokenKind::LParen
+            | TokenKind::LBracket
+            | TokenKind::LBrace
+            | TokenKind::Minus
+            | TokenKind::Pipe
+            | TokenKind::Spawn
+            | TokenKind::Send
+            | TokenKind::Ask
+            | TokenKind::Match => true,
+            _ => false,
+        }
+    }
+
+    fn parse_typed_expr_after_colon(&mut self, start: Span, type_expr: TypeExpr) -> Expr {
+        let _ = self.expect(TokenKind::Colon);
+
+        while matches!(self.peek(), TokenKind::Newline) {
+            self.advance();
+        }
+
+        let consumed_indent = matches!(self.peek(), TokenKind::Indent);
+        if consumed_indent {
+            self.advance();
+        }
+
+        let value = self.parse_expr();
+
+        if consumed_indent && matches!(self.peek(), TokenKind::Dedent) {
+            self.advance();
+        }
+
+        let end = self.prev_span();
+        Spanned::new(
+            ExprKind::TypedExpr {
+                type_expr,
+                value: Box::new(value),
+            },
+            merge_spans(&start, &end),
+        )
+    }
+
     /// ```text
     /// atom <- FLOAT_LIT / INT_LIT / STRING_LIT / BOOL_LIT / UNIT_LIT
     ///       / typed_hole / IDENT / '(' expr ')'
@@ -4023,25 +4087,17 @@ impl Parser {
                     // Let the typed expression parser handle it
                     let type_expr_spanned = self.parse_type_expr();
                     let type_expr = type_expr_spanned.node; // Extract inner TypeExpr
-                    if matches!(self.peek(), TokenKind::Colon) {
-                        self.advance(); // consume ':'
-                        let value = self.parse_expr();
-                        let end = self.prev_span();
-                        return Spanned::new(
-                            ExprKind::TypedExpr { type_expr, value: Box::new(value) },
-                            merge_spans(&start, &end),
-                        );
+                    if matches!(self.peek(), TokenKind::Colon) && self.peek_typed_expr_value() {
+                        return self.parse_typed_expr_after_colon(start, type_expr);
                     }
                     // Not a typed expression, return as type expression
                     // Need to wrap in something - use a placeholder for now
                     return Spanned::new(ExprKind::TypedHole(None), start);
                 }
-                
+
                 self.advance();
                 // Brace-form record literal: TypeName { field = value, field2 = value2 }
-                if matches!(self.peek(), TokenKind::LBrace)
-                    && self.peek_brace_record_literal()
-                {
+                if matches!(self.peek(), TokenKind::LBrace) && self.peek_brace_record_literal() {
                     return self.parse_brace_record_literal(name, start);
                 }
                 // Check for record literal syntax: TypeName: field: value field2: value2
@@ -4049,6 +4105,13 @@ impl Parser {
                     // Check if next token after colon is a field name (identifier or keyword) followed by colon
                     if self.peek_record_literal_field() {
                         return self.parse_record_literal(name, start);
+                    }
+                    if name.starts_with(|c: char| c.is_uppercase()) && self.peek_typed_expr_value()
+                    {
+                        return self.parse_typed_expr_after_colon(
+                            start,
+                            TypeExpr::Named { name, cap: None },
+                        );
                     }
                 }
                 Spanned::new(ExprKind::Ident(name), start)
@@ -4265,7 +4328,7 @@ impl Parser {
             // Parse remaining comma-separated parameters.
             while matches!(self.peek(), TokenKind::Comma) {
                 self.advance(); // consume ','
-                // Allow trailing comma before closing `)`.
+                                // Allow trailing comma before closing `)`.
                 if matches!(self.peek(), TokenKind::RParen) {
                     break;
                 }
@@ -4721,16 +4784,16 @@ impl Parser {
                 // Tuple pattern: (P1, P2, ...)
                 self.advance(); // consume '('
                 let mut elems = Vec::new();
-                
+
                 // Check for empty tuple pattern ()
                 if matches!(self.peek(), TokenKind::RParen) {
                     self.advance(); // consume ')'
                     return Pattern::Tuple(vec![]);
                 }
-                
+
                 // Parse first element
                 elems.push(self.parse_pattern());
-                
+
                 // Parse remaining elements
                 while matches!(self.peek(), TokenKind::Comma) {
                     self.advance(); // consume ','
@@ -4739,11 +4802,11 @@ impl Parser {
                     }
                     elems.push(self.parse_pattern());
                 }
-                
+
                 if self.expect(TokenKind::RParen).is_err() {
                     // error already recorded
                 }
-                
+
                 Pattern::Tuple(elems)
             }
             _ => {
@@ -5198,7 +5261,7 @@ impl Parser {
                 if self.expect(TokenKind::LParen).is_err() {
                     return Spanned::new(TypeExpr::Unit, start);
                 }
-                
+
                 // Parse parameter types
                 let mut params = Vec::new();
                 if !matches!(self.peek(), TokenKind::RParen) {
@@ -5211,23 +5274,23 @@ impl Parser {
                         params.push(self.parse_type_expr());
                     }
                 }
-                
+
                 if self.expect(TokenKind::RParen).is_err() {
                     return Spanned::new(TypeExpr::Unit, start);
                 }
-                
+
                 // Expect '->' followed by return type
                 if self.expect(TokenKind::Arrow).is_err() {
                     return Spanned::new(TypeExpr::Unit, start);
                 }
-                
+
                 // Optional effect set: `!{IO}`
                 let effects = if matches!(self.peek(), TokenKind::Bang) {
                     Some(self.parse_effect_set())
                 } else {
                     None
                 };
-                
+
                 let ret = self.parse_type_expr();
                 let end = ret.span;
                 Spanned::new(

--- a/codebase/compiler/src/parser/tests.rs
+++ b/codebase/compiler/src/parser/tests.rs
@@ -2226,11 +2226,23 @@ fn parse_enum_unit_variants() {
             assert_eq!(name, "Color");
             assert_eq!(variants.len(), 3);
             assert_eq!(variants[0].name, "Red");
-            assert!(variants[0].fields.as_ref().map(|f| f.is_empty()).unwrap_or(true));
+            assert!(variants[0]
+                .fields
+                .as_ref()
+                .map(|f| f.is_empty())
+                .unwrap_or(true));
             assert_eq!(variants[1].name, "Green");
-            assert!(variants[1].fields.as_ref().map(|f| f.is_empty()).unwrap_or(true));
+            assert!(variants[1]
+                .fields
+                .as_ref()
+                .map(|f| f.is_empty())
+                .unwrap_or(true));
             assert_eq!(variants[2].name, "Blue");
-            assert!(variants[2].fields.as_ref().map(|f| f.is_empty()).unwrap_or(true));
+            assert!(variants[2]
+                .fields
+                .as_ref()
+                .map(|f| f.is_empty())
+                .unwrap_or(true));
         }
         other => panic!("expected EnumDecl, got {:?}", other),
     }
@@ -2260,13 +2272,21 @@ fn parse_enum_with_tuple_variant() {
             assert_eq!(variants.len(), 2);
             assert_eq!(variants[0].name, "Some");
             // Tuple variant Some(Int) has one anonymous field
-            assert!(variants[0].fields.as_ref().map(|f| !f.is_empty()).unwrap_or(false));
+            assert!(variants[0]
+                .fields
+                .as_ref()
+                .map(|f| !f.is_empty())
+                .unwrap_or(false));
             assert!(matches!(
                 &variants[0].fields.as_ref().unwrap()[0],
                 VariantField::Anonymous(ty) if matches!(&ty.node, TypeExpr::Named { name: n, .. } if n == "Int")
             ));
             assert_eq!(variants[1].name, "None");
-            assert!(variants[1].fields.as_ref().map(|f| f.is_empty()).unwrap_or(true));
+            assert!(variants[1]
+                .fields
+                .as_ref()
+                .map(|f| f.is_empty())
+                .unwrap_or(true));
         }
         other => panic!("expected EnumDecl, got {:?}", other),
     }
@@ -3147,6 +3167,59 @@ fn parse_send_expr() {
             }
         }
         _ => panic!("expected FnDef"),
+    }
+}
+
+#[test]
+fn parse_indented_typed_constructor_expr() {
+    // fn test():
+    //     T:
+    //         V(n: 1)
+    let tokens = vec![
+        tok(TokenKind::Fn),
+        tok(TokenKind::Ident("test".into())),
+        tok(TokenKind::LParen),
+        tok(TokenKind::RParen),
+        tok(TokenKind::Colon),
+        tok(TokenKind::Newline),
+        tok(TokenKind::Indent),
+        tok(TokenKind::Ident("T".into())),
+        tok(TokenKind::Colon),
+        tok(TokenKind::Newline),
+        tok(TokenKind::Indent),
+        tok(TokenKind::Ident("V".into())),
+        tok(TokenKind::LParen),
+        tok(TokenKind::Ident("n".into())),
+        tok(TokenKind::Colon),
+        tok(TokenKind::IntLit(1)),
+        tok(TokenKind::RParen),
+        tok(TokenKind::Newline),
+        tok(TokenKind::Dedent),
+        tok(TokenKind::Dedent),
+        tok(TokenKind::Eof),
+    ];
+
+    let module = parse_ok(tokens);
+    match &module.items[0].node {
+        ItemKind::FnDef(fn_def) => match &fn_def.body.node[0].node {
+            StmtKind::Expr(expr) => match &expr.node {
+                ExprKind::TypedExpr { type_expr, value } => {
+                    assert!(matches!(type_expr, TypeExpr::Named { name, .. } if name == "T"));
+                    match &value.node {
+                        ExprKind::Construct { name, fields } => {
+                            assert_eq!(name, "V");
+                            assert_eq!(fields.len(), 1);
+                            assert_eq!(fields[0].0, "n");
+                            assert!(matches!(fields[0].1.node, ExprKind::IntLit(1)));
+                        }
+                        other => panic!("expected constructor value, got {:?}", other),
+                    }
+                }
+                other => panic!("expected typed expr, got {:?}", other),
+            },
+            other => panic!("expected expr stmt, got {:?}", other),
+        },
+        other => panic!("expected FnDef, got {:?}", other),
     }
 }
 
@@ -4874,7 +4947,6 @@ fn f(n: Int) -> String:
     }
 }
 
-
 // ============================================================================
 // Error Recovery Tests (Phase 2 Hardening)
 // ============================================================================
@@ -4901,16 +4973,23 @@ fn broken2(:
     print("another broken")
 "#;
     let (module, errors) = parse_source_with_errors(src);
-    
+
     // Should have errors but still parse the working function
     assert!(!errors.is_empty(), "expected parse errors");
-    assert!(module.items.len() >= 1, "expected at least one function parsed");
-    
+    assert!(
+        module.items.len() >= 1,
+        "expected at least one function parsed"
+    );
+
     // Verify the working function was parsed
-    let has_working = module.items.iter().any(|item| {
-        matches!(&item.node, ItemKind::FnDef(fn_def) if fn_def.name == "working")
-    });
-    assert!(has_working, "expected 'working' function to be parsed despite errors in other functions");
+    let has_working = module
+        .items
+        .iter()
+        .any(|item| matches!(&item.node, ItemKind::FnDef(fn_def) if fn_def.name == "working"));
+    assert!(
+        has_working,
+        "expected 'working' function to be parsed despite errors in other functions"
+    );
 }
 
 #[test]
@@ -4927,15 +5006,21 @@ fn good2():
     ret 2
 "#;
     let (module, errors) = parse_source_with_errors(src);
-    
+
     // Should have an error for the bad function
-    assert!(!errors.is_empty(), "expected parse errors for incomplete function");
-    
+    assert!(
+        !errors.is_empty(),
+        "expected parse errors for incomplete function"
+    );
+
     // Both good functions should be parsed
     let good_count = module.items.iter().filter(|item| {
         matches!(&item.node, ItemKind::FnDef(fn_def) if fn_def.name == "good1" || fn_def.name == "good2")
     }).count();
-    assert_eq!(good_count, 2, "expected both 'good1' and 'good2' functions to be parsed");
+    assert_eq!(
+        good_count, 2,
+        "expected both 'good1' and 'good2' functions to be parsed"
+    );
 }
 
 #[test]
@@ -4953,9 +5038,12 @@ fn test(x: Int) -> Int:
             ret -1
 "#;
     let (module, _errors) = parse_source_with_errors(src);
-    
+
     // Should still parse the function with match
-    assert!(!module.items.is_empty(), "expected function to be parsed despite match errors");
+    assert!(
+        !module.items.is_empty(),
+        "expected function to be parsed despite match errors"
+    );
 }
 
 #[test]
@@ -4968,13 +5056,17 @@ fn working():
     ret 1
 "#;
     let (module, errors) = parse_source_with_errors(src);
-    
+
     // Should have errors but still parse the function
-    assert!(!errors.is_empty(), "expected parse errors for incomplete type");
-    
-    let has_fn = module.items.iter().any(|item| {
-        matches!(&item.node, ItemKind::FnDef(_))
-    });
+    assert!(
+        !errors.is_empty(),
+        "expected parse errors for incomplete type"
+    );
+
+    let has_fn = module
+        .items
+        .iter()
+        .any(|item| matches!(&item.node, ItemKind::FnDef(_)));
     assert!(has_fn, "expected function to be parsed despite type error");
 }
 
@@ -4993,9 +5085,10 @@ type Color =
 "#;
     let (module, errors) = parse_source_with_errors(src);
     assert!(errors.is_empty(), "unexpected parse errors: {:?}", errors);
-    let has_enum = module.items.iter().any(|item| {
-        matches!(&item.node, ItemKind::EnumDecl { name, .. } if name == "Color")
-    });
+    let has_enum = module
+        .items
+        .iter()
+        .any(|item| matches!(&item.node, ItemKind::EnumDecl { name, .. } if name == "Color"));
     assert!(has_enum, "expected EnumDecl for Color");
 }
 
@@ -5057,9 +5150,13 @@ fn c():
     ret 1
 "#;
     let (_module, errors) = parse_source_with_errors(src);
-    
+
     // Should report errors for both broken functions
-    assert!(errors.len() >= 2, "expected at least 2 errors for broken functions a and b, got {}", errors.len());
+    assert!(
+        errors.len() >= 2,
+        "expected at least 2 errors for broken functions a and b, got {}",
+        errors.len()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Teaches the parser to accept indented typed expressions whose value is provided on the next indented line, fixing a self-hosting blocker for enum-constructor forms like `T:\n    V(n: 1)`.

## Changes
- add a shared helper for parsing typed-expression values after a colon, including optional newline/indent handling
- route both generic typed expressions and simple named-type expressions through that helper
- add a parser regression test covering the indented typed-constructor form

## Testing
- `cargo test -p gradient-compiler parse_indented_typed_constructor_expr -- --nocapture`
- `cargo test`
- manual CLI repro with `./target/debug/gradient-compiler /tmp/grad_typed_expr.gr /tmp/out.o --parse-only`

## Related
Fixes #43
