### PR TITLE
Update roadmap and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,102 @@
 <br/>
 <br/>
 
-**A programming language designed for AI agents.**
+**An agent-native programming language and compiler stack.**
 
 <br/>
 
-[![Status](https://img.shields.io/badge/status-alpha-blueviolet?style=flat-square&labelColor=0d0d17)](https://github.com/graydeon/Gradient)
+[![Status](https://img.shields.io/badge/status-alpha-blueviolet?style=flat-square&labelColor=0d0d17)](https://github.com/Ontic-Systems/Gradient)
 [![Language](https://img.shields.io/badge/impl-Rust-orange?style=flat-square&labelColor=0d0d17)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT-4f8aff?style=flat-square&labelColor=0d0d17)](LICENSE)
-[![Backends](https://img.shields.io/badge/backends-Cranelift%20|%20WASM-00e5ff?style=flat-square&labelColor=0d0d17)](#webassembly-support)
-[![Tests](https://img.shields.io/badge/tests-1058-brightgreen?style=flat-square&labelColor=0d0d17)](#status)
+[![Backend](https://img.shields.io/badge/backend-Cranelift-00e5ff?style=flat-square&labelColor=0d0d17)](#project-status)
+[![Stage](https://img.shields.io/badge/self--hosting-in_progress-2ecc71?style=flat-square&labelColor=0d0d17)](#roadmap)
 
 </div>
 
 ---
 
-Gradient eliminates an entire class of errors before code ever runs—so LLMs write correct code the first time, not the tenth.
+Gradient is a programming language designed for AI-assisted development.
 
-```
+It combines a typed language, a compiler with structured query surfaces, and a roadmap toward self-hosting so that agents can generate, inspect, verify, and eventually improve the language in the language itself.
+
+## What Gradient Is For
+
+Gradient targets four overlapping use cases:
+
+1. **Agent-assisted coding.** Give coding agents a language with explicit effects, contracts, and a machine-readable compiler surface instead of relying on fragile prompt-only loops.
+2. **Compiler-verified automation.** Move from generate-compile-fix toward generate-check-verify by making syntax, type expectations, and side effects more explicit.
+3. **Tooling for agent workflows.** Expose compiler services, diagnostics, and query APIs that are easier for agents and IDEs to consume than raw terminal text.
+4. **Research on agent-native languages.** Explore how tools, authority, effects, contracts, and eventually memory/protocol abstractions can become first-class language concepts.
+
+## Why Gradient Exists
+
+Most current LLM coding workflows burn tokens and time on avoidable failure loops:
+
+- syntax mistakes
+- missing type context
+- hidden side effects
+- weak tooling interfaces
+- repeated compile-fix retries
+
+Gradient is built to reduce that waste through:
+
+| Technique | Why It Matters |
+|-----------|----------------|
+| **Grammar-constrained generation** | pushes syntax validity earlier in the generation loop |
+| **Effect tracking** | makes side effects explicit instead of implicit |
+| **Contracts** | supports generate-check-verify workflows |
+| **Structured compiler queries** | gives agents machine-readable diagnostics and symbol data |
+| **Self-hosting roadmap** | turns the compiler into a dogfooded agent-facing system |
+
+## What Works Today
+
+The Rust host compiler is the stable center of the project today.
+
+Available now:
+
+- native compilation via **Cranelift**
+- static type checking with inference
+- algebraic data types and pattern matching
+- generics
+- modules
+- contracts via `@requires` / `@ensures`
+- effect tracking
+- lists, maps, tuples, closures, traits, and actor syntax
+- compiler-as-library query APIs
+- LSP support
+- `gradient build`, `run`, `check`, `test`, and dependency workflows
+
+Supporting docs:
+
+- [Language Guide](docs/language-guide.md)
+- [CLI Reference](docs/cli-reference.md)
+- [Agent Integration](docs/agent-integration.md)
+- [Architecture](docs/architecture.md)
+
+## What Is Still Experimental
+
+Gradient is still alpha software.
+
+These areas are real, but not yet production-grade:
+
+- the self-hosted compiler in `compiler/*.gr`
+- WebAssembly support
+- LLVM backend completion
+- formatter and REPL polish
+- registry-backed package distribution
+- refinement types and session types
+
+Public docs should be read with that distinction in mind:
+
+- **Cranelift** is the working default backend
+- **WASM** exists as an experimental path, not the primary production path
+- **LLVM** is a medium-term engineering option, not the current focus
+
+## Quick Example
+
+```gradient
+@requires(n >= 0)
+@ensures(result >= 1)
 fn factorial(n: Int) -> Int:
     if n <= 1:
         ret 1
@@ -29,289 +108,155 @@ fn factorial(n: Int) -> Int:
         ret n * factorial(n - 1)
 ```
 
----
+Gradient's direction is visible in one small example:
 
-## Why Gradient Exists
-
-Current LLM coding workflows waste tokens on generate-compile-fix loops. Gradient cuts this waste through:
-
-| Technique | What It Saves |
-|-----------|---------------|
-| **Grammar-constrained generation** | Zero syntax errors via XGrammar/llguidance integration |
-| **Enforced effects** | Pure functions proven at compile time—no silent side effects |
-| **Type-directed completion** | Agents know expected types before generating code |
-| **Contracts** | `@requires`/`@ensures` for generate-verify instead of generate-fix |
-
-**Result:** Fewer iterations, smaller context windows, lower inference costs.
-
----
+- the function is statically typed
+- the intent is declared with contracts
+- the compiler can expose this structure to tools and agents
 
 ## Quick Start
 
 ### Prerequisites
 
-- **Rust** 1.75 or later
-- For WebAssembly builds: `wasm32-unknown-unknown` target
+- Rust 1.75+
+- optional: `wasm32-unknown-unknown` target for experimental WASM work
 
 ```bash
-# Install Rust (if not already installed)
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-# Add WASM target (for WebAssembly builds)
 rustup target add wasm32-unknown-unknown
 ```
 
-### Building
+### Build
 
 ```bash
 git clone https://github.com/Ontic-Systems/Gradient.git
 cd Gradient/codebase
-
-# Build (native only)
 cargo build --release
+```
 
-# Build with WebAssembly support
-cargo build --release --features wasm
+### Create and run a project
 
-# Create and run a project
+```bash
 ./target/release/gradient new hello
 cd hello
 GRADIENT_COMPILER=../target/release/gradient-compiler ../target/release/gradient run
+```
 
-# Or compile to WebAssembly
+### Experimental WASM path
+
+```bash
+cargo build --release --features wasm
 ./target/release/gradient-compiler hello.gr hello.wasm --backend wasm
-wasmtime hello.wasm  # Run with wasmtime
+wasmtime hello.wasm
 ```
 
----
-
-## What's Working Now
-
-- **Full compilation pipeline** — source → native binary via Cranelift
-- **Type system** — inference, generics, algebraic data types, pattern matching
-- **Effects** — `!{IO}`, `!{Net}`, `!{FS}`, `!{Mut}`, `!{Time}` tracked and enforced
-- **Contracts** — runtime-checked `@requires`/`@ensures` with `result` keyword
-- **Multi-file modules** — `use math` resolves to `math.gr`
-- **FFI** — `@extern("libm")` for C imports, `@export` for exports
-- **WebAssembly** — compile to WASM for browser/edge deployment (`--backend wasm`)
-- **Package Dependencies** — Path dependencies stable (`gradient add ../local`)
-- **Standard library** — strings, lists, maps, math, file I/O, CLI args
-- **Test framework** — `@test` annotation with `gradient test`
-- **Tooling** — LSP server, structured query API, `--json` output everywhere
-
-- **1,058 tests passing locally.** See `codebase/compiler/src/*/tests.rs`. Public CI currently shows failures due to environment differences—local builds pass.
-
----
-
-## Self-Hosting Vision: Gradient in Gradient
-
-Gradient is being rearchitected for **full self-hosting** with a minimal Rust kernel.
-
-### Target Architecture
-
-```
-┌─────────────────────────────────────┐
-│ RUST KERNEL (~2,000 lines)           │  ← Minimal primitives only
-│ - String operations                 │
-│ - File I/O                          │
-│ - Memory allocation                 │
-│ - Codegen backend                   │
-└─────────────────────────────────────┘
-           ↓ FFI
-┌─────────────────────────────────────┐
-│ GRADIENT COMPILER (~15,000 lines)   │  ← 95%+ of compiler
-│ - Lexer, Parser, Type Checker      │
-│ - Queryable API (for agents!)       │  ← Agents query compiler
-│ - LSP Server                        │  ← IDE integration
-│ - IR Builder, Optimizations         │
-│ - Codegen orchestration             │
-└─────────────────────────────────────┘
-```
-
-### Why This Matters
-
-1. **Dogfooding:** Agents develop Gradient in Gradient (optimized for agentic workflows)
-2. **Self-referential:** Queryable API written in agent-friendly language
-3. **Virtuous cycle:** Better tools → faster development → better tools
-4. **Portability:** Minimal kernel = easy to port
-
-### Current Status
-
-- ✅ **Phase 3 Complete:** Type definitions in self-hosted code (~4,077 lines, all type-check)
-- 🔴 **Phase 0 In Progress:** String primitives in Rust kernel (CRITICAL BLOCKER)
-- ⏳ **Phases 1-7:** Implement lexer → parser → type checker → query API → LSP → IR → codegen
-
-### Roadmap
-
-See [Self-Hosting Roadmap](docs/SELF_HOSTING.md) for detailed phases.
-
-Track progress: [#116 - Full Self-Hosting Epic](https://github.com/Ontic-Systems/Gradient/issues/116)
-
----
+Use the WASM path as an experiment, not yet as the default deployment story.
 
 ## Language Highlights
 
-### Effects Are Part of the Type
+### Effects are explicit
 
 ```gradient
-fn add(a: Int, b: Int) -> Int:        # proven pure
+fn add(a: Int, b: Int) -> Int:
     ret a + b
 
-fn greet(name: String) -> !{IO} ():   # must declare IO
+fn greet(name: String) -> !{IO} ():
     print("Hello, " + name)
 ```
 
-### Contracts for Verification
+### Contracts are part of the surface language
 
 ```gradient
-@requires(n >= 0)
-@ensures(result >= 1)
-fn factorial(n: Int) -> Int:
-    if n <= 1: ret 1
-    else: ret n * factorial(n - 1)
+@requires(b != 0)
+@ensures(result * b == a)
+fn div_exact(a: Int, b: Int) -> Int:
+    ret a / b
 ```
 
-### Generics with Inference
-
-```gradient
-fn identity[T](x: T) -> T:
-    ret x
-
-let x: Int = identity(42)        # T inferred as Int
-let y: String = identity("hi")     # T inferred as String
-```
-
-### Pattern Matching
+### Generics and algebraic data types are built in
 
 ```gradient
 type Option[T] = Some(T) | None
 
-fn unwrap[T](opt: Option[T], default: T) -> T:
+fn unwrap_or[T](opt: Option[T], default: T) -> T:
     match opt:
-        Some(val): val
+        Some(value): value
         None: default
 ```
 
----
-
 ## Project Status
 
-**Alpha.** The compiler works. Programs compile and run.
+### Stable core
 
-| Component | Status | Notes |
-|-----------|--------|-------|
-| Lexer/Parser/Typechecker | ✅ **Stable** | 1,058 tests passing |
-| Native code generation | ✅ **Stable** | Cranelift backend (default) |
-| LSP server | ✅ **Stable** | Built, functional |
-| Test runner | ✅ **Stable** | `gradient test` works |
-| WebAssembly backend | 🧪 **Experimental** | Code exists, compile with `--features wasm` |
-| LLVM backend | ❌ **Broken** | Disabled in CI (Polly linking issue) |
-| SMT verification | 🚧 **Planned** | Feature flag only, not functional |
-| Formatter | 🧪 **Experimental** | Code exists, CLI not wired |
-| REPL | 🧪 **Experimental** | Code exists, not functional |
-| Package registry | 🚧 **Planned** | Not implemented |
-| Git dependencies | 🧪 **Experimental** | Unverified end-to-end |
+| Area | Status | Notes |
+|------|--------|-------|
+| Rust host compiler | `Stable core` | primary implementation |
+| Cranelift backend | `Stable core` | default codegen path |
+| Type system | `Stable core` | inference, effects, contracts, generics |
+| Query API | `Stable core` | machine-readable compiler services |
+| LSP | `Stable core` | editor and agent integration surface |
+| Modules and build flow | `Stable core` | multi-file project support |
 
----
+### Experimental / in progress
 
-## CLI Commands
+| Area | Status | Notes |
+|------|--------|-------|
+| Self-hosted compiler | `In progress` | major strategic focus |
+| WebAssembly backend | `Experimental` | useful path, not yet the default story |
+| LLVM backend | `Incomplete` | not on the immediate critical path |
+| Package registry | `Planned` | path dependencies are the practical option today |
+| Refinement and session types | `Planned` | research-backed, not near-term execution work |
 
+## Roadmap
+
+The roadmap has been updated to reflect the current research consensus.
+
+Short version:
+
+1. lock the bootstrap parser subset
+2. implement the first self-hosted parser milestone
+3. build parser comparison and differential tests early
+4. finish comptime polish
+5. continue self-hosted checker / IR / bootstrap work
+6. revisit LLVM and production WASM after self-hosting pressure drops
+7. keep advancing the longer-term agent-native language design agenda in parallel
+
+Detailed docs:
+
+- [Project Roadmap](docs/roadmap.md)
+- [Self-Hosting Roadmap](docs/SELF_HOSTING.md)
+
+## Intended Positioning
+
+Gradient is not trying to be "just another general-purpose language."
+
+The project is aimed at a narrower and more ambitious intersection:
+
+- a language that agents can generate more reliably
+- a compiler that agents can query directly
+- a workflow that moves verification closer to generation
+- a long-term language design program for agent-native software systems
+
+That means the near-term value is practical tooling and compiler behavior.
+
+The long-term value is a language whose semantics are shaped around tools, authority, verification, and machine-assisted development from the start.
+
+## Repository Layout
+
+```text
+Gradient/
+├── codebase/    Rust host compiler and toolchain
+├── compiler/    Self-hosted Gradient compiler work
+├── docs/        Public documentation
+├── examples/    Example programs
+├── resources/   Grammar and language reference material
+└── assets/      Project assets
 ```
-gradient new <name>          Create project
-gradient build               Compile to native binary
-gradient run                 Build and execute
-gradient check               Type-check only
-gradient test                Run @test functions
-gradient add <spec>          Add dependency (path, git, or registry)
-gradient update              Refresh lockfile and dependencies
-gradient-lsp                 LSP server (stdio)
-
-gradient-compiler flags:
-  --backend <cranelift|llvm|wasm>   Select code generation backend
-  --release                         Use LLVM backend (optimized)
-  --check                           Type-check only (no codegen)
-  --json                            JSON output format
-```
-
-### Package Management
-
-Add dependencies from local paths:
-
-```bash
-# From local path (stable)
-gradient add ../local-package
-
-# From git repository (experimental, unverified)
-gradient add https://github.com/user/repo
-gradient add https://github.com/user/repo@v1.0.0
-```
-
-**Status:** Path dependencies are the only fully supported dependency type. Git dependencies have CLI support but lack end-to-end verification. Registry dependencies (`gradient add math@1.2.0`) require a registry server that does not yet exist.
-
----
-
-## Architecture
-
-```
-Source (.gr)
-    ↓
-Lexer → Parser → AST
-    ↓
-Type Checker (effects, contracts, inference)
-    ↓
-IR Builder (SSA)
-    ↓
-┌─────────────────────────────────────────────┐
-│           Cranelift (default)               │
-│              ✅ Stable                        │
-└─────────────────────────────────────────────┘
-    ↓
-Binary .exe
-
-Experimental: WASM backend (--features wasm)
-Not working: LLVM backend (Polly linking issue)
-```
-
----
-
-## WebAssembly Support (Experimental)
-
-Gradient has experimental WebAssembly support. Code exists but requires compiling with the `wasm` feature flag:
-
-```bash
-# Build with WASM support (required)
-cargo build --release --features wasm
-
-# Compile to WASM
-./target/release/gradient-compiler input.gr output.wasm --backend wasm
-
-# Run with wasmtime
-wasmtime output.wasm
-```
-
-**Status:** WASM backend code is complete but not included in default builds. It has not undergone the same testing as the Cranelift backend.
-
-**Features (when enabled):**
-- Linear memory export for host interaction
-- WASI imports for I/O (`fd_write`, `proc_exit`)
-- String data in passive data segments
-- Bump allocator for heap allocations
-
-**Use cases:**
-- **Browser-based agents** — Run Gradient in the browser
-- **Edge deployment** — Deploy to Cloudflare Workers, Deno Deploy
-- **Sandboxed execution** — Safe execution of untrusted code
-
-**Browser demo:** `codebase/wasm-demo/index.html` (requires WASM feature build)
-
----
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
-
----
+MIT. See [LICENSE](LICENSE).
 
 <div align="center">
-<sub>Built for agents. Verified by the compiler.</sub>
+<sub>Built for agents. Grounded in the compiler.</sub>
 </div>

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,296 +1,284 @@
-# Self-Hosting Roadmap: Gradient in Gradient
+# Self-Hosting Roadmap
 
-## Vision
+Gradient's self-hosting plan is to move more of the compiler into Gradient while keeping a small Rust host kernel for platform-sensitive primitives and code generation.
 
-Achieve **full self-hosting** where 95%+ of the Gradient compiler is written in Gradient, with a minimal Rust kernel (~2,000 lines) providing only critical primitives.
+This document is the detailed execution plan for that effort.
 
-```
-┌─────────────────────────────────────┐
-│ RUST KERNEL (~2,000 lines)           │  ← Minimal primitives only
-│ - String: char_at, length, etc      │
-│ - File I/O: read, write, exists     │
-│ - Memory: alloc, free               │
-│ - Process: spawn, wait              │
-│ - Codegen: Cranelift, WASM          │
-└─────────────────────────────────────┘
-           ↓ FFI
-┌─────────────────────────────────────┐
-│ GRADIENT COMPILER (~15,000 lines)   │  ← Full implementation
-│ - Lexer (character scanning)         │
-│ - Parser (recursive descent)         │
-│ - Type Checker (HM inference)          │
-│ - Queryable API (for agents!)       │  ← KEY: Agents use this
-│ - LSP Server (JSON-RPC)             │  ← IDE integration
-│ - IR Builder (SSA form)              │
-│ - Optimizations                      │
-│ - Codegen orchestration              │
-└─────────────────────────────────────┘
-```
+It is aligned with the April 2026 research review and with the public project roadmap.
 
-## Why This Architecture?
+## Objective
 
-### 1. Dogfooding
-Agents develop Gradient in Gradient—the language is optimized for agentic workflows.
+Target state:
 
-### 2. Self-Referential Improvement
-```
-┌────────────────────────────────────────┐
-│ 1. Query API (in Gradient)            │
-│    → Agent works faster                │
-├────────────────────────────────────────┤
-│ 2. Agent improves query API             │
-│    → Even better for agents            │
-├────────────────────────────────────────┤
-│ 3. Repeat                               │
-│    → Exponential improvement           │
-└────────────────────────────────────────┘
-```
+- the Rust compiler remains the trusted host implementation
+- the self-hosted compiler becomes the primary dogfooded compiler implementation
+- the boundary between the two is explicit and small
 
-### 3. Portability
-- Minimal kernel = easy to port to new platforms
-- Gradient code is platform-independent
-- Only kernel needs platform-specific code
+Rust should keep:
 
-### 4. Safety
-- Rust kernel handles memory safety
-- Gradient handles logic
-- Clear separation of concerns
+- platform and runtime primitives
+- file and process integration
+- backend code generation engines
+- bootstrap-critical low-level functionality
+
+Gradient should increasingly own:
+
+- compiler front-end logic
+- semantic analysis
+- agent-facing compiler services
+- higher-level orchestration
 
 ## Current State
 
-**Phase 0 COMPLETE:** String primitives in Rust kernel ✅
-- ✅ `string_length(String) -> Int`
-- ✅ `string_char_at(String, Int) -> String`
-- ✅ `string_char_code_at(String, Int) -> Int` - KEY for lexer
-- ✅ `string_substring(String, Int, Int) -> String`
-- ✅ `string_append(String, String) -> String`
-- ✅ C runtime, type checker, and Cranelift codegen all implemented
+Stable facts from the repository and research:
 
-**Phase 1 COMPLETE:** Full lexer in Gradient ✅
-- ✅ `compiler/lexer.gr` - 515 lines of working code
-- ✅ Character scanning with `string_char_code_at`
-- ✅ All token types implemented
-- ✅ Comments (// and /* */ with nesting)
-- ✅ Proper position tracking with newlines
+- the Rust compiler is the production-leading implementation
+- string primitives needed for self-hosted lexer/parser work are present
+- self-hosted compiler files already exist in `compiler/*.gr`
+- parser work is still the most important self-hosting bottleneck
+- list/collection ergonomics remain a structural constraint for cleaner self-hosted implementations
 
-**Phase 3 COMPLETE:** Type definitions in self-hosted code
-- ✅ 10 compiler modules: `token.gr`, `lexer.gr`, `parser.gr`, `types.gr`, `ir.gr`, `ir_builder.gr`, `checker.gr`, `compiler.gr`, `bootstrap.gr`, `types_positional.gr`
-- ✅ ~4,077 lines of Gradient code
-- ✅ All modules type-check successfully
-- 🔴 Parser is stub (NOW UNBLOCKED!)
-- 🔴 Type checker is stub (blocked on parser)
+## Execution Principles
 
-**Rust Compiler:** Production-ready, ~30,000 lines
-- ✅ Full lexer, parser, type checker
-- ✅ Queryable API (5,400 lines)
-- ✅ LSP server
-- ✅ Codegen (Cranelift + WASM)
-- ✅ **NEW:** String primitives (Phase 0)
-- ✅ **NEW:** Self-hosted lexer (Phase 1)
+1. Keep the bootstrap parser intentionally narrow.
+2. Prefer local correctness and comparison tests over early completeness.
+3. Localize temporary workarounds so they do not spread through later phases.
+4. Do not block self-hosting on advanced type-system work beyond comptime polish.
+5. Keep the Rust compiler usable and documented while self-hosting evolves.
 
-## Roadmap
+## Step-By-Step Plan
 
-### Phase 0: String Primitives ✅ COMPLETE [#117](https://github.com/Ontic-Systems/Gradient/issues/117)
-**Status:** ✅ Merged to main in PR #127  
-**Effort:** ~1 day, ~210 lines (C + Rust)
+### Step 1: Freeze the bootstrap parser subset
 
-**Added to Rust kernel:**
-- ✅ `string_length(s: String) -> Int`
-- ✅ `string_char_at(s: String, idx: Int) -> String`
-- ✅ `string_char_code_at(s: String, idx: Int) -> Int` (KEY primitive for lexer!)
-- ✅ `string_substring(s: String, start: Int, end: Int) -> String`
-- ✅ `string_append(a: String, b: String) -> String`
+Purpose:
 
-**Impact:** Self-hosted lexer can now read source code character-by-character!
+- define the minimum grammar slice required to bootstrap meaningful self-hosted progress
 
----
+Must decide:
 
-### Phase 1: Lexer ✅ COMPLETE [#118](https://github.com/Ontic-Systems/Gradient/issues/118)
-**Status:** ✅ Merged to main in PR #128  
-**Effort:** ~2 hours, ~515 lines Gradient (206 → 515)
+- which declarations are in the first milestone
+- which expressions are in the first milestone
+- whether initial parsing is scannerless or staged through a narrow token abstraction
+- which temporary sequence representation will stand in for richer list support
 
-**Delivered:**
-- ✅ `current_char(lex)` - uses `string_char_code_at`
-- ✅ `peek_char(lex, offset)` - lookahead without consuming  
-- ✅ `next_token(lex)` - complete token scanning
-- ✅ Position tracking with line/column updates
-- ✅ Whitespace, line comments, block comments
-- ✅ Identifiers and 18 keywords
-- ✅ Number literals (integers and floats)
-- ✅ String literals with escape handling
-- ✅ All operators and delimiters
+Output:
 
-**Impact:** Self-hosted compiler can now tokenize source code!
+- a parser bootstrap scope note
+- a corpus of accepted source examples
+- a written list of intentionally unsupported constructs for the first milestone
 
----
+### Step 2: Implement parser state threading in `compiler/parser.gr`
 
-### Phase 2: Parser 🔴 READY TO START [#119](https://github.com/Ontic-Systems/Gradient/issues/119)
-**Status:** 🔴 Ready to start (Phase 1 complete!)  
-**Effort:** ~5 days, ~1,300 lines Gradient
+Purpose:
 
-Implement recursive descent parser in `compiler/parser.gr`:
-- Pratt parser for expressions (precedence climbing)
-- Parse all statement types
-- Parse module structure
-- Error recovery
+- establish the parser architecture recommended by the research
 
----
+Required characteristics:
 
-### Phase 3: Type Checker [#120](https://github.com/Ontic-Systems/Gradient/issues/120)
-**Status:** ⏳ Blocked on #119  
-**Effort:** ~7 days, ~2,500 lines Gradient
+- immutable parser state
+- parse functions return updated state with result data
+- precedence-aware expression parsing
+- simple failure behavior first
 
-Implement full type checking in `compiler/checker.gr`:
-- Hindley-Milner type inference
-- Unification algorithm
-- Effect inference
-- Polymorphism
-- Error reporting
+Recommended first parser milestone:
 
----
+- module shell
+- function definitions
+- let-bindings
+- literals
+- identifiers
+- arithmetic and comparison expressions
 
-### Phase 4: Queryable API in Gradient [#121](https://github.com/Ontic-Systems/Gradient/issues/121)
-**Status:** ⏳ Blocked on #120  
-**Effort:** ~5 days, ~1,500 lines Gradient
+Do not optimize for:
 
-**NEW FILE:** `compiler/query.gr`
+- rich recovery
+- complete syntax parity
+- elegant list accumulation
 
-Implement the queryable API that enables agents:
-- `session_from_source(source: String) -> Session`
-- `session_check(sess: Session) -> CheckResult`
-- `session_symbols(sess: Session) -> SymbolList`
-- `session_type_at(sess: Session, line: Int, col: Int) -> TypeAtResult`
-- `session_rename(sess: Session, old: String, new: String) -> RenameResult`
-- `session_effects(sess: Session) -> EffectSummary`
+### Step 3: Constrain the temporary collection strategy
 
-**This is the KEY enabler for agentic workflows.**
+Purpose:
 
----
+- avoid architectural drift while list primitives remain incomplete or awkward
 
-### Phase 5: LSP in Gradient [#122](https://github.com/Ontic-Systems/Gradient/issues/122)
-**Status:** ⏳ Blocked on #121  
-**Effort:** ~7 days, ~2,500 lines Gradient
+Rules:
 
-**NEW FILE:** `compiler/lsp.gr`
+- use one temporary representation for parser-built sequences
+- document where the representation enters and leaves the parser
+- do not allow ad hoc sequence encodings to spread into checker and IR logic
 
-Implement LSP server in Gradient:
-- JSON-RPC message handling
-- textDocument/diagnostic (real-time errors)
-- textDocument/hover (type info)
-- textDocument/definition (go to def)
-- textDocument/references (find refs)
-- textDocument/rename (safe rename)
-- textDocument/completion (autocomplete)
+Expected replacement path:
 
-Uses `query.gr` for all data.
+- once cleaner list support lands, replace the temporary representation behind stable boundaries
 
----
+### Step 4: Add parser comparison infrastructure
 
-### Phase 6: IR Builder [#123](https://github.com/Ontic-Systems/Gradient/issues/123)
-**Status:** ⏳ Blocked on #122  
-**Effort:** ~5 days, ~1,500 lines Gradient
+Purpose:
 
-Implement IR generation in `compiler/ir_builder.gr`:
-- Lower AST to SSA form
-- Generate all instruction types
-- Block/branch construction
-- Type conversions
+- make self-hosted parser progress measurable
 
----
+Build:
 
-### Phase 7: Codegen [#124](https://github.com/Ontic-Systems/Gradient/issues/124)
-**Status:** ⏳ Blocked on #123  
-**Effort:** ~5 days, ~1,000 lines Gradient
+- a normalized AST or parse-output representation
+- a shared test corpus between Rust and self-hosted parsers
+- golden tests for syntax categories
+- differential checks for the bootstrap subset
 
-Implement code generation orchestration:
-- Call Rust kernel for Cranelift codegen
-- Call Rust kernel for WASM codegen
-- Linking and output
+Success condition:
 
----
+- self-hosted parser behavior can be compared automatically against the host parser for a known subset
 
-### Phase 8: Memory Primitives [#125](https://github.com/Ontic-Systems/Gradient/issues/125)
-**Status:** 📋 Planned  
-**Effort:** ~1 day, ~200 lines Rust
+### Step 5: Finish comptime polish in the Rust compiler
 
-Add to Rust kernel:
-- `alloc(size: Int) -> Int`
-- `free(ptr: Int)`
-- `list_create() -> Int`
-- `list_push(lst: Int, item: Int)`
+Purpose:
 
-Needed for dynamic data structures.
+- land the highest-value near-term advanced-types work without derailing self-hosting
 
----
+Focus:
 
-## Critical Path
+- clearer diagnostics for non-comptime arguments
+- explicit compile-time failure behavior
+- evaluation budget limits or similar guardrails
 
-The phases MUST be completed in order. Each phase blocks the next:
+Why inside the self-hosting roadmap:
 
-```
-#117 (String) → #118 (Lexer) → #119 (Parser) → #120 (Checker)
-                                                      ↓
-#124 (Codegen) ← #123 (IR) ← #122 (LSP) ← #121 (Query API)
-```
+- comptime strengthens the language used to write future self-hosted compiler code
 
-## Definition of Done
+### Step 6: Move into self-hosted semantic passes
 
-- [ ] All phases complete
-- [ ] Compiler can compile itself
-- [ ] `gradient-compiler` is 95%+ Gradient code
-- [ ] Rust kernel ≤2,000 lines
-- [ ] Gradient compiler ≥15,000 lines
-- [ ] All 1,058+ tests passing
-- [ ] LSP working
-- [ ] Queryable API working
-- [ ] CI green
+Target files:
 
-## Total Effort Estimate
+- `compiler/checker.gr`
+- `compiler/ir.gr`
+- `compiler/ir_builder.gr`
+- `compiler/codegen.gr`
 
-| Component | Lines | Days |
-|-----------|-------|------|
-| Rust kernel additions | ~1,000 | 2 |
-| Lexer | +800 | 3 |
-| Parser | +1,300 | 5 |
-| Type checker | +2,500 | 7 |
-| Query API | +1,500 | 5 |
-| LSP | +2,500 | 7 |
-| IR builder | +1,500 | 5 |
-| Codegen | +1,000 | 5 |
-| **Total** | **~12,100** | **~39** |
+Prerequisites:
 
-## What Stays in Rust
+- parser bootstrap works
+- parser outputs are testable
+- temporary collection boundaries are understood
 
-Only critical primitives:
-- String operations (memory safety)
-- File I/O (OS syscalls)
-- Memory allocation
-- Process control
-- Codegen backends (Cranelift, WASM)
+Success condition:
 
-**Everything else → Gradient**
+- self-hosted compilation covers meaningfully more than syntax
 
-## Benefits for Agents
+### Step 7: Build a repeatable bootstrap path
 
-Once complete, agents can:
-1. Query the compiler programmatically (`Session` API in Gradient)
-2. Get structured data (JSON) instead of parsing text
-3. Check errors in ~10ms (in-memory, no file I/O)
-4. Generate code correctly the first time (type-aware)
-5. Refactor safely (automated, verified)
-6. Understand effects (purity tracking)
+Purpose:
 
-**Result: 10-50x improvement in agentic coding workflows.**
+- make self-hosting practical, not just possible
 
-## Resources
+Deliverables:
 
-- Epic: [#116 - Full Self-Hosting](https://github.com/Ontic-Systems/Gradient/issues/116)
-- Design doc: `SELF_HOSTING_STRATEGY.md` (in project root)
-- Current code: `compiler/*.gr` (~4,077 lines)
-- Rust compiler: `codebase/compiler/src/` (~30,000 lines)
+- documented stage ordering
+- commands/scripts for bootstrap validation
+- "same result" or equivalent trust checks where feasible
+- failure diagnosis notes for stage mismatches
 
----
+### Step 8: Expand the self-hosted compiler surface deliberately
 
-**Status:** Phase 3 complete, Phase 0 in progress  
-**Next milestone:** String primitives in Rust kernel  
-**ETA:** ~39 days total effort
+After front-end stability improves, expand in this order:
+
+1. query/compiler services useful to agents
+2. orchestration and build flow
+3. additional compiler subsystems where the self-hosted implementation is clearly paying for itself
+
+Reason:
+
+- the project's differentiator is not just self-hosting
+- it is self-hosting in a compiler stack designed for agent use
+
+## Dependencies And Ordering
+
+The important dependency chain is:
+
+1. parser scope
+2. parser implementation
+3. parser comparison infrastructure
+4. self-hosted checker and IR work
+5. repeatable bootstrap flow
+6. broader self-hosted compiler services
+
+Comptime can proceed in parallel because it is a contained host-compiler improvement with direct language value.
+
+LLVM completion, production WASM strategy, refinement types, and session types should not sit on the critical path for this plan.
+
+## Risks
+
+### Risk: Parser scope expands too early
+
+Impact:
+
+- slower delivery
+- more rewrite churn
+
+Mitigation:
+
+- freeze the bootstrap subset before implementation accelerates
+
+### Risk: Temporary list workarounds leak everywhere
+
+Impact:
+
+- later checker/IR code becomes harder to replace cleanly
+
+Mitigation:
+
+- isolate the workaround behind parser-local boundaries
+
+### Risk: Progress is judged by anecdotes instead of comparison tests
+
+Impact:
+
+- false confidence
+- hard-to-debug semantic drift
+
+Mitigation:
+
+- build differential and golden tests early
+
+### Risk: Advanced research pulls focus from execution
+
+Impact:
+
+- roadmap churn
+- delayed self-hosting milestones
+
+Mitigation:
+
+- keep agent-language theory as a parallel design track, not a blocker
+
+## What This Roadmap Does Not Assume
+
+It does not assume:
+
+- full parser parity before value is created
+- immediate LLVM completion
+- production-ready WASM output in the short term
+- refinement or session types as near-term prerequisites
+
+## Success Markers
+
+Near-term success:
+
+- bootstrap parser subset documented
+- first parser milestone implemented
+- parser comparison harness started
+- comptime polish completed
+
+Mid-term success:
+
+- self-hosted checker and IR work progress on top of stable parser outputs
+- bootstrap flow is reproducible
+
+Long-term success:
+
+- self-hosted compiler becomes a practical part of the project's own development loop
+- the Rust compiler and self-hosted compiler have a clear, durable boundary
+
+## Related Documents
+
+- [Project Roadmap](./roadmap.md)
+- [Architecture](./architecture.md)
+- [Agent Integration](./agent-integration.md)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,186 +1,275 @@
 # Gradient Roadmap
 
-**Status Key:** ✅ Stable | 🟢 Beta | 🧪 Experimental | 🚧 Planned | ❌ Broken
+Gradient is an alpha-stage programming language and compiler stack built for AI-assisted software development.
 
-## Current Status: Alpha (Phase 2 — Self-Hosting)
+The roadmap below reflects the current repository state and the April 2026 research synthesis.
 
-**1,058 tests passing locally.** The compiler works. Programs compile to native binaries.
+The main conclusion from that research is straightforward:
 
-**Phase 2 Progress:** Self-hosting compiler partially complete. `token.gr`, `lexer.gr`, and `parser.gr` parse and typecheck successfully.
+- self-hosting remains the highest-leverage long-term investment
+- the parser is the immediate compiler bottleneck
+- comptime is the best short-term advanced-types task
+- Cranelift remains the default backend for fast iteration
+- LLVM is optional medium-term release work, not the current blocker
+- production-grade WASM needs a deliberate backend plan, not assumption drift
 
-**Note:** Public CI shows failures due to environment differences. Local builds pass. See [CI Status](../STATUS_LOCAL_TRUTH.md).
+## Current Product Shape
 
----
+What is stable today:
 
-## Completed Phases
+- native compilation through the Rust host compiler and Cranelift
+- type checking with effects, contracts, generics, pattern matching, modules, traits, actors, lists, maps, and test support
+- compiler-as-library query APIs
+- LSP support
 
-### Phase 0 — Foundation
-- PEG grammar, CLI scaffold, Cranelift codegen PoC
+What is still in-progress or experimental:
 
-### Phase 1 — Host Compiler Frontend
-- Hand-written lexer (94 tests)
-- Recursive descent parser (128 tests)
-- Error recovery
+- the self-hosted compiler in `compiler/*.gr`
+- production-grade WASM strategy
+- LLVM backend completion
+- refinement types and session types
+- registry-backed package distribution
 
-### Phase 2 — Type System
-- Static type checker with inference (371 tests)
-- Five built-in types: `Int`, `Float`, `String`, `Bool`, `()`
-- Effect system: `!{IO}`, `!{Net}`, `!{FS}`, `!{Mut}`, `!{Time}`
+## Roadmap Principles
 
-### Phase 3 — IR Generation
-- AST to SSA IR translation
-- Instruction set: Const, Call, Ret, arithmetic, branching, phi nodes
+Every roadmap decision below follows five constraints:
 
-### Phase 4 — Full Pipeline
-- End-to-end: `.gr` → native binary via Cranelift
-- `gradient build`, `gradient run`
+1. Protect the working Rust compiler.
+2. Prioritize steps that unblock self-hosting.
+3. Prefer verification and differential testing before broadening surface area.
+4. Separate "near-term compiler execution" from "long-term agent-language theory."
+5. Keep public claims narrower than internal aspirations.
 
-### Phase 5 — Working CLI
-- `gradient new`, `gradient check`
-- Project discovery, compiler discovery
+## Step-By-Step Roadmap
 
-### Phase 6 — Standard Library
-- I/O: `print`, `println`, `print_int`, `print_float`, `print_bool`, `read_line`
-- Math: `abs`, `min`, `max`, `mod_int`, `pow`, `sqrt`
-- Conversions: `int_to_string`, `parse_int`, `parse_float`
+### Step 1: Lock the self-hosted parser bootstrap subset
 
-### Phase A — Compiler-as-Library
-- `Session::from_source()`, `check()`, `symbols()`
-- JSON-serializable outputs
+Status: `Now`
 
-### Phase B — Effect System Polish
-- Effect inference and validation
-- Purity guarantees
+Goal:
 
-### Phase C — Module Capabilities
-- `@cap(IO, Net)` annotations
+- define the exact source forms the first self-hosted parser must accept
 
-### Phase D+E — Analysis & Transforms
-- Call graph, dependency queries
-- Compiler-verified rename
+Deliverables:
 
-### Phase F — Control Flow
-- Mutable bindings (`let mut`)
-- While loops, assignment
+- parser subset specification
+- explicit statement on temporary collection/list workaround strategy
+- decision on initial scannerless strategy versus token-stream staging
 
-### Phase G — Pattern Matching
-- `match` with int/bool/wildcard patterns
+Why first:
 
-### Phase H — Algebraic Data Types
-- Enum types: `type Color = Red | Green | Blue`
-- Tuple variants: `type Shape = Circle(Float) | Point`
+- current research converges on parser work as the immediate bottleneck
+- the bootstrap parser should be intentionally smaller than full Rust-parser parity
 
-### Phase I — Modules
-- Multi-file resolution: `use math` → `math.gr`
-- Qualified calls: `math.add(a, b)`
+Exit criteria:
 
-### Phase L — Grammar for Constrained Decoding
-- `resources/gradient.ebnf` for XGrammar/llguidance/Outlines
+- one written bootstrap scope doc
+- one accepted temporary AST-sequence representation
+- one first-milestone acceptance corpus
 
-### Phase M — Design-by-Contract
-- `@requires`, `@ensures` with runtime checking
-- `result` keyword in postconditions
+### Step 2: Implement the self-hosted parser milestone
 
-### Phase N — Generics
-- Type parameters: `fn identity[T](x: T) -> T`
-- Bidirectional inference
+Status: `Now`
 
-### Phase O — Effect Polymorphism
-- Lowercase effect variables: `!{e}`
+Goal:
 
-### Phase P — Expanded Language
-- Tuples: `(Int, String)` with destructuring
-- Closures: `|x| x + 1`
-- Traits: `trait Display`, `impl Display for MyType`
-- Result/Option types with `?` operator
-- Lists: `List[T]` with `[1, 2, 3]` literals
-- String interpolation: `f"hello {name}"`
-- Pipe operator: `x |> f |> g`
-- For-in loops: `for x in list:`
-- Match guards and exhaustiveness checking
+- make `compiler/parser.gr` handle a constrained but useful program subset
 
-### Phase Q — Method Syntax
-- `obj.method(args)` dispatch
-- Chained calls: `"hello".trim().length()`
+Target milestone:
 
-### Phase R — I/O Expansion
-- `read_line()`, `parse_int`, `parse_float`, `exit(code)`, `args()`
-- File I/O: `file_read`, `file_write`, `file_exists` under `!{FS}` effect
+- function definitions
+- let-bindings
+- literals
+- arithmetic expressions
+- module-level structure needed for early compiler files
 
-### Phase S — Data Structures
-- `Map[String, V]` with 7 builtins
-- Persistent-by-copy semantics
+Implementation guidance from research:
 
-### Phase T — Test Framework
-- `@test` annotation
-- `gradient test` with discovery, harness, reporting
+- immutable state threading
+- `(result, state)` style parser functions
+- recursive descent first
+- fail-fast error behavior first
+- defer richer recovery until later
 
-### Phase U — LSP Server
-- Diagnostics, hover, completions
-- `gradient/batchDiagnostics` for agents
+Exit criteria:
 
-### Phase V — Actors
-- `actor` declarations with `state` and `on` handlers
-- `spawn`, `send`, `ask` expressions
-- `!{Actor}` effect
+- parser accepts the bootstrap subset
+- outputs are stable enough for comparison testing
+- temporary list workaround remains localized
 
----
+### Step 3: Build the parser testing bridge early
 
-## In Progress / Experimental
+Status: `Now`
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| Self-hosting compiler | 🚧 **In Progress** | 3/7 core files parse & typecheck (see below) |
-| Canonical formatter (`gradient fmt`) | 🧪 Experimental | Code exists (1,297 lines), CLI not wired |
-| Interactive REPL (`gradient repl`) | 🧪 Experimental | Code exists (960 lines), not functional |
-| WebAssembly backend | 🧪 Experimental | Compile with `--features wasm` |
-| Git dependencies | 🧪 Experimental | CLI support exists, unverified end-to-end |
-| LLVM backend | ❌ Broken | Disabled in CI (Polly linking issue) |
-| SMT verification | 🚧 Planned | Feature flag only, not functional |
+Goal:
 
-### Self-Hosting Progress Detail
+- reduce risk before downstream self-hosting work multiplies it
 
-Writing the Gradient compiler in Gradient itself (~6,800 lines across 7 files).
+Deliverables:
 
-| File | Lines | Status | Notes |
-|------|-------|--------|-------|
-| `token.gr` | ~750 | ✅ Complete | Token types parse & typecheck |
-| `lexer.gr` | ~490 | ✅ Complete | Lexical analysis with `LexState` record |
-| `parser.gr` | ~990 | ✅ Complete | AST nodes & recursive descent parser |
-| `types.gr` | ~600 | 🚧 In Progress | Type system definitions |
-| `checker.gr` | ~800 | 🚧 In Progress | Type inference & checking |
-| `ir.gr` | ~700 | 🚧 In Progress | IR instruction definitions |
-| `ir_builder.gr` | ~400 | 🚧 In Progress | IR construction from AST |
+- shared parser corpus between Rust and self-hosted implementations
+- AST serialization or comparable normalized output
+- golden tests for representative syntax families
+- initial differential tests against the host parser
 
-**Critical Blocker:** Module system for self-hosted files currently requires manual concatenation to validate multi-file programs.
+Why this early:
 
----
+- the research strongly supports differential testing as high ROI
+- parser confidence should not depend on manual spot checks
 
-## Planned
+Exit criteria:
 
-| Feature | Status | Notes |
-|---------|--------|-------|
-| Package registry server | 🚧 Planned | No server implementation exists |
-| Registry dependencies | 🚧 Planned | Blocked on registry server |
-| IDE plugins (VS Code, Zed) | 🚧 Planned | LSP exists, plugins not started |
-| Linear types | 🚧 Planned | Runtime exists, language surface not defined |
-| Session types | 🚧 Planned | Design phase only |
-| Advanced supervision trees | 🚧 Planned | Documentation exists, not implemented |
-| Grammar-constrained decoding | 🚧 Planned | XGrammar/llguidance integration |
+- at least one automated Rust-vs-self-hosted parser comparison path
+- golden output checked in for the bootstrap subset
 
----
+### Step 4: Finish comptime polish
 
-## Recently Completed (Stable)
+Status: `Now`
 
-| Feature | Status | Completion |
-|---------|--------|------------|
-| Cranelift backend | ✅ Stable | Primary native backend |
-| Type system | ✅ Stable | 1,058 tests |
-| Effects system | ✅ Stable | Tracked and enforced |
-| Pattern matching | ✅ Stable | Full ADT support |
-| Generics | ✅ Stable | Type parameters, inference |
-| Module system | ✅ Stable | Multi-file `use` resolution |
-| LSP server | ✅ Stable | Diagnostics, completions, hover |
-| Test framework | ✅ Stable | `@test` annotations |
-| Query API | ✅ Stable | JSON output, compiler-as-agent |
-| FFI / Extern | ✅ Stable | `@extern` and `@export` working |
+Goal:
+
+- close the remaining comptime quality gaps without expanding scope
+
+Deliverables:
+
+- improved error reporting for runtime values passed to comptime parameters
+- explicit compile-time failure surfaces
+- evaluation budget or termination guardrails
+
+Why now:
+
+- comptime is the shortest advanced-types task with direct compiler value
+- it improves the language without destabilizing the self-hosting critical path
+
+Exit criteria:
+
+- current TODOs closed
+- tests updated
+- comptime documented as complete enough for current roadmap purposes
+
+### Step 5: Complete self-hosted semantic passes
+
+Status: `Next`
+
+Goal:
+
+- move from parser bootstrap to a useful self-hosted compiler front end
+
+Scope:
+
+- `compiler/checker.gr`
+- `compiler/ir.gr`
+- `compiler/ir_builder.gr`
+- `compiler/codegen.gr`
+
+Dependency note:
+
+- this step should start only once parser shape and comparison testing are credible
+
+Exit criteria:
+
+- self-hosted compiler can process meaningful Gradient programs beyond tokenization/parsing
+- bootstrap flow is documented and repeatable
+
+### Step 6: Harden the public compiler workflow
+
+Status: `Next`
+
+Goal:
+
+- keep the Rust host compiler clearly production-leading while self-hosting advances
+
+Deliverables:
+
+- clearer CI expectations
+- stronger local-vs-CI parity
+- improved docs for supported versus experimental features
+- regression tracking for parser, typechecker, and build-system workflows
+
+Exit criteria:
+
+- stable public docs
+- fewer ambiguous "works locally but not in CI" claims
+- public roadmap and README remain aligned
+
+### Step 7: Revisit backend expansion in the right order
+
+Status: `Later`
+
+Priority order:
+
+1. Cranelift remains the default development backend.
+2. LLVM is an optional bounded release-backend completion project.
+3. production WASM is a separate backend initiative with an explicit design choice.
+
+What this means in practice:
+
+- do not let LLVM displace parser/self-hosting work
+- do not market WASM as fully mature until the backend path is hardened
+- treat backend comparison as an engineering track, not the main narrative
+
+Exit criteria:
+
+- written backend strategy update
+- explicit decision between direct WASM emission, LLVM-to-WASM reuse, or another dedicated route
+
+### Step 8: Formalize Gradient's agent-native language core
+
+Status: `Parallel research track`
+
+Goal:
+
+- turn the broader research thesis into coherent language design direction
+
+Core themes from research:
+
+- typed tool and capability interfaces
+- effect and authority tracking
+- memory partitioning semantics
+- contracts around actions and observations
+- executable semantics
+- multi-agent coordination primitives
+
+Important boundary:
+
+- this work should inform naming and design decisions now
+- it should not block parser and self-hosting execution
+
+Exit criteria:
+
+- one design memo for agent-native language primitives
+- clear distinction between current features, near-term plans, and long-term research
+
+## Milestone View
+
+### Near-Term
+
+- parser bootstrap scope locked
+- first self-hosted parser milestone implemented
+- parser differential testing started
+- comptime polished
+
+### Mid-Term
+
+- self-hosted checker and IR work meaningfully underway
+- public docs and CI status tightened
+- backend strategy clarified without derailing self-hosting
+
+### Long-Term
+
+- self-hosted compiler becomes the center of the Gradient development loop
+- production-grade WASM strategy lands
+- agent-native language features move from theory into concrete design and implementation
+
+## Notable Non-Goals Right Now
+
+- broadening the language surface before self-hosting bottlenecks are reduced
+- marketing LLVM as imminent
+- treating experimental WASM support as production-ready
+- starting refinement or session types ahead of parser/comptime/testing priorities
+
+## Related Documents
+
+- [Self-Hosting Roadmap](./SELF_HOSTING.md)
+- [Agent Integration](./agent-integration.md)
+- [Architecture](./architecture.md)


### PR DESCRIPTION
## What changed

This PR rewrites the public roadmap and README to align the repository's public positioning with the recent research conclusions and the project's current implementation reality.

It updates:

- `README.md`
- `docs/roadmap.md`
- `docs/SELF_HOSTING.md`

## Why it changed

The previous docs had drifted in three ways:

- roadmap priorities were not aligned with the latest planning direction
- self-hosting planning still reflected an older phase/status narrative
- the README mixed stable capabilities with experimental or medium-term work too loosely

This PR narrows the public claims and makes the project story more coherent.

## User and developer impact

For users:

- the README now explains Gradient's intended use cases more clearly
- stable versus experimental areas are separated more cleanly
- backend messaging is more accurate about Cranelift, LLVM, and WASM

For contributors:

- the roadmap now prioritizes parser bootstrap, early differential testing, comptime polish, and self-hosting execution in a clearer order
- `docs/SELF_HOSTING.md` is now a step-by-step execution plan rather than an outdated phase ledger

## Validation

- reviewed the updated docs for consistency with each other
- confirmed the PR is scoped only to public repo docs
- no code or test changes were included
