### PR TITLE
fix(self-hosting): resolve forward reference and keyword conflicts (#79)

### DIFF
--- a/compiler/ir.gr
+++ b/compiler/ir.gr
@@ -628,52 +628,52 @@ mod ir:
             string_table: []
 
     /// Add a function to the module
-    fn add_function(mod: IrModule, func: IrFunction) -> IrModule:
+    fn add_function(module_: IrModule, func: IrFunction) -> IrModule:
         IrModule:
-            name: mod.name
-            functions: list_append(mod.functions, func)
-            globals: mod.globals
-            types: mod.types
-            string_table: mod.string_table
+            name: module_.name
+            functions: list_append(module_.functions, func)
+            globals: module_.globals
+            types: module_.types
+            string_table: module_.string_table
 
     /// Add a global variable to the module
-    fn add_global(mod: IrModule, global: GlobalVar) -> IrModule:
+    fn add_global(module_: IrModule, global: GlobalVar) -> IrModule:
         IrModule:
-            name: mod.name
-            functions: mod.functions
-            globals: list_append(mod.globals, global)
-            types: mod.types
-            string_table: mod.string_table
+            name: module_.name
+            functions: module_.functions
+            globals: list_append(module_.globals, global)
+            types: module_.types
+            string_table: module_.string_table
 
-    /// Look up a function by name
-    fn find_function(mod: IrModule, name: String) -> Option[IrFunction]:
+    /// Find a function by name
+    fn find_function(module_: IrModule, name: String) -> Option[IrFunction]:
         let idx = 0
-        let len = list_len(mod.functions)
+        let len = list_len(module_.functions)
         while idx < len:
-            let func = list_get(mod.functions, idx)
+            let func = list_get(module_.functions, idx)
             if func.name == name:
                 ret Option[IrFunction]: Some(func)
             idx = idx + 1
         ret Option[IrFunction]: None
 
     /// Look up a global by name
-    fn find_global(mod: IrModule, name: String) -> Option[GlobalVar]:
+    fn find_global(module_: IrModule, name: String) -> Option[GlobalVar]:
         let idx = 0
-        let len = list_len(mod.globals)
+        let len = list_len(module_.globals)
         while idx < len:
-            let global = list_get(mod.globals, idx)
+            let global = list_get(module_.globals, idx)
             if global.name == name:
                 ret Option[GlobalVar]: Some(global)
             idx = idx + 1
         ret Option[GlobalVar]: None
 
     /// Count total functions in module
-    fn function_count(mod: IrModule) -> Int:
-        ret list_len(mod.functions)
+    fn function_count(module_: IrModule) -> Int:
+        ret list_len(module_.functions)
 
     /// Count total globals in module
-    fn global_count(mod: IrModule) -> Int:
-        ret list_len(mod.globals)
+    fn global_count(module_: IrModule) -> Int:
+        ret list_len(module_.globals)
 
     // =========================================================================
     // IR Verification
@@ -690,7 +690,7 @@ mod ir:
         UnusedValue
 
     /// Verify a complete module
-    fn verify_module(mod: IrModule) -> List[VerifyError]:
+    fn verify_module(module_: IrModule) -> List[VerifyError]:
         // Simplified - would perform comprehensive validation
         []
 

--- a/compiler/token.gr
+++ b/compiler/token.gr
@@ -633,7 +633,7 @@ mod token:
     fn format_position(pos: Position) -> String:
         let sb = stringbuilder_new()
         stringbuilder_append_int(sb, pos.line)
-        stringbuilder_append_char(sb, ":")
+        stringbuilder_append_char(sb, 58)  // ':'
         stringbuilder_append_int(sb, pos.col)
         ret stringbuilder_to_string(sb)
 
@@ -641,10 +641,10 @@ mod token:
     fn format_span(span: Span) -> String:
         let sb = stringbuilder_new()
         stringbuilder_append_int(sb, span.file_id)
-        stringbuilder_append_char(sb, ":")
+        stringbuilder_append_char(sb, 58)  // ':'
         let start_str = format_position(span.start)
         stringbuilder_append(sb, start_str)
-        stringbuilder_append_char(sb, "-")
+        stringbuilder_append_char(sb, 45)  // '-'
         let end_str = format_position(span.end)
         stringbuilder_append(sb, end_str)
         ret stringbuilder_to_string(sb)
@@ -652,11 +652,11 @@ mod token:
     /// Format a token for display (for error messages)
     fn format_token(tok: Token) -> String:
         let sb = stringbuilder_new()
-        stringbuilder_append_char(sb, "[")
+        stringbuilder_append_char(sb, 91)   // '['
         let span_str = format_span(tok.span)
         stringbuilder_append(sb, span_str)
-        stringbuilder_append_char(sb, "]")
-        stringbuilder_append_char(sb, " ")
+        stringbuilder_append_char(sb, 93)   // ']'
+        stringbuilder_append_char(sb, 32)   // ' '
         let kind_str = kind_name(tok.kind)
         stringbuilder_append(sb, kind_str)
         ret stringbuilder_to_string(sb)

--- a/compiler/types.gr
+++ b/compiler/types.gr
@@ -7,6 +7,85 @@
 mod types:
 
     // =========================================================================
+    // Core Type References and Supporting Types (defined before Ty enum)
+    // =========================================================================
+
+    /// Reference to a type (using index into type pool)
+    type TyRef:
+        idx: Int
+
+    // =========================================================================
+    // Capabilities (defined before Ty enum)
+    // =========================================================================
+
+    /// Reference capabilities for memory safety without garbage collection.
+    /// Based on Pony's capability system.
+    enum Capability:
+        /// Isolated - unique, sendable reference (no aliases)
+        Iso
+
+        /// Value - immutable, sendable reference (any number of read aliases)
+        Val
+
+        /// Reference - readable and writable (single read/write alias)
+        Ref
+
+        /// Box - immutable reference (any number of read aliases, not sendable)
+        Box
+
+        /// Transition - transitioning from Iso (can become Ref or Val)
+        Trn
+
+        /// Tag - opaque, identity-only reference (cannot read/write)
+        Tag
+
+    // =========================================================================
+    // Effects (defined before Ty enum)
+    // =========================================================================
+
+    /// Set of effects that a function may perform
+    type EffectSet:
+        /// Concrete effects (e.g., "IO", "FS", "Network")
+        effects: List[String]
+
+        /// Effect variables for polymorphic effects
+        polys: List[String]
+
+        /// Whether this set represents "pure" (no effects)
+        is_pure: Bool
+
+    // =========================================================================
+    // User-defined Type Metadata (defined before Ty enum)
+    // =========================================================================
+
+    /// Information about an enum variant
+    type VariantInfo:
+        name: String
+        tag: Int
+        payload: Option[TyRef]
+
+    /// Information about a struct field
+    type FieldInfo:
+        name: String
+        ty: TyRef
+        mutable: Bool
+
+    // =========================================================================
+    // Function Signature Components (defined before Ty enum)
+    // =========================================================================
+
+    /// Type parameter for generics
+    type TypeParam:
+        name: String
+        bounds: List[TyRef]  // Trait bounds (if any)
+
+    /// Parameter with type for function signatures
+    type ParamTy:
+        name: String
+        ty: TyRef
+        comptime: Bool
+
+    // =========================================================================
     // Core Type Enum
     // =========================================================================
 
@@ -64,62 +143,6 @@ mod types:
         // Type-level computation placeholder
         ComptimeExpr(expr_hash: Int)
 
-    /// Reference to a type (using index into type pool)
-    type TyRef:
-        idx: Int
-
-    /// Information about an enum variant
-    type VariantInfo:
-        name: String
-        tag: Int
-        payload: Option[TyRef]
-
-    /// Information about a struct field
-    type FieldInfo:
-        name: String
-        ty: TyRef
-        mutable: Bool
-
-    // =========================================================================
-    // Capabilities
-    // =========================================================================
-
-    /// Reference capabilities for memory safety without garbage collection.
-    /// Based on Pony's capability system.
-    enum Capability:
-        /// Isolated - unique, sendable reference (no aliases)
-        Iso
-
-        /// Value - immutable, sendable reference (any number of read aliases)
-        Val
-
-        /// Reference - readable and writable (single read/write alias)
-        Ref
-
-        /// Box - immutable reference (any number of read aliases, not sendable)
-        Box
-
-        /// Transition - transitioning from Iso (can become Ref or Val)
-        Trn
-
-        /// Tag - opaque, identity-only reference (cannot read/write)
-        Tag
-
-    // =========================================================================
-    // Effects
-    // =========================================================================
-
-    /// Set of effects that a function may perform
-    type EffectSet:
-        /// Concrete effects (e.g., "IO", "FS", "Network")
-        effects: List[String]
-
-        /// Effect variables for polymorphic effects
-        polys: List[String]
-
-        /// Whether this set represents "pure" (no effects)
-        is_pure: Bool
-
     // =========================================================================
     // Function Signatures
     // =========================================================================
@@ -132,17 +155,6 @@ mod types:
         ret: TyRef
         effects: EffectSet
         is_comptime: Bool
-
-    /// Type parameter for generics
-    type TypeParam:
-        name: String
-        bounds: List[TyRef]  // Trait bounds (if any)
-
-    /// Parameter with type for function signatures
-    type ParamTy:
-        name: String
-        ty: TyRef
-        comptime: Bool
 
     // =========================================================================
     // Type Environment


### PR DESCRIPTION
## Summary

Fixed several syntax errors in self-hosted compiler files that were preventing them from parsing and type-checking correctly.

## Changes

### types.gr
- Reordered type definitions to resolve forward reference errors
- Moved supporting types (TyRef, Capability, EffectSet, etc.) before Ty enum

### ir.gr  
- Renamed `mod` parameter to `module_` in 7 functions to avoid keyword conflict

### token.gr
- Fixed stringbuilder_append_char calls to use ASCII integer values

## Test Results
All 1,092 tests pass.

Fixes #79