### PR TITLE
fix(ir): use ConstructVariant for enum variant construction (#73)

### DIFF
--- a/codebase/compiler/src/ir/builder/mod.rs
+++ b/codebase/compiler/src/ir/builder/mod.rs
@@ -2184,30 +2184,41 @@ impl IrBuilder {
                 self.record_values.insert(record_ptr, type_name.clone());
                 record_ptr
             }
-            ast::ExprKind::Construct { name: _, fields } => {
-                // TODO: Implement proper enum variant construction with named fields
-                // For now, build as a tuple of field values (same as RecordLit)
-                let mut field_vals = Vec::new();
-                for (_name, val_expr) in fields.iter() {
-                    let val = self.build_expr(val_expr);
-                    field_vals.push(val);
-                }
-                // Create a tuple-like structure for the constructor
-                let mut elem_addrs = Vec::new();
-                for val in field_vals {
-                    let addr = self.fresh_value(Type::Ptr);
-                    self.emit(Instruction::Alloca(addr, Type::I64));
-                    self.emit(Instruction::Store(val, addr));
-                    elem_addrs.push(addr);
-                }
-                if elem_addrs.is_empty() {
-                    let v = self.fresh_value(Type::Ptr);
-                    self.emit(Instruction::Const(v, Literal::Int(0)));
-                    v
+            ast::ExprKind::Construct { name, fields } => {
+                // Check if this is an enum variant constructor
+                if let Some(&tag) = self.enum_variant_tags.get(name.as_str()) {
+                    // Enum variant construction - use ConstructVariant
+                    let payload: Vec<Value> = fields
+                        .iter()
+                        .map(|(_, val_expr)| self.build_expr(val_expr))
+                        .collect();
+                    let result = self.fresh_value(Type::Ptr);
+                    self.emit(Instruction::ConstructVariant { result, tag, payload });
+                    result
                 } else {
-                    let base = elem_addrs[0];
-                    self.tuple_element_addrs.insert(base, elem_addrs);
-                    base
+                    // Not a known enum variant - build as a tuple of field values
+                    let mut field_vals = Vec::new();
+                    for (_name, val_expr) in fields.iter() {
+                        let val = self.build_expr(val_expr);
+                        field_vals.push(val);
+                    }
+                    // Create a tuple-like structure for the constructor
+                    let mut elem_addrs = Vec::new();
+                    for val in field_vals {
+                        let addr = self.fresh_value(Type::Ptr);
+                        self.emit(Instruction::Alloca(addr, Type::I64));
+                        self.emit(Instruction::Store(val, addr));
+                        elem_addrs.push(addr);
+                    }
+                    if elem_addrs.is_empty() {
+                        let v = self.fresh_value(Type::Ptr);
+                        self.emit(Instruction::Const(v, Literal::Int(0)));
+                        v
+                    } else {
+                        let base = elem_addrs[0];
+                        self.tuple_element_addrs.insert(base, elem_addrs);
+                        base
+                    }
                 }
             }
             ast::ExprKind::TypedExpr {


### PR DESCRIPTION
## Summary
Fixes the IR builder to use the proper `ConstructVariant` instruction for enum variant construction with named fields, instead of building a tuple-like structure.

## Changes
- Check if constructor name is a known enum variant (via `enum_variant_tags`)
- If so, emit `ConstructVariant` with the proper tag and payload values
- Fall back to tuple-like construction for non-enum types (e.g., records)

## Testing
- All 1,058 tests passing
- Verified enum variant construction now uses proper tagged union representation

## Related Issues
Fixes #73