### PR TITLE
test: fix phase_mm_integration tests with incorrect newline expectations

### DIFF
--- a/codebase/compiler/tests/phase_mm_integration.rs
+++ b/codebase/compiler/tests/phase_mm_integration.rs
@@ -171,8 +171,8 @@ fn main() -> !{IO} ():
 ";
     let (out, code) = compile_and_run(src, None);
     assert_eq!(code, 0);
-    // print() uses puts() which appends a newline.
-    assert_eq!(out, "3.14\n");
+    // print() uses printf("%s") without a newline.
+    assert_eq!(out, "3.14");
 }
 
 #[test]
@@ -186,8 +186,8 @@ fn main() -> !{IO} ():
 ";
     let (out, code) = compile_and_run(src, None);
     assert_eq!(code, 0);
-    // print() uses puts() which appends a newline.
-    assert_eq!(out, "0\n");
+    // print() uses printf("%s") without a newline.
+    assert_eq!(out, "0");
 }
 
 // ---------------------------------------------------------------------------
@@ -204,8 +204,8 @@ fn main() -> !{IO} ():
     print(\"after\")
 ";
     let (out, code) = compile_and_run(src, None);
-    // "before" is printed, then exit(0) is called, "after" is never reached.
-    assert_eq!(out, "before\n", "should print 'before' then stop");
+    // "before" is printed (without newline, print uses printf), then exit(0) is called.
+    assert_eq!(out, "before", "should print 'before' then stop");
     assert_eq!(code, 0, "exit(0) should produce exit code 0");
 }
 
@@ -255,7 +255,8 @@ fn main() -> !{IO} ():
 ";
     let (out, code) = compile_and_run(src, None);
     assert_eq!(code, 0);
-    assert_eq!(out, "42hello world\ntrue");
+    // All print functions use printf without newlines.
+    assert_eq!(out, "42hello worldtrue");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix four integration tests in `phase_mm_integration.rs` that had incorrect assertions expecting newlines in output.

## Problem

The tests expected newlines in output but the `print`, `print_int`, and `print_bool` functions use `printf` without newlines:

| Test | Expected | Actual | Issue |
|------|----------|--------|-------|
| test_parse_float_valid | `"3.14\n"` | `"3.14"` | print() doesn't add newline |
| test_parse_float_invalid_returns_zero | `"0\n"` | `"0"` | print() doesn't add newline |
| test_exit_zero_terminates_immediately | `"before\n"` | `"before"` | print() doesn't add newline |
| test_multifield_enum_variant_destructuring | `"42hello world\ntrue"` | `"42hello worldtrue"` | All print functions lack newlines |

## Root Cause

The codegen uses `printf` without newlines in format strings:
- `print_int`: `printf("%ld", value)`
- `print`: `printf("%s", s)`  
- `print_bool`: `printf("%s", str_ptr)`

Test comments incorrectly stated `print()` uses `puts()` which appends a newline, but the implementation actually uses `printf` without newlines.

## Changes

- Fixed 4 test assertions to match actual output behavior
- Updated incorrect comments about `puts()` vs `printf()`

## Verification

All 9 phase_mm_integration tests now pass:
```bash
cargo test --test phase_mm_integration
```

## Related

Fixes #67
