### PR TITLE
fix(wasm): register functions in FunctionSection and use TypeSection builder

### DIFF
--- a/codebase/compiler/src/backend/wasm.rs
+++ b/codebase/compiler/src/backend/wasm.rs
@@ -32,7 +32,7 @@ use std::collections::HashMap;
 use wasm_encoder::{
     BlockType, CodeSection, ConstExpr, DataSection, ExportKind, ExportSection, Function,
     FunctionSection, GlobalSection, GlobalType, ImportSection, Instruction as WasmInstr, MemArg,
-    MemorySection, MemoryType, Section, ValType,
+    MemorySection, MemoryType, Section, TypeSection, ValType,
 };
 
 /// Unique identifier for data segments (string literals, etc.)
@@ -137,8 +137,8 @@ pub struct WasmBackend {
     /// Current type index counter
     next_type_idx: u32,
 
-    /// Type section bytes (we'll build this manually)
-    type_section_bytes: Vec<u8>,
+    /// Type section builder
+    type_section: TypeSection,
 }
 
 impl WasmBackend {
@@ -206,7 +206,7 @@ impl WasmBackend {
             type_indices: Vec::new(),
             func_name_to_idx: HashMap::new(),
             next_type_idx: 0, // C-2: WASI type slots allocated lazily
-            type_section_bytes: Vec::new(),
+            type_section: TypeSection::new(),
         })
     }
 
@@ -285,8 +285,11 @@ impl WasmBackend {
         let func_idx = self.next_func_idx;
         self.next_func_idx += 1;
 
-        let _type_idx = self.next_type_idx;
+        let type_idx = self.next_type_idx;
         self.next_type_idx += 1;
+        self.type_section
+            .function([ValType::I32], [ValType::I32]);
+        self.functions.function(type_idx);
 
         // Locals: 5 extra i32s beyond the size param (local 0)
         let mut func = Function::new([(5, ValType::I32)]);
@@ -362,6 +365,11 @@ impl WasmBackend {
         if !self.needs_fd_write {
             let type_idx = self.next_type_idx;
             self.next_type_idx += 1;
+            // fd_write: (i32, i32, i32, i32) -> i32
+            self.type_section.function(
+                [ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+                [ValType::I32],
+            );
             let import_idx = self.next_func_idx;
             self.next_func_idx += 1;
             self.imports.import(
@@ -375,6 +383,13 @@ impl WasmBackend {
 
         let func_idx = self.next_func_idx;
         self.next_func_idx += 1;
+
+        let type_idx = self.next_type_idx;
+        self.next_type_idx += 1;
+        // println wrapper: (ptr: i32, len: i32) -> i32
+        self.type_section
+            .function([ValType::I32, ValType::I32], [ValType::I32]);
+        self.functions.function(type_idx);
 
         // WASI fd_write signature: fd_write(fd: i32, iovs: i32, iovs_len: i32, nwritten: i32) -> i32
         // fd = 1 for stdout
@@ -498,10 +513,35 @@ impl WasmBackend {
         Ok(())
     }
 
+    /// Map an IR type to its WASM ValType, returning None for Void.
+    fn ir_type_to_val_type(ty: &ir::Type) -> Option<ValType> {
+        match ty {
+            ir::Type::I32 | ir::Type::Bool => Some(ValType::I32),
+            ir::Type::I64 => Some(ValType::I64),
+            ir::Type::F64 => Some(ValType::F64),
+            ir::Type::Ptr => Some(ValType::I32), // 32-bit WASM pointers
+            ir::Type::Void => None,
+        }
+    }
+
     /// Compile a single IR function to WASM.
     fn compile_function(&mut self, function: &ir::Function) -> Result<(), WasmCodegenError> {
         let func_idx = self.next_func_idx;
         self.next_func_idx += 1;
+
+        // Register the function's type in the type section and function section.
+        let type_idx = self.next_type_idx;
+        self.next_type_idx += 1;
+        let param_types: Vec<ValType> = function
+            .params
+            .iter()
+            .filter_map(Self::ir_type_to_val_type)
+            .collect();
+        let result_types: Vec<ValType> = Self::ir_type_to_val_type(&function.return_type)
+            .into_iter()
+            .collect();
+        self.type_section.function(param_types, result_types);
+        self.functions.function(type_idx);
 
         // Map function name
         self.func_name_to_idx
@@ -615,43 +655,6 @@ impl WasmBackend {
 
     /// Finalize the WASM module and return the binary bytes.
     pub fn finish(self) -> Result<Vec<u8>, WasmCodegenError> {
-        // Build type section
-        // Type 0: fd_write (i32, i32, i32, i32) -> i32
-        // Type 1: proc_exit (i32) -> ()
-        // Type 2+: user functions
-
-        // We need to manually construct the type section since wasm-encoder
-        // doesn't expose a direct TypeSection builder in the same way
-
-        // For now, create a minimal type section
-        let mut type_section = Vec::new();
-        type_section.push(0x01); // section id
-
-        // Type section content:
-        // count: 2 (fd_write and proc_exit types)
-        // Type 0: (i32, i32, i32, i32) -> i32
-        // Type 1: (i32) -> ()
-
-        // Simplified type section encoding
-        let type_content = vec![
-            0x02, // count = 2 types
-            // Type 0: function type
-            0x60, // func type
-            0x04, // 4 params
-            0x7f, 0x7f, 0x7f, 0x7f, // i32, i32, i32, i32
-            0x01, // 1 result
-            0x7f, // i32
-            // Type 1: function type
-            0x60, // func type
-            0x01, // 1 param
-            0x7f, // i32
-            0x00, // 0 results
-        ];
-
-        let type_len = type_content.len();
-        type_section.extend_from_slice(&encode_leb128(type_len as u32));
-        type_section.extend_from_slice(&type_content);
-
         // Manually build the module sections
         let mut result = Vec::new();
 
@@ -659,8 +662,12 @@ impl WasmBackend {
         result.extend_from_slice(&[0x00, 0x61, 0x73, 0x6d]); // \0asm
         result.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]); // version 1
 
-        // Type section
-        result.extend_from_slice(&type_section);
+        // Type section (built incrementally as functions were compiled)
+        let mut type_bytes = Vec::new();
+        self.type_section.append_to(&mut type_bytes);
+        if !type_bytes.is_empty() {
+            result.extend_from_slice(&type_bytes);
+        }
 
         // Import section: only emit if at least one WASI import was requested (C-2).
         if self.needs_fd_write || self.needs_proc_exit {
@@ -722,21 +729,6 @@ impl WasmBackend {
     }
 }
 
-/// Encode a u32 as LEB128 bytes.
-fn encode_leb128(mut value: u32) -> Vec<u8> {
-    let mut result = Vec::new();
-    loop {
-        let byte = (value & 0x7f) as u8;
-        value >>= 7;
-        if value != 0 {
-            result.push(byte | 0x80);
-        } else {
-            result.push(byte);
-            break;
-        }
-    }
-    result
-}
 
 #[cfg(test)]
 mod tests {

--- a/codebase/compiler/tests/runtime_security_regressions.rs
+++ b/codebase/compiler/tests/runtime_security_regressions.rs
@@ -261,6 +261,7 @@ int main(void) {{
 mod agent_security_tests {
     use std::env;
     use std::fs;
+    use std::path::PathBuf;
     use std::sync::Mutex;
     use tempfile::TempDir;
 
@@ -272,6 +273,14 @@ mod agent_security_tests {
     // in parallel threads.
     static CWD_LOCK: Mutex<()> = Mutex::new(());
 
+    /// Restores the working directory on drop, even if the test panics.
+    struct RestoreDir(PathBuf);
+    impl Drop for RestoreDir {
+        fn drop(&mut self) {
+            let _ = env::set_current_dir(&self.0);
+        }
+    }
+
     #[test]
     fn load_rejects_absolute_paths() {
         let _guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -281,12 +290,11 @@ mod agent_security_tests {
 
         let original_dir = env::current_dir().expect("get current dir");
         env::set_current_dir(&tmp).expect("change to temp dir");
+        let _restore = RestoreDir(original_dir);
 
         let params = serde_json::json!({"file": workspace_file.display().to_string()});
         let mut session = None;
         let result = handle_load(&params, &mut session);
-
-        env::set_current_dir(original_dir).expect("restore original dir");
 
         assert!(result.is_err(), "Absolute paths should be rejected");
         let err = result.unwrap_err();
@@ -300,12 +308,11 @@ mod agent_security_tests {
 
         let original_dir = env::current_dir().expect("get current dir");
         env::set_current_dir(&tmp).expect("change to temp dir");
+        let _restore = RestoreDir(original_dir);
 
         let params = serde_json::json!({"file": "../../../etc/passwd"});
         let mut session = None;
         let result = handle_load(&params, &mut session);
-
-        env::set_current_dir(original_dir).expect("restore original dir");
 
         assert!(result.is_err(), "Path traversal should be rejected");
     }
@@ -319,12 +326,11 @@ mod agent_security_tests {
 
         let original_dir = env::current_dir().expect("get current dir");
         env::set_current_dir(&tmp).expect("change to temp dir");
+        let _restore = RestoreDir(original_dir);
 
         let params = serde_json::json!({"file": "test.gr"});
         let mut session = None;
         let result = handle_load(&params, &mut session);
-
-        env::set_current_dir(original_dir).expect("restore original dir");
 
         assert!(result.is_ok(), "Valid relative paths should be accepted");
     }


### PR DESCRIPTION
## Summary

- Fixes the WASM Function section regression introduced by the C-2 lazy WASI imports refactor in PR #168
- `emit_malloc_builtin`, `emit_println_builtin`, and `compile_function` were all adding bodies to the CodeSection without registering corresponding entries in the FunctionSection — a WASM binary where Code count ≠ Function count is invalid and rejected by wasmtime
- The hardcoded two-entry Type section in `finish()` is replaced with `wasm_encoder::TypeSection`, which is populated incrementally as each function is compiled, so all signatures (malloc, fd_write, println, user functions) are always present and consistent
- Adds a `RestoreDir` Drop guard in `agent_security_tests` so the working directory is restored even if a test panics

## Test plan

- [x] All 10 existing `wasm_tests` pass
- [x] `test_e2e_wasm_validation` passes (checks Type + Function + Code sections are present)
- [x] Full compiler test suite passes with no regressions

Fixes [GRA-93](mention://issue/a6cc11df-20cd-4fa9-8942-9f4d2baf90dd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)