### PR TITLE
fix(runtime): cap file_read size + saturating growth (#182)

### DIFF
--- a/codebase/compiler/runtime/gradient_runtime.c
+++ b/codebase/compiler/runtime/gradient_runtime.c
@@ -157,33 +157,92 @@ char* __gradient_read_line(void) {
  * C-3 fix: ftell() returns -1 for non-seekable files (e.g. /proc/*).
  * When size < 0, fall back to an incremental read so we never pass a
  * negative value to malloc().
+ *
+ * GRA-182 hardening:
+ * - Hard cap on total bytes read (default 64 MiB, override via env
+ *   `GRADIENT_FILE_READ_MAX_BYTES`).  Prevents FS-effect code from
+ *   exhausting host memory when handed an arbitrary file path
+ *   (oversize file, pipe, /proc/*, /dev/*, etc.).
+ * - Saturating capacity growth in the non-seekable branch — `cap * 2`
+ *   could wrap on a 32-bit `size_t` and produce a smaller realloc().
+ * - Reject seekable files whose declared size already exceeds the cap
+ *   before any allocation.
  */
+
+/* Default cap: 64 MiB.  Tunable at runtime; never below 4 KiB to keep
+ * the small-file fast path useful. */
+#define GRADIENT_FILE_READ_DEFAULT_MAX (64ULL * 1024ULL * 1024ULL)
+#define GRADIENT_FILE_READ_MIN_MAX     (4ULL * 1024ULL)
+
+static size_t __gradient_file_read_max_bytes(void) {
+    static size_t cached = 0;
+    if (cached != 0) return cached;
+    const char* env = getenv("GRADIENT_FILE_READ_MAX_BYTES");
+    unsigned long long parsed = 0;
+    if (env && *env) {
+        char* end = NULL;
+        unsigned long long v = strtoull(env, &end, 10);
+        if (end != env && v >= GRADIENT_FILE_READ_MIN_MAX) {
+            parsed = v;
+        }
+    }
+    if (parsed == 0) parsed = GRADIENT_FILE_READ_DEFAULT_MAX;
+    /* Clamp to SIZE_MAX - 1 so `+ 1` for the NUL terminator never overflows. */
+    if (parsed > (unsigned long long)(SIZE_MAX - 1)) {
+        parsed = (unsigned long long)(SIZE_MAX - 1);
+    }
+    cached = (size_t)parsed;
+    return cached;
+}
+
 char* __gradient_file_read(const char* path) {
     FILE* f = fopen(path, "r");
     if (!f) return strdup("");
+
+    const size_t max_bytes = __gradient_file_read_max_bytes();
 
     fseek(f, 0, SEEK_END);
     long size = ftell(f);
     rewind(f);
 
     if (size < 0) {
-        /* Non-seekable file: read incrementally. */
+        /* Non-seekable file: read incrementally with a saturating, capped grow. */
         size_t cap = 4096, len = 0;
-        char* buf = (char*)malloc(cap);
+        if (cap > max_bytes) cap = max_bytes;
+        char* buf = (char*)malloc(cap + 1);
         if (!buf) { fclose(f); return strdup(""); }
         size_t n;
         while ((n = fread(buf + len, 1, cap - len, f)) > 0) {
             len += n;
+            if (len >= max_bytes) {
+                /* Cap reached — return what we have, truncated. */
+                len = max_bytes;
+                break;
+            }
             if (len == cap) {
-                char* tmp = (char*)realloc(buf, cap * 2);
+                /* Saturating doubling: never overflow, never exceed max_bytes. */
+                size_t new_cap;
+                if (cap > max_bytes / 2) {
+                    new_cap = max_bytes;
+                } else {
+                    new_cap = cap * 2;
+                }
+                if (new_cap == cap) break; /* nothing more we can grow */
+                char* tmp = (char*)realloc(buf, new_cap + 1);
                 if (!tmp) { free(buf); fclose(f); return strdup(""); }
                 buf = tmp;
-                cap *= 2;
+                cap = new_cap;
             }
         }
         buf[len] = '\0';
         fclose(f);
         return buf;
+    }
+
+    /* Seekable: refuse files larger than the cap before any allocation. */
+    if ((unsigned long)size > (unsigned long)max_bytes) {
+        fclose(f);
+        return strdup("");
     }
 
     char* buf = (char*)malloc((size_t)size + 1);

--- a/codebase/compiler/tests/runtime_security_regressions.rs
+++ b/codebase/compiler/tests/runtime_security_regressions.rs
@@ -80,6 +80,118 @@ int main(void) {{
     build_and_run_c_harness("file_read_ftell_regression", "cc", &[], &source);
 }
 
+/// GRA-182 regression: file_read must enforce a maximum size cap.
+/// A file larger than the cap (env-overridden to a small value here) must
+/// be rejected and return an empty string rather than allocating a buffer
+/// proportional to the file size.
+#[test]
+fn file_read_enforces_max_bytes_cap() {
+    let runtime_c = runtime_c_path();
+    let tmp = TempDir::new().expect("tempdir");
+    let big_path = tmp.path().join("oversize.bin");
+    // 256 KiB of zeros — larger than the 4 KiB cap we set via env below.
+    fs::write(&big_path, vec![0u8; 256 * 1024]).expect("write oversize file");
+    let big_path_str = big_path.display().to_string();
+
+    let source = format!(
+        r#"#include <stdlib.h>
+#include <string.h>
+
+#include "{runtime_c}"
+
+int main(void) {{
+    char* content = __gradient_file_read("{big_path_str}");
+    if (content == NULL) return 1;
+    /* With a 4 KiB cap, an oversize seekable file must come back as "" (rejected). */
+    size_t len = strlen(content);
+    int ok = (len == 0);
+    free(content);
+    return ok ? 0 : 2;
+}}
+"#
+    );
+
+    let tmp2 = TempDir::new().expect("tempdir");
+    let source_path = tmp2.path().join("file_read_cap_regression.c");
+    let binary_path = tmp2.path().join("file_read_cap_regression");
+    fs::write(&source_path, &source).expect("write harness");
+
+    let status = Command::new("cc")
+        .arg(&source_path)
+        .arg("-o")
+        .arg(&binary_path)
+        .arg("-lcurl")
+        .status()
+        .expect("compile harness");
+    assert!(status.success(), "harness compilation failed: {status:?}");
+
+    let output = Command::new(&binary_path)
+        .env("GRADIENT_FILE_READ_MAX_BYTES", "4096")
+        .env("ASAN_OPTIONS", "detect_leaks=1:halt_on_error=1")
+        .env("UBSAN_OPTIONS", "halt_on_error=1")
+        .output()
+        .expect("run harness");
+    assert!(
+        output.status.success(),
+        "max-bytes cap not enforced.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// GRA-182 regression: non-seekable file_read must also honor the cap and
+/// must not overflow capacity in saturating doubling.
+#[test]
+fn file_read_nonseekable_honors_max_bytes_cap() {
+    let runtime_c = runtime_c_path();
+    let source = format!(
+        r#"#include <stdlib.h>
+#include <string.h>
+
+#include "{runtime_c}"
+
+int main(void) {{
+    /* /dev/zero is non-seekable in some implementations (and infinitely long
+     * in others); regardless, the read must terminate at the cap, not loop. */
+    char* content = __gradient_file_read("/dev/zero");
+    if (content == NULL) return 1;
+    size_t len = strlen(content);
+    /* With cap=4096, length must be <= 4096. */
+    int ok = (len <= 4096);
+    free(content);
+    return ok ? 0 : 2;
+}}
+"#
+    );
+
+    let tmp = TempDir::new().expect("tempdir");
+    let source_path = tmp.path().join("file_read_nonseekable_cap.c");
+    let binary_path = tmp.path().join("file_read_nonseekable_cap");
+    fs::write(&source_path, &source).expect("write harness");
+
+    let status = Command::new("cc")
+        .arg(&source_path)
+        .arg("-o")
+        .arg(&binary_path)
+        .arg("-lcurl")
+        .status()
+        .expect("compile harness");
+    assert!(status.success(), "harness compilation failed: {status:?}");
+
+    let output = Command::new(&binary_path)
+        .env("GRADIENT_FILE_READ_MAX_BYTES", "4096")
+        .env("ASAN_OPTIONS", "detect_leaks=1:halt_on_error=1")
+        .env("UBSAN_OPTIONS", "halt_on_error=1")
+        .output()
+        .expect("run harness");
+    assert!(
+        output.status.success(),
+        "non-seekable cap not enforced.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn map_helpers_update_and_remove_entries_without_leaking_replaced_strings() {
     let runtime_c = runtime_c_path();


### PR DESCRIPTION
Fixes #182

## Summary
`__gradient_file_read` had no upper bound on bytes read and used unchecked `cap *= 2` for the non-seekable buffer. FS-effect Gradient code handed a multi-GiB log file or `/dev/zero` could exhaust host memory.

## Changes
- Configurable max read size via `GRADIENT_FILE_READ_MAX_BYTES` env var (default **64 MiB**, floor 4 KiB, clamped to `SIZE_MAX - 1`).
- Seekable path: refuse files whose declared size exceeds the cap before any allocation; return `""` (consistent with existing error semantics).
- Non-seekable path: stop at the cap and saturating doubling — once `cap > max_bytes / 2` the next `realloc` jumps to exactly `max_bytes`, so capacity growth can never wrap and never exceeds the cap.
- Allocate `cap + 1` so the NUL terminator always has room.

## Tests
`codebase/compiler/tests/runtime_security_regressions.rs`:
- `file_read_enforces_max_bytes_cap` — 256 KiB seekable file with a 4 KiB env cap must come back empty (rejected).
- `file_read_nonseekable_honors_max_bytes_cap` — `/dev/zero` with a 4 KiB cap must terminate at length ≤ cap.

Existing `file_read_nonseekable_proc_file_no_crash` regression still passes.

```
cargo test -p gradient-compiler --test runtime_security_regressions file_read
test result: ok. 3 passed; 0 failed
```

## Deferred (follow-up)
The issue also requests replacing empty-string errors with structured error codes. That changes the `__gradient_file_read` ABI (return type and call sites in `cranelift.rs`, plus typechecker effect signature). Tracking separately so this PR stays scoped to the memory-DoS fix, which is the security risk identified in the review.
