### PR TITLE
Fix comptime error reporting for runtime values passed to comptime parameters

### DIFF
--- a/codebase/compiler/src/typechecker/checker.rs
+++ b/codebase/compiler/src/typechecker/checker.rs
@@ -2781,13 +2781,21 @@ impl TypeChecker {
                 std::collections::HashMap::new();
 
             // Check each argument type.
-            for (i, (arg, (param_name, param_ty, _comptime))) in
+            for (i, (arg, (param_name, param_ty, is_comptime))) in
                 args.iter().zip(sig.params.iter()).enumerate()
             {
                 let arg_ty = self.check_expr(arg);
                 if arg_ty.is_error() || param_ty.is_error() {
                     continue;
                 }
+
+                // Validate comptime parameters.
+                if *is_comptime {
+                    if let Err(e) = self.require_comptime(arg) {
+                        self.errors.push(e);
+                    }
+                }
+
                 if has_effect_vars && Self::ty_has_effect_variables(param_ty) {
                     // Effect-polymorphic parameter: use effect-aware matching.
                     if !Self::match_type_with_effect_vars(param_ty, &arg_ty, &mut effect_bindings) {

--- a/codebase/compiler/tests/comptime_integration_tests.rs
+++ b/codebase/compiler/tests/comptime_integration_tests.rs
@@ -45,19 +45,16 @@ fn test(y: Int) -> Int:
 ";
 
     let errors = typecheck_source(source);
-    // NOTE: This test currently fails because the comptime validation is happening
-    // but the error is not being captured properly. The feature works for the
-    // happy path (literals passed to comptime params) but the error path needs
-    // additional work.
-    // TODO: Fix comptime error reporting for runtime arguments
-    if !errors.is_empty() {
-        let error_msg = format!("{}", errors[0]);
-        assert!(
-            error_msg.contains("compile-time") || error_msg.contains("comptime"),
-            "Error should mention comptime: {}",
-            error_msg
-        );
-    }
+    // This test verifies that passing a runtime value to a comptime parameter
+    // produces a proper error message.
+    assert!(!errors.is_empty(), "Expected error for runtime value passed to comptime param, but got no errors");
+    
+    let error_msg = format!("{}", errors[0]);
+    assert!(
+        error_msg.contains("compile-time") || error_msg.contains("comptime"),
+        "Error should mention comptime: {}",
+        error_msg
+    );
 }
 
 #[test]
@@ -165,15 +162,17 @@ fn main(runtime_val: Int) -> Int:
 ";
 
     let errors = typecheck_source(source);
-    // NOTE: This test is for the error path which needs additional work.
-    // The happy path (comptime params with literals) works correctly.
-    // TODO: Ensure error is reported for runtime values passed to comptime params
-    if !errors.is_empty() {
-        let error_msg = format!("{}", errors[0]);
-        assert!(
-            error_msg.contains("compile-time") || error_msg.contains("comptime"),
-            "Error should mention comptime: {}",
-            error_msg
-        );
-    }
+    // This test verifies that passing a runtime value to a comptime parameter
+    // produces a proper error message.
+    assert!(
+        !errors.is_empty(),
+        "Expected error for runtime value passed to comptime param, but got no errors"
+    );
+
+    let error_msg = format!("{}", errors[0]);
+    assert!(
+        error_msg.contains("compile-time") || error_msg.contains("comptime"),
+        "Error should mention comptime: {}",
+        error_msg
+    );
 }


### PR DESCRIPTION
## Summary

Fixes #150

When a runtime value is passed to a function parameter marked as `comptime`, the typechecker now properly reports an error.

## Changes

- `checker.rs`: Changed `_comptime` to `is_comptime` in `check_call` and added comptime validation logic
- `comptime_integration_tests.rs`: Updated tests to properly assert errors are produced

## Testing

- All 9 comptime integration tests pass
- Full test suite passes locally

## Checklist

- [x] Issue created (#150)
- [x] Fix implemented
- [x] Tests updated
- [x] Tests pass locally
- [ ] CI passes
- [ ] PR merged