### PR TITLE
fix(runtime): arena allocator checked arithmetic (#178)

### DIFF
--- a/codebase/compiler/tests/runtime_arena_overflow_regressions.rs
+++ b/codebase/compiler/tests/runtime_arena_overflow_regressions.rs
@@ -1,0 +1,182 @@
+//! GRA-178 regression tests: arena allocator overflow safety.
+//!
+//! These tests link `runtime/memory/arena.c` directly (not via the
+//! `__gradient_arena_*` wrappers) so we can pass attacker-shaped
+//! `size_t` values that would not survive the wrapper's `int64_t`
+//! signature.  They verify that the checked arithmetic in
+//! `arena_alloc_aligned` and `arena_chunk_new` returns NULL on overflow
+//! instead of wrapping and producing an undersized buffer.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn arena_c_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("compiler -> codebase parent")
+        .join("runtime")
+        .join("memory")
+        .join("arena.c")
+}
+
+fn arena_h_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("compiler -> codebase parent")
+        .join("runtime")
+        .join("memory")
+}
+
+fn build_and_run(test_name: &str, source: &str) {
+    let tmp = TempDir::new().expect("tempdir");
+    let src = tmp.path().join(format!("{test_name}.c"));
+    let bin = tmp.path().join(test_name);
+    fs::write(&src, source).expect("write source");
+
+    let arena_c = arena_c_path();
+    let inc = arena_h_dir();
+
+    let status = Command::new("cc")
+        .arg("-I")
+        .arg(&inc)
+        .arg(&src)
+        .arg(&arena_c)
+        .arg("-o")
+        .arg(&bin)
+        .status()
+        .expect("compile");
+    assert!(status.success(), "compile failed for {test_name}");
+
+    let output = Command::new(&bin)
+        .env("ASAN_OPTIONS", "halt_on_error=1")
+        .env("UBSAN_OPTIONS", "halt_on_error=1")
+        .output()
+        .expect("run");
+    assert!(
+        output.status.success(),
+        "{test_name} failed.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn arena_chunk_new_rejects_size_max() {
+    // arena_create_with_size(SIZE_MAX) would compute `sizeof(ArenaChunk) + SIZE_MAX`
+    // which wraps to a tiny value; malloc would succeed and any subsequent write
+    // into ->data would corrupt the heap.  The fix returns NULL on overflow.
+    let source = r#"
+#include <stddef.h>
+#include <stdint.h>
+#include "arena.h"
+
+int main(void) {
+    Arena* a = arena_create_with_size((size_t)-1);
+    /* Must fail cleanly: NULL, not a corrupt arena pointing at a 1-byte buffer. */
+    return a == NULL ? 0 : 1;
+}
+"#;
+    build_and_run("arena_chunk_size_overflow", source);
+}
+
+#[test]
+fn arena_alloc_aligned_rejects_size_max() {
+    // arena_alloc_aligned(arena, SIZE_MAX, align) must reject before computing
+    // size+align (which would overflow) and before computing aligned+size (which
+    // would wrap the bump pointer past end_ptr).
+    let source = r#"
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "arena.h"
+
+int main(void) {
+    Arena* a = arena_create();
+    if (!a) return 1;
+
+    void* p1 = arena_alloc_aligned(a, (size_t)-1, 8);
+    if (p1 != NULL) {
+        arena_destroy(a);
+        return 2; /* must reject SIZE_MAX */
+    }
+
+    /* Just shy of SIZE_MAX is still impossible to satisfy and must be NULL. */
+    void* p2 = arena_alloc_aligned(a, (size_t)-1 - 8, 8);
+    if (p2 != NULL) {
+        arena_destroy(a);
+        return 3;
+    }
+
+    /* A reasonable allocation must still succeed after the rejected ones. */
+    void* p3 = arena_alloc_aligned(a, 64, 8);
+    if (p3 == NULL) {
+        arena_destroy(a);
+        return 4;
+    }
+
+    arena_destroy(a);
+    return 0;
+}
+"#;
+    build_and_run("arena_alloc_size_overflow", source);
+}
+
+#[test]
+fn arena_alloc_aligned_zero_size_returns_null() {
+    // Pre-existing contract: zero-size allocations return NULL.  Re-asserted
+    // here so future overflow-rejection logic doesn't accidentally treat 0 as
+    // a valid allocation.
+    let source = r#"
+#include <stddef.h>
+#include <stdint.h>
+#include "arena.h"
+
+int main(void) {
+    Arena* a = arena_create();
+    if (!a) return 1;
+    void* p = arena_alloc_aligned(a, 0, 8);
+    int ok = (p == NULL);
+    arena_destroy(a);
+    return ok ? 0 : 2;
+}
+"#;
+    build_and_run("arena_alloc_zero_size", source);
+}
+
+#[test]
+fn arena_repeated_alloc_does_not_wrap_bump_pointer() {
+    // Sanity: many allocations that together approach but never exceed the
+    // chunk size must succeed; the next one that would push past end_ptr
+    // must trigger a new chunk rather than wrapping.
+    let source = r#"
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "arena.h"
+
+int main(void) {
+    Arena* a = arena_create_with_size(4096);
+    if (!a) return 1;
+
+    /* Fill the first chunk with small allocations. */
+    for (int i = 0; i < 100; i++) {
+        void* p = arena_alloc_aligned(a, 32, 8);
+        if (p == NULL) {
+            arena_destroy(a);
+            return 2;
+        }
+    }
+
+    /* This allocation is larger than what's left and must trigger a new
+     * chunk via the checked size+align path; must succeed, not wrap. */
+    void* big = arena_alloc_aligned(a, 8192, 8);
+    int ok = (big != NULL) && (arena_num_chunks(a) >= 2);
+    arena_destroy(a);
+    return ok ? 0 : 3;
+}
+"#;
+    build_and_run("arena_repeated_alloc", source);
+}

--- a/codebase/runtime/memory/arena.c
+++ b/codebase/runtime/memory/arena.c
@@ -2,25 +2,56 @@
  * Arena Allocator Implementation
  *
  * Bump-pointer arena allocator for efficient temporary memory management.
+ *
+ * GRA-178 hardening: every size/alignment/pointer addition that could be
+ * influenced by an attacker-supplied size goes through checked arithmetic
+ * helpers below.  These return false on overflow so the caller can fail
+ * the allocation cleanly instead of silently producing an undersized
+ * buffer or wrapping the bump pointer past `end_ptr`.
  */
 
 #include "arena.h"
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/* ── Checked arithmetic helpers ──────────────────────────────────────────── */
+
+/* Add two size_t values; return false on overflow. */
+static inline bool checked_add_size(size_t a, size_t b, size_t* out) {
+    if (b > SIZE_MAX - a) return false;
+    *out = a + b;
+    return true;
+}
+
+/* Add a uintptr_t and a size_t; return false on overflow. */
+static inline bool checked_add_uptr(uintptr_t a, size_t b, uintptr_t* out) {
+    if (b > UINTPTR_MAX - a) return false;
+    *out = a + (uintptr_t)b;
+    return true;
+}
 
 /* Internal: Allocate a new chunk */
 static ArenaChunk* arena_chunk_new(size_t chunk_size) {
-    /* Allocate chunk with flexible array member */
-    size_t total_size = sizeof(ArenaChunk) + chunk_size;
+    /* Allocate chunk with flexible array member.
+     * Checked: sizeof(ArenaChunk) + chunk_size must not overflow size_t,
+     * otherwise malloc would be called with a tiny wrapped value and
+     * subsequent writes into ->data would corrupt unrelated heap memory. */
+    size_t total_size = 0;
+    if (!checked_add_size(sizeof(ArenaChunk), chunk_size, &total_size)) {
+        return NULL;
+    }
     ArenaChunk* chunk = (ArenaChunk*)malloc(total_size);
     if (!chunk) return NULL;
-    
+
     chunk->next = NULL;
     chunk->size = chunk_size;
     chunk->used = 0;
     /* Don't initialize data - arena_alloc will zero memory */
-    
+
     return chunk;
 }
 
@@ -86,79 +117,112 @@ void arena_destroy(Arena* arena) {
 /* Round up to nearest multiple of alignment (must be power of 2) */
 static inline size_t align_up(size_t size, size_t align) {
     assert((align & (align - 1)) == 0 && "alignment must be power of 2");
+    /* `size + align - 1` could overflow if size is near SIZE_MAX.
+     * Saturate to SIZE_MAX so the caller's subsequent capacity check fails. */
+    if (size > SIZE_MAX - (align - 1)) return SIZE_MAX;
     return (size + align - 1) & ~(align - 1);
 }
 
 static inline uintptr_t align_ptr_up(uintptr_t ptr, size_t align) {
     assert((align & (align - 1)) == 0 && "alignment must be power of 2");
+    /* If ptr is so close to UINTPTR_MAX that `ptr + align - 1` would wrap,
+     * saturate to UINTPTR_MAX so the caller's `aligned <= end - size` check
+     * fails cleanly.  In practice arena pointers come from malloc() and
+     * cannot reach this region, but checking it removes the UB hazard. */
+    if (ptr > UINTPTR_MAX - (align - 1)) return UINTPTR_MAX;
     return (ptr + align - 1) & ~(align - 1);
 }
 
 void* arena_alloc_aligned(Arena* arena, size_t size, size_t align) {
     if (!arena || size == 0) return NULL;
-    
+
     /* Validate alignment */
     if (align == 0) align = 8;
     if (align > 256 || (align & (align - 1)) != 0) {
         align = 8; /* Fallback to 8-byte alignment */
     }
-    
+
+    /* Reject sizes that cannot possibly fit even in a fresh chunk and
+     * would overflow the size+align math below. */
+    if (size > SIZE_MAX - align) return NULL;
+
     /* Try to allocate from current chunk */
     uintptr_t current = (uintptr_t)arena->bump_ptr;
     uintptr_t aligned = align_ptr_up(current, align);
+    if (aligned == UINTPTR_MAX) return NULL;
     size_t padding = aligned - current;
-    
-    /* Check if there's enough space in current chunk */
-    if (aligned + size <= (uintptr_t)arena->end_ptr) {
+
+    /* Check space in current chunk using subtraction so we never compute
+     * `aligned + size` when that addition could wrap.  Equivalent to
+     * `aligned + size <= end_ptr` but overflow-safe. */
+    uintptr_t end = (uintptr_t)arena->end_ptr;
+    if (aligned <= end && size <= (size_t)(end - aligned)) {
         /* Zero the padding bytes for safety */
         if (padding > 0) {
             memset((void*)current, 0, padding);
         }
-        
+
         void* result = (void*)aligned;
         arena->bump_ptr = (uint8_t*)(aligned + size);
-        arena->chunks->used += padding + size;
+        /* padding + size: bounded by chunk size which is bounded by size_t. */
+        size_t step = 0;
+        if (!checked_add_size(padding, size, &step)) return NULL;
+        arena->chunks->used += step;
         arena->total_allocated += size;
-        
+
         /* Zero the allocated memory */
         memset(result, 0, size);
-        
+
         return result;
     }
-    
+
     /* Need a new chunk */
-    /* Calculate required chunk size (must fit this allocation) */
-    size_t required_size = size + align;
+    /* Calculate required chunk size (must fit this allocation, with checked add). */
+    size_t required_size = 0;
+    if (!checked_add_size(size, align, &required_size)) {
+        return NULL;
+    }
     size_t new_chunk_size = arena->chunk_size;
     if (required_size > new_chunk_size) {
         new_chunk_size = required_size;
     }
-    
+
     ArenaChunk* new_chunk = arena_chunk_new(new_chunk_size);
     if (!new_chunk) return NULL;
-    
+
     /* Link new chunk to front of list */
     new_chunk->next = arena->chunks;
     arena->chunks = new_chunk;
     arena->num_chunks++;
-    
+
     /* Set up bump pointer in new chunk */
     arena->bump_ptr = new_chunk->data;
     arena->end_ptr = new_chunk->data + new_chunk_size;
-    
+
     /* Allocate from new chunk */
     current = (uintptr_t)arena->bump_ptr;
     aligned = align_ptr_up(current, align);
+    if (aligned == UINTPTR_MAX) return NULL;
     padding = aligned - current;
-    
+
+    /* Sanity: the new chunk was sized to fit `size + align`, so size must
+     * fit between aligned and end.  Re-check using subtraction to keep the
+     * invariant local rather than trusting the sizing math. */
+    end = (uintptr_t)arena->end_ptr;
+    if (aligned > end || size > (size_t)(end - aligned)) {
+        return NULL;
+    }
+
     void* result = (void*)aligned;
     arena->bump_ptr = (uint8_t*)(aligned + size);
-    new_chunk->used = padding + size;
+    size_t step = 0;
+    if (!checked_add_size(padding, size, &step)) return NULL;
+    new_chunk->used = step;
     arena->total_allocated += size;
-    
+
     /* Zero the allocated memory */
     memset(result, 0, size);
-    
+
     return result;
 }
 


### PR DESCRIPTION
Fixes #178

## Summary
The arena allocator (`codebase/runtime/memory/arena.c`) performed unchecked size/pointer additions in places where an attacker-influenced size could wrap and produce an undersized buffer, OOB memset, or a bump pointer past `end_ptr`.

## Hardening
- New `checked_add_size` / `checked_add_uptr` helpers (return `false` on overflow).
- `arena_chunk_new` — `sizeof(ArenaChunk) + chunk_size` is now checked; `arena_create_with_size(SIZE_MAX)` returns NULL instead of yielding a corrupt arena.
- `arena_alloc_aligned`:
  - rejects `size > SIZE_MAX - align` up front;
  - capacity check uses `size <= end - aligned` instead of `aligned + size <= end` (subtraction cannot wrap when `aligned <= end`);
  - `padding + size` accumulations go through `checked_add_size`;
  - saturating `align_ptr_up` / `align_up` so near-UINTPTR_MAX / SIZE_MAX inputs fail cleanly instead of UB-wrapping.
- New-chunk path re-checks the capacity invariant locally rather than trusting upstream sizing math.

## Tests
New `runtime_arena_overflow_regressions.rs` — links `arena.c` directly so we can pass real `size_t` overflow values that wouldn't survive the public `int64_t` wrapper:

| Test | Asserts |
|---|---|
| `arena_chunk_new_rejects_size_max` | `arena_create_with_size(SIZE_MAX)` → NULL |
| `arena_alloc_aligned_rejects_size_max` | SIZE_MAX and SIZE_MAX−8 → NULL; normal alloc still works |
| `arena_alloc_aligned_zero_size_returns_null` | pre-existing contract preserved |
| `arena_repeated_alloc_does_not_wrap_bump_pointer` | new-chunk path triggers cleanly instead of wrapping |

Existing `runtime_arena_tests.rs` (11 tests) still passes.

```
cargo test -p gradient-compiler --test runtime_arena_overflow_regressions
test result: ok. 4 passed; 0 failed
cargo test -p gradient-compiler --test runtime_arena_tests
test result: ok. 11 passed; 0 failed
```
