### PR TITLE
fix(typechecker): register enum variants in mod: blocks (#82)

### DIFF
--- a/codebase/compiler/src/typechecker/checker.rs
+++ b/codebase/compiler/src/typechecker/checker.rs
@@ -545,7 +545,52 @@ impl TypeChecker {
 
                                 // Also register unqualified for internal use
                                 self.env.define_enum(name.clone(), enum_ty.clone());
-                                self.env.define_type_alias(name.clone(), enum_ty);
+                                self.env.define_type_alias(name.clone(), enum_ty.clone());
+
+                                // Register unit variants as values of the enum type
+                                // in the module scope, and tuple variants as functions.
+                                for (vname, field_ty) in &ty_variants {
+                                    match field_ty {
+                                        None => {
+                                            // Unit variant: register as a variable with the enum type.
+                                            self.env.define(vname.clone(), enum_ty.clone());
+                                        }
+                                        Some(Ty::Tuple(field_types)) => {
+                                            // Multi-field tuple variant: register as a function with one
+                                            // parameter per field so `Task(42, "hello", true)` type-checks.
+                                            let params: Vec<(String, Ty, bool)> = field_types
+                                                .iter()
+                                                .enumerate()
+                                                .map(|(i, ty)| (format!("field{}", i), ty.clone(), false))
+                                                .collect();
+                                            self.env.define_fn(
+                                                vname.clone(),
+                                                FnSig {
+                                                    type_params: vec![],
+                                                    params,
+                                                    ret: enum_ty.clone(),
+                                                    effects: vec![],
+                                                },
+                                            );
+                                        }
+                                        Some(single_ty) => {
+                                            // Single-field tuple variant: register as a function from field_ty to enum_ty.
+                                            self.env.define_fn(
+                                                vname.clone(),
+                                                FnSig {
+                                                    type_params: vec![],
+                                                    params: vec![(
+                                                        "value".to_string(),
+                                                        single_ty.clone(),
+                                                        false,
+                                                    )],
+                                                    ret: enum_ty.clone(),
+                                                    effects: vec![],
+                                                },
+                                            );
+                                        }
+                                    }
+                                }
                             }
                             ItemKind::FnDef(fn_def) => {
                                 let sig = self.fn_def_to_sig(fn_def);


### PR DESCRIPTION
## Summary

Fixed enum variant scoping bug that prevented variants from being accessible within `mod X:` blocks.

## Bug

When defining enums inside `mod X:` blocks, the variants were not registered as accessible values/functions, causing "undefined variable" errors:



## Fix

Added variant registration logic in the `ModBlock` handling of `check_module()`:
- Unit variants registered as module-scope variables
- Tuple variants registered as constructor functions

## Verification

- All 1,092 tests pass
- Minimal reproduction case now works
- Unblocks Phase 2 self-hosting work

Fixes #82
Closes #81