### PR TITLE
sec/wave-1: Emergency stops — C-3, C-5, H-3, H-4, M-2, L-4, L-7 + WASM gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,16 +109,16 @@ jobs:
           workspaces: codebase
       - name: Build compiler with WASM feature
         working-directory: codebase
-        run: cargo build -p gradient-compiler --features wasm
+        run: cargo build -p gradient-compiler --features wasm-unstable
       - name: Clippy with WASM feature
         working-directory: codebase
-        run: cargo clippy -p gradient-compiler --features wasm -- -D warnings
+        run: cargo clippy -p gradient-compiler --features wasm-unstable -- -D warnings
       - name: Run WASM unit tests
         working-directory: codebase
-        run: cargo test -p gradient-compiler --features wasm --test wasm_tests
+        run: cargo test -p gradient-compiler --features wasm-unstable --test wasm_tests
       - name: Run WASM E2E tests
         working-directory: codebase
-        run: cargo test -p gradient-compiler --features wasm --test wasm_e2e_tests
+        run: cargo test -p gradient-compiler --features wasm-unstable --test wasm_e2e_tests
       - name: Install wasmtime
         run: |
           curl https://wasmtime.dev/install.sh -sSf | bash
@@ -128,7 +128,7 @@ jobs:
         run: |
           echo 'fn main() -> Int:' > /tmp/test.gr
           echo '    ret 42' >> /tmp/test.gr
-          cargo run --quiet --bin gradient-compiler --features wasm -- /tmp/test.gr /tmp/test.wasm --experimental
+          cargo run --quiet --bin gradient-compiler --features wasm-unstable -- /tmp/test.gr /tmp/test.wasm --experimental
           ls -la /tmp/test.wasm
           echo "WASM file generated successfully"
       - name: Validate WASM with wasmtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+## [Unreleased]
+
+### Security
+
+#### Wave 1 — Emergency Stops (2026-04-23)
+
+- **C-3** (`runtime/gradient_runtime.c`): Guard `malloc(size+1)` in
+  `__gradient_file_read` against `ftell()` returning −1 on non-seekable files
+  (pipes, `/proc/*`).  Falls back to incremental buffered read instead of
+  passing a wrapped `size_t` value to `malloc`.
+
+- **C-5** (`runtime/gradient_runtime.c`): Harden `__gradient_http_get` and
+  `http_post_impl` against protocol-downgrade and SSRF attacks:
+  `CURLOPT_PROTOCOLS_STR="https"`, `CURLOPT_REDIR_PROTOCOLS_STR="https"`,
+  `CURLOPT_MAXREDIRS=5`, `CURLOPT_SSL_VERIFYPEER=1`,
+  `CURLOPT_SSL_VERIFYHOST=2`.
+
+- **H-3** (`runtime/gradient_runtime.c`): Introduce `safe_realloc(ptr, size)`
+  wrapper that `free()`s the original pointer and calls `abort()` on `NULL`
+  return. Replaced all seven raw `realloc` call sites (map growth, curl
+  receive buffer, JSON string/array buffers, `json_buf_append`,
+  `stringbuilder_grow`).
+
+- **H-4** (`runtime/gradient_runtime.c`): Add `depth` counter to `JsonParser`
+  and a `MAX_JSON_DEPTH = 128` guard in `json_parse_array` and
+  `json_parse_object`. Deeply-nested inputs (depth-bomb payloads) now return a
+  parse error instead of consuming unbounded stack.
+
+- **M-2** (`scripts/install.sh`): Add `--locked` to the `cargo build` invocation
+  so installs are reproducible and cannot silently resolve different dependency
+  versions than those in `Cargo.lock`.
+
+- **L-4** (`build-system/src/commands/build.rs`): Replace the fixed
+  `/tmp/gradient_stdin_output.o` path with `tempfile::NamedTempFile` so
+  concurrent invocations and unprivileged users cannot race or predict the
+  output path.
+
+- **L-7** (`compiler/src/codegen/cranelift.rs`): Enable Cranelift's built-in IR
+  verifier (`enable_verifier = true`) in debug builds (`#[cfg(debug_assertions)]`)
+  to catch malformed IR early during development.
+
+- **WASM gate**: Renamed feature `wasm` → `wasm-unstable` in `Cargo.toml` and
+  all `#[cfg]` sites. The WASM backend is gated until C-1 (allocator OOB) and
+  C-2 (unconstrained WASI imports) are resolved. See `docs/WASM.md`.

--- a/codebase/Cargo.lock
+++ b/codebase/Cargo.lock
@@ -795,6 +795,7 @@ dependencies = [
  "semver",
  "serde",
  "sha2",
+ "tempfile",
  "tokio",
  "toml",
  "toml_edit",

--- a/codebase/build-system/Cargo.toml
+++ b/codebase/build-system/Cargo.toml
@@ -20,3 +20,4 @@ reqwest = { version = "0.11", features = ["json"] }
 semver = "1.0"
 tokio = { version = "1.0", features = ["rt-multi-thread"] }
 zip = "0.6"
+tempfile = "3"

--- a/codebase/build-system/src/commands/build.rs
+++ b/codebase/build-system/src/commands/build.rs
@@ -379,22 +379,29 @@ pub fn execute_stdin(
         }
     };
 
-    // Determine output file
-    let output_ext = if emit_ir { "ir" } else { "o" };
-    let output_file = std::env::temp_dir().join(format!("gradient_stdin_output.{}", output_ext));
+    // L-4: use a uniquely-named temp file to avoid races on the fixed path.
+    let output_suffix = if emit_ir { ".ir" } else { ".o" };
+    let temp_file = match tempfile::Builder::new()
+        .prefix("gradient_stdin_")
+        .suffix(output_suffix)
+        .tempfile()
+    {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error: Failed to create temp file: {}", e);
+            std::process::exit(1);
+        }
+    };
+    let output_path = temp_file.path().to_path_buf();
 
     if verbose {
-        println!("  Compiling from stdin -> {}", output_file.display());
+        println!("  Compiling from stdin -> {}", output_path.display());
     }
 
     // Build compiler command with stdin flag
     let mut cmd = std::process::Command::new(&compiler);
-    cmd.arg(
-        output_file
-            .to_str()
-            .unwrap_or("/tmp/gradient_stdin_output.o"),
-    )
-    .arg("--stdin");
+    cmd.arg(output_path.to_str().expect("temp path is valid UTF-8"))
+        .arg("--stdin");
 
     // Add flags for bootstrap testing
     if parse_only {
@@ -412,13 +419,17 @@ pub fn execute_stdin(
 
     let compile_status = cmd.status();
 
+    // Keep the NamedTempFile alive until after the compiler runs so the path
+    // remains valid; it is cleaned up when this binding drops.
+    let _ = temp_file;
+
     match compile_status {
         Ok(status) if status.success() => {
             if verbose {
                 if emit_ir {
-                    println!("  IR output written to: {}", output_file.display());
+                    println!("  IR output written to: {}", output_path.display());
                 } else {
-                    println!("  Compiled to: {}", output_file.display());
+                    println!("  Compiled to: {}", output_path.display());
                 }
             }
         }

--- a/codebase/compiler/Cargo.toml
+++ b/codebase/compiler/Cargo.toml
@@ -56,10 +56,11 @@ smt = ["z3"]
 # This is the new feature flag for Phase M contract verification.
 smt-verify = ["z3"]
 # Enable the WASM backend for WebAssembly output.
-# Usage: cargo build --features wasm
-wasm = ["wasm-encoder"]
+# UNSTABLE: gated pending C-1 (allocator OOB) and C-2 (WASI capability leak) fixes.
+# Usage: cargo build --features wasm-unstable
+wasm-unstable = ["wasm-encoder"]
 # Enable all backends.
-all-backends = ["llvm", "smt", "smt-verify", "wasm"]
+all-backends = ["llvm", "smt", "smt-verify", "wasm-unstable"]
 
 [dependencies.inkwell]
 # LLVM bindings for Rust. Only compiled when the `llvm` feature is enabled.

--- a/codebase/compiler/runtime/gradient_runtime.c
+++ b/codebase/compiler/runtime/gradient_runtime.c
@@ -51,6 +51,25 @@
 #include <time.h>
 #include <limits.h>
 
+/* ── H-3: safe_realloc ──────────────────────────────────────────────────── */
+
+/*
+ * safe_realloc(ptr, size) -> void*
+ *
+ * Wraps realloc: if the allocation fails, frees the original pointer and
+ * calls abort() so callers never receive a NULL without a stack trace.
+ * Use this everywhere a failed realloc would otherwise leave dangling
+ * memory or cause a use-after-free.
+ */
+static void* safe_realloc(void* ptr, size_t size) {
+    void* result = realloc(ptr, size);
+    if (!result) {
+        free(ptr);
+        abort();
+    }
+    return result;
+}
+
 /* ── Program arguments ─────────────────────────────────────────────────── */
 
 static int    __gradient_saved_argc = 0;
@@ -134,6 +153,10 @@ char* __gradient_read_line(void) {
  * Reads the entire contents of the file at `path` and returns a
  * heap-allocated, null-terminated string.  Returns an empty string
  * (not NULL) on any error so callers never have to handle NULL.
+ *
+ * C-3 fix: ftell() returns -1 for non-seekable files (e.g. /proc/*).
+ * When size < 0, fall back to an incremental read so we never pass a
+ * negative value to malloc().
  */
 char* __gradient_file_read(const char* path) {
     FILE* f = fopen(path, "r");
@@ -143,7 +166,27 @@ char* __gradient_file_read(const char* path) {
     long size = ftell(f);
     rewind(f);
 
-    char* buf = (char*)malloc(size + 1);
+    if (size < 0) {
+        /* Non-seekable file: read incrementally. */
+        size_t cap = 4096, len = 0;
+        char* buf = (char*)malloc(cap);
+        if (!buf) { fclose(f); return strdup(""); }
+        size_t n;
+        while ((n = fread(buf + len, 1, cap - len, f)) > 0) {
+            len += n;
+            if (len == cap) {
+                char* tmp = (char*)realloc(buf, cap * 2);
+                if (!tmp) { free(buf); fclose(f); return strdup(""); }
+                buf = tmp;
+                cap *= 2;
+            }
+        }
+        buf[len] = '\0';
+        fclose(f);
+        return buf;
+    }
+
+    char* buf = (char*)malloc((size_t)size + 1);
     if (!buf) {
         fclose(f);
         return strdup("");
@@ -762,8 +805,8 @@ static int64_t map_find(GradientMap* m, const char* key) {
 /* Internal: grow the map arrays by 2x. */
 static void map_grow(GradientMap* m) {
     int64_t new_cap = m->capacity * 2;
-    m->keys   = (char**)realloc(m->keys,   (size_t)new_cap * sizeof(char*));
-    m->values = (int64_t*)realloc(m->values, (size_t)new_cap * sizeof(int64_t));
+    m->keys   = (char**)safe_realloc(m->keys,   (size_t)new_cap * sizeof(char*));
+    m->values = (int64_t*)safe_realloc(m->values, (size_t)new_cap * sizeof(int64_t));
     /* Zero out new slots. */
     for (int64_t i = m->capacity; i < new_cap; i++) {
         m->keys[i]   = NULL;
@@ -1354,9 +1397,7 @@ typedef struct {
 static size_t curl_write_cb(void* contents, size_t size, size_t nmemb, void* userp) {
     size_t total = size * nmemb;
     CurlBuffer* buf = (CurlBuffer*)userp;
-    char* tmp = (char*)realloc(buf->data, buf->size + total + 1);
-    if (!tmp) return 0;
-    buf->data = tmp;
+    buf->data = (char*)safe_realloc(buf->data, buf->size + total + 1);
     memcpy(buf->data + buf->size, contents, total);
     buf->size += total;
     buf->data[buf->size] = '\0';
@@ -1389,6 +1430,12 @@ void* __gradient_http_get(const char* url) {
     CurlBuffer buf = { .data = (char*)malloc(1), .size = 0 };
     buf.data[0] = '\0';
 
+    /* C-5: restrict protocols, enforce TLS verification, cap redirects. */
+    curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "https");
+    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "https");
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
     curl_easy_setopt(curl, CURLOPT_URL, url);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buf);
@@ -1432,6 +1479,12 @@ static void* http_post_impl(const char* url, const char* body,
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
     }
 
+    /* C-5: restrict protocols, enforce TLS verification, cap redirects. */
+    curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "https");
+    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "https");
+    curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 5L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
     curl_easy_setopt(curl, CURLOPT_URL, url);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body ? body : "");
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_cb);
@@ -1546,9 +1599,13 @@ static void* json_object(void* map_ptr) {
     return (void*)p;
 }
 
+/* H-4: maximum nesting depth for JSON arrays and objects. */
+#define MAX_JSON_DEPTH 128
+
 typedef struct {
     const char* input;
     size_t pos;
+    int depth;
     char error[256];
 } JsonParser;
 
@@ -1609,13 +1666,8 @@ static char* json_parse_string_raw(JsonParser* p) {
 
         if (len + 2 > cap) {
             cap *= 2;
-            char* tmp = (char*)realloc(buf, cap);
-            if (!tmp) {
-                free(buf);
-                json_set_error(p, "out of memory while growing string buffer");
-                return NULL;
-            }
-            buf = tmp;
+            /* H-3: safe_realloc aborts on OOM rather than silently leaking. */
+            buf = (char*)safe_realloc(buf, cap);
         }
         buf[len++] = ch;
     }
@@ -1656,6 +1708,12 @@ static void* json_parse_number(JsonParser* p) {
 }
 
 static void* json_parse_array(JsonParser* p) {
+    /* H-4: depth-bomb guard. */
+    if (p->depth >= MAX_JSON_DEPTH) {
+        json_set_error(p, "JSON nesting depth limit (%d) exceeded", MAX_JSON_DEPTH);
+        return NULL;
+    }
+    p->depth++;
     p->pos++;
     json_skip_ws(p);
 
@@ -1663,6 +1721,7 @@ static void* json_parse_array(JsonParser* p) {
     int64_t len = 0;
     int64_t* items = (int64_t*)malloc((size_t)(cap * 8));
     if (!items) {
+        p->depth--;
         json_set_error(p, "out of memory while parsing array");
         return NULL;
     }
@@ -1676,22 +1735,14 @@ static void* json_parse_array(JsonParser* p) {
                     json_free_value((void*)(intptr_t)items[i]);
                 }
                 free(items);
+                p->depth--;
                 return NULL;
             }
 
             if (len >= cap) {
                 cap *= 2;
-                int64_t* tmp = (int64_t*)realloc(items, (size_t)(cap * 8));
-                if (!tmp) {
-                    json_free_value(val);
-                    for (int64_t i = 0; i < len; i++) {
-                        json_free_value((void*)(intptr_t)items[i]);
-                    }
-                    free(items);
-                    json_set_error(p, "out of memory while growing array");
-                    return NULL;
-                }
-                items = tmp;
+                /* H-3: safe_realloc aborts on OOM rather than silently leaking. */
+                items = (int64_t*)safe_realloc(items, (size_t)(cap * 8));
             }
             items[len++] = (int64_t)(intptr_t)val;
 
@@ -1706,6 +1757,7 @@ static void* json_parse_array(JsonParser* p) {
                 json_free_value((void*)(intptr_t)items[i]);
             }
             free(items);
+            p->depth--;
             json_set_error(p, "expected ',' or ']' at pos %zu", p->pos);
             return NULL;
         }
@@ -1718,6 +1770,7 @@ static void* json_parse_array(JsonParser* p) {
             json_free_value((void*)(intptr_t)items[i]);
         }
         free(items);
+        p->depth--;
         json_set_error(p, "out of memory while finalizing array");
         return NULL;
     }
@@ -1725,15 +1778,23 @@ static void* json_parse_array(JsonParser* p) {
     list[1] = len;
     memcpy(list + 2, items, (size_t)(len * 8));
     free(items);
+    p->depth--;
     return json_array((void*)list);
 }
 
 static void* json_parse_object(JsonParser* p) {
+    /* H-4: depth-bomb guard. */
+    if (p->depth >= MAX_JSON_DEPTH) {
+        json_set_error(p, "JSON nesting depth limit (%d) exceeded", MAX_JSON_DEPTH);
+        return NULL;
+    }
+    p->depth++;
     p->pos++;
     json_skip_ws(p);
 
     GradientMap* map = (GradientMap*)__gradient_map_new();
     if (!map) {
+        p->depth--;
         json_set_error(p, "out of memory while parsing object");
         return NULL;
     }
@@ -1744,6 +1805,7 @@ static void* json_parse_object(JsonParser* p) {
             char* key = json_parse_string_raw(p);
             if (!key) {
                 map_destroy(map);
+                p->depth--;
                 return NULL;
             }
 
@@ -1751,6 +1813,7 @@ static void* json_parse_object(JsonParser* p) {
             if (p->input[p->pos] != ':') {
                 free(key);
                 map_destroy(map);
+                p->depth--;
                 json_set_error(p, "expected ':' at pos %zu", p->pos);
                 return NULL;
             }
@@ -1761,6 +1824,7 @@ static void* json_parse_object(JsonParser* p) {
             if (!val) {
                 free(key);
                 map_destroy(map);
+                p->depth--;
                 return NULL;
             }
 
@@ -1777,12 +1841,14 @@ static void* json_parse_object(JsonParser* p) {
             if (p->input[p->pos] == '}') break;
 
             map_destroy(map);
+            p->depth--;
             json_set_error(p, "expected ',' or '}' at pos %zu", p->pos);
             return NULL;
         }
     }
 
     p->pos++;
+    p->depth--;
     return json_object((void*)map);
 }
 
@@ -1818,7 +1884,7 @@ static void* json_parse_value(JsonParser* p) {
 }
 
 void* __gradient_json_parse(const char* input, int64_t* out_ok) {
-    JsonParser parser = { .input = input ? input : "", .pos = 0, .error = {0} };
+    JsonParser parser = { .input = input ? input : "", .pos = 0, .depth = 0, .error = {0} };
     void* result = json_parse_value(&parser);
     if (!result || parser.error[0]) {
         *out_ok = 0;
@@ -1842,7 +1908,7 @@ static void json_buf_append(char** buf, size_t* len, size_t* cap, const char* s)
     size_t slen = strlen(s);
     while (*len + slen + 1 > *cap) {
         *cap *= 2;
-        *buf = (char*)realloc(*buf, *cap);
+        *buf = (char*)safe_realloc(*buf, *cap);
     }
     memcpy(*buf + *len, s, slen);
     *len += slen;
@@ -5183,9 +5249,7 @@ static int stringbuilder_grow(GradientStringBuilder* sb, int64_t min_capacity) {
         new_capacity *= 2;
     }
 
-    char* new_buffer = (char*)realloc(sb->buffer, new_capacity);
-    if (!new_buffer) return -1;
-
+    char* new_buffer = (char*)safe_realloc(sb->buffer, new_capacity);
     sb->buffer = new_buffer;
     sb->capacity = new_capacity;
     return 0;

--- a/codebase/compiler/src/backend/mod.rs
+++ b/codebase/compiler/src/backend/mod.rs
@@ -3,8 +3,8 @@
 //! This module contains the various code generation backends that translate
 //! Gradient IR into target-specific output formats.
 
-#[cfg(feature = "wasm")]
+#[cfg(feature = "wasm-unstable")]
 pub mod wasm;
 
-#[cfg(feature = "wasm")]
+#[cfg(feature = "wasm-unstable")]
 pub use wasm::WasmBackend;

--- a/codebase/compiler/src/codegen/cranelift.rs
+++ b/codebase/compiler/src/codegen/cranelift.rs
@@ -239,6 +239,11 @@ impl CraneliftCodegen {
         settings_builder
             .set("is_pic", "true")
             .map_err(|e| format!("Failed to set is_pic: {}", e))?;
+        // L-7: enable Cranelift's IR verifier in debug builds to catch malformed IR early.
+        #[cfg(debug_assertions)]
+        settings_builder
+            .set("enable_verifier", "true")
+            .map_err(|e| format!("Failed to set enable_verifier: {}", e))?;
 
         let flags = settings::Flags::new(settings_builder);
 

--- a/codebase/compiler/src/codegen/mod.rs
+++ b/codebase/compiler/src/codegen/mod.rs
@@ -37,7 +37,7 @@
 pub mod cranelift;
 #[cfg(feature = "llvm")]
 pub mod llvm;
-#[cfg(feature = "wasm")]
+#[cfg(feature = "wasm-unstable")]
 pub mod wasm;
 
 use crate::ir;
@@ -129,7 +129,7 @@ pub fn llvm_available() -> bool {
 pub enum BackendWrapper {
     #[cfg(feature = "llvm")]
     Llvm(llvm::LlvmCodegen<'static>),
-    #[cfg(feature = "wasm")]
+    #[cfg(feature = "wasm-unstable")]
     Wasm(wasm::WasmBackend),
     Cranelift(CraneliftCodegen),
 }
@@ -174,11 +174,11 @@ impl BackendWrapper {
     pub fn new_with_backend(backend_type: &str) -> Result<Self, CodegenError> {
         match backend_type {
             "wasm" => {
-                #[cfg(feature = "wasm")]
+                #[cfg(feature = "wasm-unstable")]
                 {
                     Ok(BackendWrapper::Wasm(wasm::WasmBackend::new()?))
                 }
-                #[cfg(not(feature = "wasm"))]
+                #[cfg(not(feature = "wasm-unstable"))]
                 {
                     Err(CodegenError::from(
                         "WASM backend not available (compiled without wasm feature)",
@@ -213,7 +213,7 @@ impl BackendWrapper {
         match self {
             #[cfg(feature = "llvm")]
             BackendWrapper::Llvm(codegen) => codegen.name(),
-            #[cfg(feature = "wasm")]
+            #[cfg(feature = "wasm-unstable")]
             BackendWrapper::Wasm(backend) => backend.name(),
             BackendWrapper::Cranelift(cg) => cg.name(),
         }
@@ -233,7 +233,7 @@ impl CodegenBackend for BackendWrapper {
         match self {
             #[cfg(feature = "llvm")]
             BackendWrapper::Llvm(codegen) => codegen.compile_module(module),
-            #[cfg(feature = "wasm")]
+            #[cfg(feature = "wasm-unstable")]
             BackendWrapper::Wasm(backend) => backend.compile_module(module),
             BackendWrapper::Cranelift(cg) => cg.compile_module(module).map_err(CodegenError::from),
         }
@@ -248,7 +248,7 @@ impl CodegenBackend for BackendWrapper {
                 // So we use the trait method through the wrapper
                 codegen.emit_bytes()
             }
-            #[cfg(feature = "wasm")]
+            #[cfg(feature = "wasm-unstable")]
             BackendWrapper::Wasm(backend) => {
                 let boxed: Box<dyn CodegenBackend> = Box::new(backend);
                 boxed.finish()

--- a/codebase/compiler/src/main.rs
+++ b/codebase/compiler/src/main.rs
@@ -659,7 +659,7 @@ fn main() {
                 let available_backends = format!(
                     "cranelift{}{}",
                     if cfg!(feature = "llvm") { ", llvm" } else { "" },
-                    if cfg!(feature = "wasm") { ", wasm" } else { "" }
+                    if cfg!(feature = "wasm-unstable") { ", wasm (unstable)" } else { "" }
                 );
                 eprintln!(
                     "Error: Failed to initialize '{}' backend: {}\nAvailable backends: {}",

--- a/codebase/compiler/tests/runtime_security_regressions.rs
+++ b/codebase/compiler/tests/runtime_security_regressions.rs
@@ -41,8 +41,11 @@ fn runtime_c_path() -> String {
         .to_string()
 }
 
+/// C-3 regression: ftell() returns -1 on non-seekable / virtual files.
+/// Before the fix, malloc(-1 + 1) == malloc(0) on Linux (UB) and wraps to
+/// ULONG_MAX on platforms where size_t is unsigned.  The fix guards size < 0.
 #[test]
-fn file_read_returns_empty_on_ftell_failure_paths() {
+fn file_read_nonseekable_proc_file_no_crash() {
     let runtime_c = runtime_c_path();
     let source = format!(
         r#"#include <stdlib.h>
@@ -51,15 +54,24 @@ fn file_read_returns_empty_on_ftell_failure_paths() {
 #include "{runtime_c}"
 
 int main(void) {{
-    char* content = __gradient_file_read("/proc/self/maps");
+    /* /proc/self/cmdline: virtual file where ftell() may return 0 or -1.
+     * Either way, reading must not crash and must return non-NULL. */
+    char* content = __gradient_file_read("/proc/self/cmdline");
     if (content == NULL) {{
         return 1;
     }}
-    if (strcmp(content, "") != 0) {{
-        free(content);
+    free(content);
+
+    /* Non-existent path returns empty string, not NULL. */
+    char* missing = __gradient_file_read("/nonexistent_gradient_test_path_xyz");
+    if (missing == NULL) {{
         return 2;
     }}
-    free(content);
+    if (strcmp(missing, "") != 0) {{
+        free(missing);
+        return 3;
+    }}
+    free(missing);
     return 0;
 }}
 "#
@@ -316,4 +328,84 @@ mod agent_security_tests {
 
         assert!(result.is_ok(), "Valid relative paths should be accepted");
     }
+}
+
+/// H-4 regression: deeply-nested JSON must return a parse error, not crash.
+#[test]
+fn json_depth_bomb_returns_parse_error() {
+    let runtime_c = runtime_c_path();
+    let source = format!(
+        r#"#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "{runtime_c}"
+
+int main(void) {{
+    /* Build a 200-deep array nesting: [[[ ... ]]] */
+    char* input = (char*)malloc(200 * 2 + 1);
+    if (!input) return 1;
+    int pos = 0;
+    for (int i = 0; i < 200; i++) input[pos++] = '[';
+    for (int i = 0; i < 200; i++) input[pos++] = ']';
+    input[pos] = '\0';
+
+    int64_t ok = 0;
+    void* result = __gradient_json_parse(input, &ok);
+    free(input);
+
+    /* Must report failure, not crash. */
+    if (ok != 0) {{
+        return 2;
+    }}
+    /* Error message pointer must be non-NULL. */
+    if (!result) {{
+        return 3;
+    }}
+    free(result);
+    return 0;
+}}
+"#
+    );
+
+    build_and_run_c_harness("json_depth_bomb_regression", "cc", &[], &source);
+}
+
+/// H-4 regression: JSON at exactly MAX_JSON_DEPTH must parse successfully.
+#[test]
+fn json_at_max_depth_parses_ok() {
+    let runtime_c = runtime_c_path();
+    let source = format!(
+        r#"#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "{runtime_c}"
+
+int main(void) {{
+    /* Build a 128-deep array (exactly at the limit with a value inside). */
+    char* input = (char*)malloc(128 * 2 + 2);
+    if (!input) return 1;
+    int pos = 0;
+    for (int i = 0; i < 128; i++) input[pos++] = '[';
+    input[pos++] = '1';
+    for (int i = 0; i < 128; i++) input[pos++] = ']';
+    input[pos] = '\0';
+
+    int64_t ok = 0;
+    void* result = __gradient_json_parse(input, &ok);
+    free(input);
+
+    if (ok != 1 || !result) {{
+        return 2;
+    }}
+    /* json_free_value is internal; just exit (process cleanup handles it). */
+    return 0;
+}}
+"#
+    );
+
+    build_and_run_c_harness("json_max_depth_regression", "cc", &[], &source);
 }

--- a/codebase/compiler/tests/wasm_e2e_tests.rs
+++ b/codebase/compiler/tests/wasm_e2e_tests.rs
@@ -3,7 +3,7 @@
 //! These tests construct Gradient IR, compile to WASM, and verify the output.
 //! When wasmtime is available, tests also run the compiled binary.
 
-#[cfg(feature = "wasm")]
+#[cfg(feature = "wasm-unstable")]
 mod e2e_tests {
     use gradient_compiler::backend::WasmBackend;
     use gradient_compiler::codegen::CodegenBackend;
@@ -498,7 +498,7 @@ mod e2e_tests {
     }
 }
 
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(feature = "wasm-unstable"))]
 mod e2e_tests {
     // Empty module when wasm feature is not enabled
 }

--- a/codebase/compiler/tests/wasm_tests.rs
+++ b/codebase/compiler/tests/wasm_tests.rs
@@ -3,7 +3,7 @@
 //! These tests verify that the WASM backend can compile Gradient IR
 //! into valid WebAssembly binaries that can be run with wasmtime.
 
-#[cfg(feature = "wasm")]
+#[cfg(feature = "wasm-unstable")]
 mod wasm_tests {
     use gradient_compiler::backend::WasmBackend;
     use gradient_compiler::codegen::CodegenBackend;
@@ -353,7 +353,7 @@ mod wasm_tests {
     }
 }
 
-#[cfg(not(feature = "wasm"))]
+#[cfg(not(feature = "wasm-unstable"))]
 mod wasm_tests {
     // Empty module when wasm feature is not enabled
 }

--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -1,0 +1,34 @@
+# WebAssembly Backend (Unstable)
+
+The Gradient WASM backend is currently **gated behind the `wasm-unstable` feature flag** and is not enabled in default or release builds.
+
+## Why is it gated?
+
+Two open security findings must be resolved before the WASM backend is considered production-ready:
+
+- **C-1** — The bump allocator does not call `memory.grow` before writing past the initial page boundary, which can cause silent out-of-bounds writes that corrupt data-section content.
+- **C-2** — WASI imports (`fd_write`, `proc_exit`, etc.) are emitted unconditionally regardless of which effects the compiled module actually uses. A pure function module should emit zero WASI imports.
+
+Tracking issue: GRA-42 Security HUB.
+
+## Enabling the WASM backend
+
+```sh
+cargo build --features wasm-unstable
+```
+
+When invoking the compiler, select the WASM backend with `--backend wasm`.
+
+## Running WASM output
+
+Use a runtime that enforces capability isolation, and always supply only the directories and environment variables the module actually needs:
+
+```sh
+wasmtime --dir=./data --env=HOME=/tmp output.wasm
+```
+
+Do **not** run WASM output with `--dir=/` or without explicit `--dir` / `--env` restrictions.
+
+## Roadmap
+
+The `wasm-unstable` gate will be removed once C-1 and C-2 fixes land and their test suite passes (see Wave 2 of the security remediation plan).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -113,7 +113,7 @@ fi
 cd "$REPO_ROOT"
 
 echo "==> Building Gradient (release) from $MANIFEST_PATH"
-cargo build --release --manifest-path "$MANIFEST_PATH"
+cargo build --release --locked --manifest-path "$MANIFEST_PATH"
 
 echo
 echo "==> Installing symlinks into $PREFIX"


### PR DESCRIPTION
## Summary

Wave 1 of the security remediation plan (GRA-79). Emergency-stop fixes for 7 findings from the security audit:

- **C-3** — Guard `ftell()=-1` in `__gradient_file_read`; fall back to incremental read for non-seekable files so we never call `malloc(size+1)` with a negative `size`.
- **C-5** — Restrict libcurl to HTTPS-only in both GET and POST paths: `CURLOPT_PROTOCOLS_STR="https"`, `CURLOPT_REDIR_PROTOCOLS_STR="https"`, `CURLOPT_MAXREDIRS=5`, `CURLOPT_SSL_VERIFYPEER=1`, `CURLOPT_SSL_VERIFYHOST=2`.
- **H-3** — Introduce `safe_realloc()` wrapper that `free()`s the original and calls `abort()` on NULL; replaces all 7 raw `realloc` sites.
- **H-4** — Add `depth` counter to `JsonParser`; `MAX_JSON_DEPTH=128` guard in `json_parse_array` and `json_parse_object` — depth-bomb inputs return a parse error instead of unbounded recursion.
- **M-2** — Add `--locked` to `cargo build` in `scripts/install.sh`.
- **L-4** — Replace fixed `/tmp/gradient_stdin_output.o` with `tempfile::NamedTempFile` to eliminate TOCTOU races.
- **L-7** — Enable Cranelift IR verifier (`enable_verifier=true`) under `#[cfg(debug_assertions)]`.
- **WASM gate** — Rename feature `wasm` → `wasm-unstable` pending C-1/C-2 fixes; add `docs/WASM.md`.

Source-breaking: none in core. The `wasm-unstable` rename affects users building with `--features wasm` — they must switch to `--features wasm-unstable`. WASM was already experimental.

## Test plan

- [x] `cargo test --workspace` — all tests pass
- [x] `json_depth_bomb_returns_parse_error` — 200-deep depth-bomb returns parse error, no crash
- [x] `json_at_max_depth_parses_ok` — 128-deep array parses successfully
- [x] `file_read_nonseekable_proc_file_no_crash` — reading `/proc/self/cmdline` does not crash
- [x] `cargo build --workspace` — clean build, no unexpected_cfg warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)