### PR TITLE
feat(compiler): improve comptime error diagnostics for runtime values

### DIFF
--- a/codebase/compiler/src/typechecker/checker.rs
+++ b/codebase/compiler/src/typechecker/checker.rs
@@ -2792,7 +2792,24 @@ impl TypeChecker {
                 // Validate comptime parameters.
                 if *is_comptime {
                     if let Err(e) = self.require_comptime(arg) {
-                        self.errors.push(e);
+                        // Enhance the error with comptime parameter context
+                        let mut enhanced = TypeError::new(
+                            format!(
+                                "runtime value passed to comptime parameter `{}`",
+                                param_name
+                            ),
+                            arg.span,
+                        );
+                        enhanced = enhanced.with_note(format!(
+                            "parameter `{}` is marked `comptime` and requires a compile-time known value",
+                            param_name
+                        ));
+                        // Include the original error message as an additional note
+                        enhanced = enhanced.with_note(e.message);
+                        enhanced = enhanced.with_note(
+                            "to fix: either remove `comptime` from the parameter, or pass a literal or comptime-known value"
+                        );
+                        self.errors.push(enhanced);
                     }
                 }
 
@@ -5411,7 +5428,24 @@ impl TypeChecker {
                 has_comptime_params = true;
                 // Check that the argument is comptime-evaluable.
                 if let Err(e) = self.require_comptime(arg) {
-                    self.errors.push(e);
+                    // Enhance the error with comptime parameter context
+                    let mut enhanced = TypeError::new(
+                        format!(
+                            "runtime value passed to comptime parameter `{}`",
+                            param_name
+                        ),
+                        arg.span,
+                    );
+                    enhanced = enhanced.with_note(format!(
+                        "parameter `{}` is marked `comptime` and requires a compile-time known value",
+                        param_name
+                    ));
+                    // Include the original error message as an additional note
+                    enhanced = enhanced.with_note(e.message);
+                    enhanced = enhanced.with_note(
+                        "to fix: either remove `comptime` from the parameter, or pass a literal or comptime-known value"
+                    );
+                    self.errors.push(enhanced);
                 } else {
                     // Try to evaluate the argument to a comptime value.
                     match self.try_eval_comptime(arg) {


### PR DESCRIPTION
## Summary

When a runtime value is passed to a comptime parameter, the error message now clearly identifies:
- The specific parameter name (e.g., `runtime value passed to comptime parameter `x``)
- That the parameter is marked `comptime` and requires a compile-time known value
- How to fix (either remove `comptime` from the parameter, or pass a literal/comptime-known value)

## Changes

Enhanced error diagnostics in two locations in `checker.rs`:
- Line ~2792: Function call comptime parameter validation
- Line ~5411: Qualified call comptime parameter validation

Both now wrap the original `require_comptime` error with context-specific messages that include:
1. Clear error stating it's a runtime value passed to a comptime parameter
2. Note explaining the parameter requires a compile-time known value
3. The original error message as context
4. Actionable fix suggestion

## Testing

- All 9 comptime integration tests pass
- Full compiler test suite passes
- Verified new error format:
  ```
  ERROR: runtime value passed to comptime parameter `x`
    NOTE: parameter `x` is marked `comptime` and requires a compile-time known value
    NOTE: expected compile-time value, but `runtime_val` is a runtime value
    NOTE: to fix: either remove `comptime` from the parameter, or pass a literal or comptime-known value
  ```

Fixes #160