### PR TITLE
fix(runtime): correct file_read test failures and unignore tests

### DIFF
--- a/codebase/compiler/tests/file_io_tests.rs
+++ b/codebase/compiler/tests/file_io_tests.rs
@@ -80,7 +80,6 @@ fn compile_and_run(src: &str) -> (String, i32) {
 }
 
 #[test]
-#[ignore = "file_read runtime returns newline for nonexistent files (see runtime fix needed)"]
 fn test_file_write_and_read() {
     let src = r#"
 mod test
@@ -117,7 +116,6 @@ fn main() -> !{IO, FS} ():
 }
 
 #[test]
-#[ignore = "file_read runtime returns newline for nonexistent files (see runtime fix needed)"]
 fn test_file_exists() {
     let src = r#"
 mod test
@@ -143,7 +141,8 @@ fn main() -> !{IO, FS} ():
     print_status("After: ", file_exists(path))
     
     // Cleanup
-    file_delete(path)
+    let _ = file_delete(path)
+    ()
 "#;
     let (out, code) = compile_and_run(src);
     assert_eq!(code, 0, "Exit code should be 0, got: {}", out);
@@ -160,7 +159,6 @@ fn main() -> !{IO, FS} ():
 }
 
 #[test]
-#[ignore = "file_read runtime returns newline for nonexistent files (see runtime fix needed)"]
 fn test_file_append() {
     let src = r#"
 mod test
@@ -183,7 +181,8 @@ fn main() -> !{IO, FS} ():
     println("Content: " + file_read(path))
     
     // Cleanup
-    file_delete(path)
+    let _ = file_delete(path)
+    ()
 "#;
     let (out, code) = compile_and_run(src);
     assert_eq!(code, 0, "Exit code should be 0, got: {}", out);
@@ -205,7 +204,6 @@ fn main() -> !{IO, FS} ():
 }
 
 #[test]
-#[ignore = "file_read runtime returns newline for nonexistent files (see runtime fix needed)"]
 fn test_file_delete() {
     let src = r#"
 mod test
@@ -254,7 +252,6 @@ fn main() -> !{IO, FS} ():
 }
 
 #[test]
-#[ignore = "file_read runtime returns newline for nonexistent files (see runtime fix needed)"]
 fn test_file_delete_nonexistent() {
     let src = r#"
 mod test
@@ -283,7 +280,6 @@ fn main() -> !{IO, FS} ():
 }
 
 #[test]
-#[ignore = "file_read runtime returns newline for nonexistent files (see runtime fix needed)"]
 fn test_file_read_empty_for_nonexistent() {
     let src = r#"
 mod test
@@ -310,7 +306,6 @@ fn main() -> !{IO, FS} ():
 }
 
 #[test]
-#[ignore = "file_read runtime returns newline for nonexistent files (see runtime fix needed)"]
 fn test_file_operations_workflow() {
     let src = r#"
 mod test


### PR DESCRIPTION
## Summary

Fixes #155

The file_read runtime was already correctly returning empty string for nonexistent files. The issue was type errors in the test Gradient code.

## Root Cause Analysis

Upon investigation, the runtime `__gradient_file_read` function in `gradient_runtime.c` was already correctly handling nonexistent files by returning `strdup()` (empty string) when `fopen` fails.

The actual issue was in the test code:
- `test_file_exists` and `test_file_append` ended with `file_delete(path)` which returns `Bool`
- The `main` function expected to return `()` (Unit)
- This caused type errors: `function `main` body has type `Bool`, expected `()``

## Changes

- Fixed test functions to explicitly return `()` after `file_delete` calls (using `let _ = file_delete(path)` followed by `()`)
- Removed `#[ignore]` attributes from all 7 file_io_tests

## Testing

All 7 file I/O tests now pass:
- `test_file_write_and_read`
- `test_file_exists`
- `test_file_append`
- `test_file_delete`
- `test_file_delete_nonexistent`
- `test_file_read_empty_for_nonexistent`
- `test_file_operations_workflow`

Full test suite passes locally.

## Semantics

`file_read` on nonexistent paths returns an empty string (`""`), consistent with the documented behavior in the runtime code comments. This provides a clean, predictable failure model without requiring NULL handling.