### PR TITLE
fix(codegen): resolve file I/O Bool/i64 type mismatch #53

### DIFF
--- a/codebase/compiler/runtime/gradient_runtime.c
+++ b/codebase/compiler/runtime/gradient_runtime.c
@@ -148,7 +148,7 @@ char* __gradient_file_read(const char* path) {
  * Creates or overwrites the file at `path` with `content`.
  * Returns 1 (true) on success, 0 (false) on failure.
  */
-int64_t __gradient_file_write(const char* path, const char* content) {
+int8_t __gradient_file_write(const char* path, const char* content) {
     FILE* f = fopen(path, "w");
     if (!f) return 0;
     fputs(content, f);
@@ -162,7 +162,7 @@ int64_t __gradient_file_write(const char* path, const char* content) {
  * Returns 1 (true) if the file at `path` exists and is accessible,
  * 0 (false) otherwise.  Uses POSIX access(2) with F_OK.
  */
-int64_t __gradient_file_exists(const char* path) {
+int8_t __gradient_file_exists(const char* path) {
     return access(path, F_OK) == 0 ? 1 : 0;
 }
 
@@ -172,7 +172,7 @@ int64_t __gradient_file_exists(const char* path) {
  * Appends `content` to the file at `path`, creating it if it does not
  * exist.  Returns 1 (true) on success, 0 (false) on failure.
  */
-int64_t __gradient_file_append(const char* path, const char* content) {
+int8_t __gradient_file_append(const char* path, const char* content) {
     FILE* f = fopen(path, "a");
     if (!f) return 0;
     fputs(content, f);
@@ -186,7 +186,7 @@ int64_t __gradient_file_append(const char* path, const char* content) {
  * Deletes the file at `path`.
  * Returns 1 (true) on success, 0 (false) on failure.
  */
-int64_t __gradient_file_delete(const char* path) {
+int8_t __gradient_file_delete(const char* path) {
     if (!path) return 0;
     return remove(path) == 0 ? 1 : 0;
 }

--- a/codebase/compiler/src/codegen/cranelift.rs
+++ b/codebase/compiler/src/codegen/cranelift.rs
@@ -958,7 +958,7 @@ impl CraneliftCodegen {
             let mut sig = self.module.make_signature();
             sig.params.push(AbiParam::new(pointer_type)); // path
             sig.params.push(AbiParam::new(pointer_type)); // content
-            sig.returns.push(AbiParam::new(cl_types::I64)); // 1 = ok, 0 = error
+            sig.returns.push(AbiParam::new(cl_types::I8)); // 1 = ok, 0 = error
 
             let func_id = self
                 .module
@@ -975,7 +975,7 @@ impl CraneliftCodegen {
         {
             let mut sig = self.module.make_signature();
             sig.params.push(AbiParam::new(pointer_type)); // path
-            sig.returns.push(AbiParam::new(cl_types::I64)); // 1 = exists, 0 = not found
+            sig.returns.push(AbiParam::new(cl_types::I8)); // 1 = exists, 0 = not found
 
             let func_id = self
                 .module
@@ -993,7 +993,7 @@ impl CraneliftCodegen {
             let mut sig = self.module.make_signature();
             sig.params.push(AbiParam::new(pointer_type)); // path
             sig.params.push(AbiParam::new(pointer_type)); // content
-            sig.returns.push(AbiParam::new(cl_types::I64)); // 1 = ok, 0 = error
+            sig.returns.push(AbiParam::new(cl_types::I8)); // 1 = ok, 0 = error
 
             let func_id = self
                 .module
@@ -1010,7 +1010,7 @@ impl CraneliftCodegen {
         {
             let mut sig = self.module.make_signature();
             sig.params.push(AbiParam::new(pointer_type)); // path
-            sig.returns.push(AbiParam::new(cl_types::I64)); // 1 = ok, 0 = error
+            sig.returns.push(AbiParam::new(cl_types::I8)); // 1 = ok, 0 = error
 
             let func_id = self
                 .module
@@ -4437,9 +4437,8 @@ impl CraneliftCodegen {
                                     self.module.declare_func_in_func(func_id, builder.func);
                                 let call_inst = builder.ins().call(func_ref, &[path, content]);
                                 let result = builder.inst_results(call_inst).to_vec()[0];
-                                // Convert i64 result to bool (i8)
-                                let bool_result = builder.ins().ireduce(cl_types::I8, result);
-                                value_map.insert(*dst, bool_result);
+                                // Runtime now returns i8 (bool) directly
+                                value_map.insert(*dst, result);
                             }
 
                             // ── file_exists(path): call __gradient_file_exists -> Bool ──
@@ -4453,9 +4452,8 @@ impl CraneliftCodegen {
                                     self.module.declare_func_in_func(func_id, builder.func);
                                 let call_inst = builder.ins().call(func_ref, &[path]);
                                 let result = builder.inst_results(call_inst).to_vec()[0];
-                                // Convert i64 result to bool (i8)
-                                let bool_result = builder.ins().ireduce(cl_types::I8, result);
-                                value_map.insert(*dst, bool_result);
+                                // Runtime now returns i8 (bool) directly
+                                value_map.insert(*dst, result);
                             }
 
                             // ── file_append(path, content): call __gradient_file_append -> Bool ──
@@ -4470,9 +4468,8 @@ impl CraneliftCodegen {
                                     self.module.declare_func_in_func(func_id, builder.func);
                                 let call_inst = builder.ins().call(func_ref, &[path, content]);
                                 let result = builder.inst_results(call_inst).to_vec()[0];
-                                // Convert i64 result to bool (i8)
-                                let bool_result = builder.ins().ireduce(cl_types::I8, result);
-                                value_map.insert(*dst, bool_result);
+                                // Runtime now returns i8 (bool) directly
+                                value_map.insert(*dst, result);
                             }
 
                             // ── file_delete(path): call __gradient_file_delete -> Bool ──
@@ -4486,9 +4483,8 @@ impl CraneliftCodegen {
                                     self.module.declare_func_in_func(func_id, builder.func);
                                 let call_inst = builder.ins().call(func_ref, &[path]);
                                 let result = builder.inst_results(call_inst).to_vec()[0];
-                                // Convert i64 result to bool (i8)
-                                let bool_result = builder.ins().ireduce(cl_types::I8, result);
-                                value_map.insert(*dst, bool_result);
+                                // Runtime now returns i8 (bool) directly
+                                value_map.insert(*dst, result);
                             }
 
                             // ── http_get(url): call __gradient_http_get(url) -> Result ptr ──

--- a/codebase/compiler/src/ir/builder/mod.rs
+++ b/codebase/compiler/src/ir/builder/mod.rs
@@ -699,16 +699,16 @@ impl IrBuilder {
             .insert("file_read".to_string(), Type::Ptr);
         self.register_func("file_write");
         self.function_return_types
-            .insert("file_write".to_string(), Type::I64);
+            .insert("file_write".to_string(), Type::Bool);
         self.register_func("file_exists");
         self.function_return_types
-            .insert("file_exists".to_string(), Type::I64);
+            .insert("file_exists".to_string(), Type::Bool);
         self.register_func("file_append");
         self.function_return_types
-            .insert("file_append".to_string(), Type::I64);
+            .insert("file_append".to_string(), Type::Bool);
         self.register_func("file_delete");
         self.function_return_types
-            .insert("file_delete".to_string(), Type::I64);
+            .insert("file_delete".to_string(), Type::Bool);
 
         // ── List operations ─────────────────────────────────────────────
         self.register_func("list_length");


### PR DESCRIPTION
The file I/O builtins (file_write, file_exists, file_append, file_delete) were registered with Type::I64 return type in the IR builder, but the typechecker expected Bool. This caused Cranelift verifier errors when assigning results to Bool variables.

## Changes
- IR builder: Change file_write/exists/append/delete return type from I64 to Bool
- Runtime: Change return type from int64_t to int8_t for all file I/O functions  
- Cranelift codegen: Change declared signature returns from I64 to I8
- Cranelift handlers: Remove unnecessary ireduce conversions (now direct i8)

## Testing
- All 1092 tests pass
- Manual verification: file_write compiled and linked successfully

Fixes #53