### PR TITLE
docs(README,cli-reference): align documentation with current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ cargo build --release
 ```bash
 ./target/release/gradient new hello
 cd hello
-GRADIENT_COMPILER=../target/release/gradient-compiler ../target/release/gradient run
+../target/release/gradient run
 ```
 
 ### Experimental WASM path

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -5,7 +5,7 @@
 ## Installation (from source)
 
 ```bash
-cd codebase/build-system
+cd codebase
 cargo build --release
 # Binary at: target/release/gradient
 # Optionally: cp target/release/gradient ~/.local/bin/
@@ -228,9 +228,9 @@ Usage: gradient init
 
 Initialize a Gradient project in the current directory.
 
-**Status:** Scaffolded -- not yet functional.
+**Status:** Working.
 
-**Future behavior:** Creates `gradient.toml` and `src/main.gr` in the current directory.
+**Behavior:** Creates `gradient.toml` and `src/main.gr` in the current directory.
 
 ---
 


### PR DESCRIPTION
## Summary

Audit and align README and CLI reference with current project state.

## Changes

- README.md: Remove obsolete GRADIENT_COMPILER env var from quick start
- docs/cli-reference.md: Fix build path (codebase/build-system -> codebase)
- docs/cli-reference.md: Update gradient init status from 'Scaffolded' to 'Working'

## Testing

Verified all workflows manually:
- cargo build --release ✓
- gradient new / build / run ✓
- gradient check / fmt / repl ✓

## Related Issues

Fixes GRA-107