### PR TITLE
fix(typechecker): empty map_new() now unifies with expected concrete types #56

### DIFF
--- a/codebase/compiler/src/typechecker/checker.rs
+++ b/codebase/compiler/src/typechecker/checker.rs
@@ -2744,7 +2744,10 @@ impl TypeChecker {
                             arg_ty,
                         ));
                     }
-                } else if arg_ty != *param_ty && !param_ty.is_type_var() {
+                } else if arg_ty != *param_ty
+                    && !param_ty.is_type_var()
+                    && !Self::types_compatible_with_typevars(&arg_ty, param_ty)
+                {
                     self.errors.push(TypeError::mismatch(
                         format!(
                             "argument {} (`{}`) of `{}`: expected `{}`, found `{}`",
@@ -5375,7 +5378,10 @@ impl TypeChecker {
                         arg_ty,
                     ));
                 }
-            } else if arg_ty != *param_ty && !param_ty.is_type_var() {
+            } else if arg_ty != *param_ty
+                && !param_ty.is_type_var()
+                && !Self::types_compatible_with_typevars(&arg_ty, param_ty)
+            {
                 self.errors.push(TypeError::mismatch(
                     format!(
                         "argument {} (`{}`) of `{}`: expected `{}`, found `{}`",


### PR DESCRIPTION
The typechecker was failing to unify  (from ) with  (expected parameter type) because the argument type check only handled bare type variables, not type variables nested in container types.

## Changes
- checker.rs: Add  check in two places where function call arguments are validated
- This allows types like  to unify with  when V is an unresolved type parameter

## Example that now works


## Testing
- All 1092 tests pass
- Manual verification with map_new() → use_map() flow works

Fixes #56