### PR TITLE
fix(tests): resolve wave-2 WASM e2e regression, flaky security tests, and lints (GRA-92)

### DIFF
--- a/codebase/compiler/src/backend/wasm.rs
+++ b/codebase/compiler/src/backend/wasm.rs
@@ -152,7 +152,7 @@ impl WasmBackend {
         let mut exports = ExportSection::new();
         let functions = FunctionSection::new();
         let code = CodeSection::new();
-        let mut imports = ImportSection::new();
+        let imports = ImportSection::new();
         let mut globals = GlobalSection::new();
         let mut memories = MemorySection::new();
         let data = DataSection::new();

--- a/codebase/compiler/tests/runtime_security_regressions.rs
+++ b/codebase/compiler/tests/runtime_security_regressions.rs
@@ -261,27 +261,30 @@ int main(void) {{
 mod agent_security_tests {
     use std::env;
     use std::fs;
+    use std::sync::Mutex;
     use tempfile::TempDir;
 
     use gradient_compiler::agent::handlers::handle_load;
     use gradient_compiler::agent::protocol;
 
+    // env::set_current_dir is process-global; serialize all tests that use it
+    // to prevent race conditions when the test suite runs in parallel.
+    static CWD_LOCK: Mutex<()> = Mutex::new(());
+
     #[test]
     fn load_rejects_absolute_paths() {
+        let _guard = CWD_LOCK.lock().expect("cwd lock poisoned");
         let tmp = TempDir::new().expect("failed to create tempdir");
         let workspace_file = tmp.path().join("test.gr");
         fs::write(&workspace_file, "fn main() -> ():\n    ()\n").expect("write test file");
 
-        // Change to the temp directory as our "workspace"
         let original_dir = env::current_dir().expect("get current dir");
         env::set_current_dir(&tmp).expect("change to temp dir");
 
-        // Try to load with absolute path - should be rejected
         let params = serde_json::json!({"file": workspace_file.display().to_string()});
         let mut session = None;
         let result = handle_load(&params, &mut session);
 
-        // Restore original directory
         env::set_current_dir(original_dir).expect("restore original dir");
 
         assert!(result.is_err(), "Absolute paths should be rejected");
@@ -291,18 +294,16 @@ mod agent_security_tests {
 
     #[test]
     fn load_rejects_traversal_attempts() {
+        let _guard = CWD_LOCK.lock().expect("cwd lock poisoned");
         let tmp = TempDir::new().expect("failed to create tempdir");
 
-        // Change to the temp directory as our "workspace"
         let original_dir = env::current_dir().expect("get current dir");
         env::set_current_dir(&tmp).expect("change to temp dir");
 
-        // Try path traversal to escape workspace
         let params = serde_json::json!({"file": "../../../etc/passwd"});
         let mut session = None;
         let result = handle_load(&params, &mut session);
 
-        // Restore original directory
         env::set_current_dir(original_dir).expect("restore original dir");
 
         assert!(result.is_err(), "Path traversal should be rejected");
@@ -310,20 +311,18 @@ mod agent_security_tests {
 
     #[test]
     fn load_accepts_relative_paths_within_workspace() {
+        let _guard = CWD_LOCK.lock().expect("cwd lock poisoned");
         let tmp = TempDir::new().expect("failed to create tempdir");
         let workspace_file = tmp.path().join("test.gr");
         fs::write(&workspace_file, "fn main() -> ():\n    ()\n").expect("write test file");
 
-        // Change to the temp directory as our "workspace"
         let original_dir = env::current_dir().expect("get current dir");
         env::set_current_dir(&tmp).expect("change to temp dir");
 
-        // Try to load with relative path - should work
         let params = serde_json::json!({"file": "test.gr"});
         let mut session = None;
         let result = handle_load(&params, &mut session);
 
-        // Restore original directory
         env::set_current_dir(original_dir).expect("restore original dir");
 
         assert!(result.is_ok(), "Valid relative paths should be accepted");

--- a/codebase/compiler/tests/wasm_e2e_tests.rs
+++ b/codebase/compiler/tests/wasm_e2e_tests.rs
@@ -6,7 +6,6 @@
 #[cfg(feature = "wasm")]
 mod e2e_tests {
     use gradient_compiler::backend::WasmBackend;
-    use gradient_compiler::codegen::CodegenBackend;
     use gradient_compiler::ir::{
         BasicBlock, BlockRef, Function, Instruction, Literal, Module, Type, Value,
     };
@@ -410,8 +409,12 @@ mod e2e_tests {
         // Type section (1) - required for functions
         assert!(sections_found.contains_key(&1), "Missing Type section");
 
-        // Import section (2) - required for WASI
-        assert!(sections_found.contains_key(&2), "Missing Import section");
+        // Import section (2) - C-2: only present when IO builtins are used.
+        // This test module is pure (no IO calls), so no import section is expected.
+        assert!(
+            !sections_found.contains_key(&2),
+            "Pure module must not have an Import section (C-2 lazy WASI imports)"
+        );
 
         // Function section (3) - required
         assert!(sections_found.contains_key(&3), "Missing Function section");
@@ -428,7 +431,7 @@ mod e2e_tests {
         // Code section (10) - required for function bodies
         assert!(sections_found.contains_key(&10), "Missing Code section");
 
-        println!("All required sections present for WASI compatibility!");
+        println!("All required sections present; no WASI imports in pure module (C-2 verified)!");
     }
 
     /// Test: Compare output sizes for different program types.

--- a/codebase/compiler/tests/wasm_tests.rs
+++ b/codebase/compiler/tests/wasm_tests.rs
@@ -6,12 +6,10 @@
 #[cfg(feature = "wasm")]
 mod wasm_tests {
     use gradient_compiler::backend::WasmBackend;
-    use gradient_compiler::codegen::CodegenBackend;
     use gradient_compiler::ir::{
-        BasicBlock, BlockRef, Function, Instruction, Literal, Module, Type, Value,
+        BasicBlock, BlockRef, Function, Instruction, Module, Type, Value,
     };
     use std::collections::HashMap;
-    use std::io::Write;
     use std::process::Command;
 
     /// Test that we can compile a simple arithmetic function to WASM.


### PR DESCRIPTION
## Summary

Fixes three issues introduced by the wave-2 security PR (#168):

- **WASM E2E regression** (`wasm_e2e_tests.rs` line 414): `test_e2e_wasm_validation` asserted the Import section was present for a pure module. After C-2 (lazy WASI imports), pure modules correctly emit no Import section. Updated the assertion to verify absence instead, matching the C-2 invariant.

- **Flaky agent security tests** (`runtime_security_regressions.rs`): Three tests in `agent_security_tests` called `env::set_current_dir`, which is process-global. When run in parallel they raced with each other and with `handle_load`'s `env::current_dir()` call. Added a `static Mutex<()>` (`CWD_LOCK`) to serialize all three tests without requiring an external crate.

- **Lint warnings**: Removed `mut` from `imports` in `wasm.rs` (unused_mut), and removed unused imports (`Literal`, `std::io::Write`, `CodegenBackend`) from `wasm_tests.rs` and `wasm_e2e_tests.rs`. Zero warnings under `--features wasm`.

## Test plan

- [x] `cargo check --tests --features wasm` — zero warnings
- [x] `cargo test -p gradient-compiler --features wasm -- wasm` — 11 tests pass
- [x] `cargo test -p gradient-compiler --test runtime_security_regressions` — 7 tests pass, 1 ignored (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)