### PR TITLE
fix(resolve): sandbox imports under source root (#181)

### DIFF
--- a/codebase/compiler/src/resolve.rs
+++ b/codebase/compiler/src/resolve.rs
@@ -78,9 +78,34 @@ impl ResolveResult {
 }
 
 /// Resolves `use` declarations to source files and parses all dependencies.
+///
+/// # Import sandboxing (issue #181)
+///
+/// The resolver enforces a *source root* sandbox: every successfully-resolved
+/// import path must canonicalize to a path that lies inside the source root
+/// (or inside one of the allowlisted stdlib roots, if any are configured).
+/// Imports whose canonicalized path escapes the sandbox — via `..`, an
+/// absolute path, or a symlink that points outside the root — are rejected
+/// with a resolution error and never read from disk.
+///
+/// By default the source root is the canonicalized parent directory of the
+/// entry file. Callers that need a different root (for example a project
+/// root distinct from the entry file's directory) can use
+/// [`ModuleResolver::with_source_root`].
 pub struct ModuleResolver {
     /// The base directory for resolving imports (directory of the entry file).
+    /// This is *not* the security boundary — it is just the search start point.
     base_dir: PathBuf,
+    /// Canonicalized source root that every resolved import must stay under.
+    /// `None` means the resolver could not canonicalize a root (e.g. the
+    /// entry file's parent does not exist on disk); in that case all
+    /// filesystem-touching imports are rejected.
+    source_root: Option<PathBuf>,
+    /// Canonicalized roots outside `source_root` that imports are *also*
+    /// allowed to resolve into (typically the standard library install dir).
+    /// Empty by default — absolute imports are rejected unless they fall
+    /// under one of these roots.
+    stdlib_roots: Vec<PathBuf>,
     /// Already-loaded modules, keyed by module name.
     loaded: HashMap<String, ResolvedModule>,
     /// Modules currently being loaded (for cycle detection).
@@ -93,19 +118,97 @@ pub struct ModuleResolver {
 
 impl ModuleResolver {
     /// Create a new resolver rooted at the directory containing the entry file.
+    ///
+    /// The source root is set to the canonicalized parent directory of the
+    /// entry file; all imports are sandboxed to that directory.
     pub fn new(entry_file: &Path) -> Self {
         let base_dir = entry_file
             .parent()
             .map(|p| p.to_path_buf())
             .unwrap_or_else(|| PathBuf::from("."));
 
+        // Canonicalize the source root for the security check. If the parent
+        // directory does not exist or cannot be canonicalized, leave the
+        // source root as `None` and downstream sandbox checks will reject
+        // every filesystem import.
+        let source_root = std::fs::canonicalize(&base_dir).ok();
+
         Self {
             base_dir,
+            source_root,
+            stdlib_roots: Vec::new(),
             loaded: HashMap::new(),
             loading: HashSet::new(),
             errors: Vec::new(),
             next_file_id: 0,
         }
+    }
+
+    /// Create a resolver with an explicit source root.
+    ///
+    /// The given `source_root` is canonicalized and becomes the security
+    /// boundary for all imports. `base_dir` (the search start) defaults to
+    /// the entry file's parent directory, just like [`ModuleResolver::new`].
+    pub fn with_source_root(entry_file: &Path, source_root: &Path) -> Self {
+        let base_dir = entry_file
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        let canonical_root = std::fs::canonicalize(source_root).ok();
+
+        Self {
+            base_dir,
+            source_root: canonical_root,
+            stdlib_roots: Vec::new(),
+            loaded: HashMap::new(),
+            loading: HashSet::new(),
+            errors: Vec::new(),
+            next_file_id: 0,
+        }
+    }
+
+    /// Add an allowlisted root directory that imports are allowed to resolve
+    /// into in addition to the source root. Intended for stdlib install
+    /// directories. Non-existent paths are silently ignored.
+    pub fn allow_stdlib_root(mut self, root: &Path) -> Self {
+        if let Ok(canonical) = std::fs::canonicalize(root) {
+            self.stdlib_roots.push(canonical);
+        }
+        self
+    }
+
+    /// Returns the canonicalized source root, if any.
+    pub fn source_root(&self) -> Option<&Path> {
+        self.source_root.as_deref()
+    }
+
+    /// Check that `candidate` (which must already exist on disk) canonicalizes
+    /// to a path inside the source root or one of the allowlisted stdlib
+    /// roots. Returns the canonicalized path on success, or `None` if the
+    /// path escapes the sandbox.
+    ///
+    /// This is the single security gate for filesystem imports: every
+    /// successfully-resolved candidate from `resolve_file_path` /
+    /// `resolve_module_path` is run through here before the file is read.
+    fn enforce_sandbox(&self, candidate: &Path) -> Option<PathBuf> {
+        // Canonicalize follows symlinks, so a symlink that points out of the
+        // source root will be caught by the `starts_with` check below.
+        let canonical = std::fs::canonicalize(candidate).ok()?;
+
+        if let Some(root) = &self.source_root {
+            if canonical.starts_with(root) {
+                return Some(canonical);
+            }
+        }
+
+        for stdlib in &self.stdlib_roots {
+            if canonical.starts_with(stdlib) {
+                return Some(canonical);
+            }
+        }
+
+        None
     }
 
     /// Resolve all modules starting from the given entry file.
@@ -334,7 +437,11 @@ impl ModuleResolver {
 
     /// Resolve the file path for a file path import (e.g. `use "./token.gr"`).
     ///
-    /// Resolves relative to the importing file's directory.
+    /// Resolves relative to the importing file's directory, then enforces the
+    /// import sandbox: every successful candidate must canonicalize to a path
+    /// inside the source root (or an allowlisted stdlib root). Absolute paths
+    /// are rejected unless they fall under one of those roots — which makes
+    /// `..` escapes and absolute escapes both fail closed.
     fn resolve_file_path(&self, file_path: &str, from_file: &Path) -> Option<PathBuf> {
         let from_dir = from_file.parent().unwrap_or_else(|| Path::new("."));
 
@@ -342,23 +449,37 @@ impl ModuleResolver {
         if file_path.starts_with("./") || file_path.starts_with("../") {
             let candidate = from_dir.join(file_path);
             if candidate.exists() {
-                return Some(candidate.clean());
+                if let Some(canonical) = self.enforce_sandbox(&candidate) {
+                    return Some(canonical);
+                }
             }
         } else {
-            // For absolute paths or bare filenames, try as-is first
+            // For absolute paths or bare filenames, try as-is first.
+            // The sandbox check below will reject absolute paths that are not
+            // under the source root or an allowlisted stdlib root, so absolute
+            // imports are denied by default.
             let candidate = PathBuf::from(file_path);
             if candidate.is_absolute() && candidate.exists() {
-                return Some(candidate);
+                if let Some(canonical) = self.enforce_sandbox(&candidate) {
+                    return Some(canonical);
+                }
+                // Fall through: an absolute path that escapes the sandbox is
+                // not silently re-resolved against base_dir. It is rejected.
+                return None;
             }
             // Then try relative to from_dir
             let candidate = from_dir.join(file_path);
             if candidate.exists() {
-                return Some(candidate.clean());
+                if let Some(canonical) = self.enforce_sandbox(&candidate) {
+                    return Some(canonical);
+                }
             }
             // Finally try relative to base directory
             let candidate = self.base_dir.join(file_path);
             if candidate.exists() {
-                return Some(candidate.clean());
+                if let Some(canonical) = self.enforce_sandbox(&candidate) {
+                    return Some(canonical);
+                }
             }
         }
 
@@ -369,6 +490,9 @@ impl ModuleResolver {
     ///
     /// For `use math`: looks for `math.gr` in the same directory as `from_file`.
     /// For `use math.utils`: looks for `math/utils.gr` relative to the base dir.
+    ///
+    /// Like [`resolve_file_path`], every successful candidate is run through
+    /// the sandbox check and rejected if it escapes the source root.
     fn resolve_module_path(&self, path_segments: &[String], from_file: &Path) -> Option<PathBuf> {
         let from_dir = from_file.parent().unwrap_or_else(|| Path::new("."));
 
@@ -380,12 +504,16 @@ impl ModuleResolver {
             // Simple case: `use math` -> `math.gr` in the same directory
             let candidate = from_dir.join(format!("{}.gr", path_segments[0]));
             if candidate.exists() {
-                return Some(candidate);
+                if let Some(canonical) = self.enforce_sandbox(&candidate) {
+                    return Some(canonical);
+                }
             }
             // Also try from the base directory
             let candidate = self.base_dir.join(format!("{}.gr", path_segments[0]));
             if candidate.exists() {
-                return Some(candidate);
+                if let Some(canonical) = self.enforce_sandbox(&candidate) {
+                    return Some(canonical);
+                }
             }
         } else {
             // Multi-segment: `use math.utils` -> `math/utils.gr`
@@ -399,12 +527,16 @@ impl ModuleResolver {
             // Try from the importing file's directory
             let candidate = from_dir.join(&rel_path);
             if candidate.exists() {
-                return Some(candidate);
+                if let Some(canonical) = self.enforce_sandbox(&candidate) {
+                    return Some(canonical);
+                }
             }
             // Try from the base directory
             let candidate = self.base_dir.join(&rel_path);
             if candidate.exists() {
-                return Some(candidate);
+                if let Some(canonical) = self.enforce_sandbox(&candidate) {
+                    return Some(canonical);
+                }
             }
         }
 
@@ -412,11 +544,18 @@ impl ModuleResolver {
     }
 }
 
-/// Trait to clean up path normalization (resolve . and .. components)
+/// Trait to clean up path normalization (resolve . and .. components).
+///
+/// Kept for backwards-compatibility / potential reuse, but no longer used by
+/// the resolver itself: the import sandbox check (see
+/// [`ModuleResolver::enforce_sandbox`]) uses `std::fs::canonicalize` so that
+/// symlinks are followed and `..` cannot escape the source root.
+#[allow(dead_code)]
 trait PathClean {
     fn clean(&self) -> PathBuf;
 }
 
+#[allow(dead_code)]
 impl PathClean for PathBuf {
     fn clean(&self) -> PathBuf {
         let mut result = PathBuf::new();

--- a/codebase/compiler/tests/import_sandbox_tests.rs
+++ b/codebase/compiler/tests/import_sandbox_tests.rs
@@ -1,0 +1,313 @@
+//! Import sandbox tests (issue #181).
+//!
+//! Verifies that the module resolver enforces a source-root sandbox:
+//!
+//! 1. `../escape.gr` — a relative import that climbs out of the source root
+//!    must be rejected even though the target file exists on disk.
+//! 2. Absolute path imports — `import "/etc/passwd"` style — must be denied
+//!    by default (no stdlib allowlist configured).
+//! 3. Symlink-out-of-root — a file that *appears* to be inside the source
+//!    root but is actually a symlink whose target is outside must be
+//!    rejected (canonicalize follows the link).
+//!
+//! The sandbox is the security boundary; the resolver's "search relative
+//! to base_dir" behaviour is preserved for normal in-root imports.
+
+use std::fs;
+use std::path::PathBuf;
+
+use gradient_compiler::resolve::ModuleResolver;
+
+/// Build a temp project layout:
+///
+///   <tmp>/
+///     outside/
+///       escape.gr           (target of `../escape.gr`)
+///     project/
+///       main.gr             (entry; written by caller)
+///       (other files written by caller)
+///
+/// Returns `(tmp, project_dir)`.
+fn make_project() -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let outside = tmp.path().join("outside");
+    let project = tmp.path().join("project");
+    fs::create_dir_all(&outside).unwrap();
+    fs::create_dir_all(&project).unwrap();
+    fs::write(
+        outside.join("escape.gr"),
+        "mod escape\n\nfn pwned() -> Int:\n    1\n",
+    )
+    .unwrap();
+    (tmp, project)
+}
+
+#[test]
+fn rejects_parent_dir_escape_via_use() {
+    // `use "../escape.gr"` should be rejected: escape.gr exists but lives
+    // outside the source root (= project/).
+    let (_tmp, project) = make_project();
+    let entry = project.join("main.gr");
+    fs::write(
+        &entry,
+        "mod main\n\nuse \"../escape.gr\"\n\nfn main():\n    ()\n",
+    )
+    .unwrap();
+
+    let resolver = ModuleResolver::new(&entry);
+    let result = resolver.resolve_all(&entry);
+
+    assert!(
+        !result.errors.is_empty(),
+        "expected resolution error for ../ escape, got none"
+    );
+    assert!(
+        result
+            .errors
+            .iter()
+            .any(|e| e.contains("cannot resolve import")),
+        "expected `cannot resolve import` error, got: {:?}",
+        result.errors
+    );
+    // The escape module must NOT have been loaded.
+    assert!(
+        !result.modules.contains_key("escape"),
+        "escape module should not have been loaded; modules: {:?}",
+        result.modules.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn rejects_parent_dir_escape_via_import_statement() {
+    // Same check, but for the `import "..."` top-level statement form.
+    let (_tmp, project) = make_project();
+    let entry = project.join("main.gr");
+    fs::write(
+        &entry,
+        "mod main\n\nimport \"../escape.gr\"\n\nfn main():\n    ()\n",
+    )
+    .unwrap();
+
+    let resolver = ModuleResolver::new(&entry);
+    let result = resolver.resolve_all(&entry);
+
+    assert!(
+        !result.errors.is_empty(),
+        "expected resolution error for `import \"../escape.gr\"`"
+    );
+    assert!(
+        !result.modules.contains_key("escape"),
+        "escape module should not have been loaded"
+    );
+}
+
+#[test]
+fn rejects_absolute_path_import_outside_root() {
+    // An absolute path that points outside the source root must be rejected
+    // even though the file exists. The default policy denies absolute
+    // imports unless they resolve under an allowlisted stdlib root.
+    let (_tmp, project) = make_project();
+    // The "outside" file lives at <tmp>/outside/escape.gr. Its absolute
+    // path is by construction not under the source root <tmp>/project.
+    let outside_abs = project
+        .parent()
+        .unwrap()
+        .join("outside")
+        .join("escape.gr")
+        .canonicalize()
+        .unwrap();
+
+    let entry = project.join("main.gr");
+    fs::write(
+        &entry,
+        format!(
+            "mod main\n\nimport \"{}\"\n\nfn main():\n    ()\n",
+            outside_abs.display()
+        ),
+    )
+    .unwrap();
+
+    let resolver = ModuleResolver::new(&entry);
+    let result = resolver.resolve_all(&entry);
+
+    assert!(
+        !result.errors.is_empty(),
+        "expected resolution error for absolute import outside root, got none"
+    );
+    assert!(
+        !result.modules.contains_key("escape"),
+        "escape module must not be loaded via absolute path; modules: {:?}",
+        result.modules.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn rejects_symlink_pointing_outside_root() {
+    // Layout:
+    //   <tmp>/outside/secret.gr   (real file outside the project)
+    //   <tmp>/project/main.gr
+    //   <tmp>/project/secret.gr   -> symlink -> ../outside/secret.gr
+    //
+    // The path `./secret.gr` looks innocuous but canonicalize() follows the
+    // symlink, yielding <tmp>/outside/secret.gr, which is outside the
+    // source root. The resolver must reject it.
+    let tmp = tempfile::tempdir().unwrap();
+    let outside = tmp.path().join("outside");
+    let project = tmp.path().join("project");
+    fs::create_dir_all(&outside).unwrap();
+    fs::create_dir_all(&project).unwrap();
+
+    let real = outside.join("secret.gr");
+    fs::write(&real, "mod secret\n\nfn leak() -> Int:\n    42\n").unwrap();
+
+    let link = project.join("secret.gr");
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+    }
+    #[cfg(not(unix))]
+    {
+        // On platforms without unix-style symlinks, skip the test rather
+        // than fail. The sandbox still protects against `..` and absolute
+        // escapes (covered by the other tests).
+        eprintln!("skipping symlink test on non-unix platform");
+        return;
+    }
+
+    let entry = project.join("main.gr");
+    fs::write(
+        &entry,
+        "mod main\n\nimport \"./secret.gr\"\n\nfn main():\n    ()\n",
+    )
+    .unwrap();
+
+    let resolver = ModuleResolver::new(&entry);
+    let result = resolver.resolve_all(&entry);
+
+    assert!(
+        !result.errors.is_empty(),
+        "expected resolution error for symlink-out-of-root, got none"
+    );
+    assert!(
+        !result.modules.contains_key("secret"),
+        "secret module must not be loaded via symlink escape; modules: {:?}",
+        result.modules.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn allows_in_root_relative_imports() {
+    // Sanity check: the sandbox does not break legitimate same-directory
+    // imports. `use sibling` must still work.
+    let (_tmp, project) = make_project();
+    let entry = project.join("main.gr");
+    fs::write(
+        &entry,
+        "mod main\n\nuse sibling\n\nfn main():\n    ()\n",
+    )
+    .unwrap();
+    fs::write(
+        project.join("sibling.gr"),
+        "mod sibling\n\nfn hello() -> Int:\n    1\n",
+    )
+    .unwrap();
+
+    let resolver = ModuleResolver::new(&entry);
+    let result = resolver.resolve_all(&entry);
+
+    assert!(
+        result.errors.is_empty(),
+        "in-root import must succeed, got errors: {:?}",
+        result.errors
+    );
+    assert!(result.modules.contains_key("main"));
+    assert!(result.modules.contains_key("sibling"));
+}
+
+#[test]
+fn allows_absolute_path_when_under_stdlib_root() {
+    // If a stdlib root is explicitly allowlisted, absolute imports under
+    // that root are permitted. This exercises the configurable allowlist
+    // half of the spec.
+    let tmp = tempfile::tempdir().unwrap();
+    let stdlib = tmp.path().join("stdlib");
+    let project = tmp.path().join("project");
+    fs::create_dir_all(&stdlib).unwrap();
+    fs::create_dir_all(&project).unwrap();
+
+    fs::write(
+        stdlib.join("io.gr"),
+        "mod io\n\nfn print_line() -> Int:\n    0\n",
+    )
+    .unwrap();
+    let stdlib_io_abs = stdlib.join("io.gr").canonicalize().unwrap();
+
+    let entry = project.join("main.gr");
+    fs::write(
+        &entry,
+        format!(
+            "mod main\n\nimport \"{}\"\n\nfn main():\n    ()\n",
+            stdlib_io_abs.display()
+        ),
+    )
+    .unwrap();
+
+    let resolver = ModuleResolver::new(&entry).allow_stdlib_root(&stdlib);
+    let result = resolver.resolve_all(&entry);
+
+    assert!(
+        result.errors.is_empty(),
+        "import under allowlisted stdlib root must succeed, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.modules.contains_key("io"),
+        "io module should be loaded via stdlib allowlist"
+    );
+}
+
+#[test]
+fn with_source_root_uses_explicit_root() {
+    // `with_source_root` lets callers pin a project root that is not the
+    // entry file's parent directory. Imports must still be sandboxed to
+    // the explicit root.
+    let (_tmp, project) = make_project();
+    let sub = project.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    let entry = sub.join("main.gr");
+    fs::write(
+        &entry,
+        "mod main\n\nuse \"../escape.gr\"\n\nfn main():\n    ()\n",
+    )
+    .unwrap();
+    // Even though `../escape.gr` from sub/ resolves to project/escape.gr
+    // (which doesn't exist), we want to confirm that pinning the source
+    // root to `project/` does not let you climb above it. Build a file
+    // at <tmp>/escape.gr (one level above project/) and confirm it stays
+    // unreachable.
+    let above = project.parent().unwrap().join("escape.gr");
+    fs::write(&above, "mod escape\nfn x() -> Int:\n    1\n").unwrap();
+
+    // Entry is sub/main.gr; explicit source_root is project/.
+    // `../escape.gr` from sub/main.gr resolves to project/escape.gr, which
+    // does not exist; the climb to <tmp>/escape.gr would require `../../`.
+    // What matters is that even an explicit `../../escape.gr` cannot
+    // escape the pinned root.
+    fs::write(
+        &entry,
+        "mod main\n\nuse \"../../escape.gr\"\n\nfn main():\n    ()\n",
+    )
+    .unwrap();
+
+    let resolver = ModuleResolver::with_source_root(&entry, &project);
+    let result = resolver.resolve_all(&entry);
+
+    assert!(
+        !result.errors.is_empty(),
+        "expected resolution error climbing above explicit source root"
+    );
+    assert!(
+        !result.modules.contains_key("escape"),
+        "escape module must not load via `../../` against pinned root"
+    );
+}


### PR DESCRIPTION
Fixes #181

## Summary
Adds a security boundary to `ModuleResolver`: every successfully-located import candidate is canonicalized and asserted to lie under the canonicalized source root (or an allowlisted stdlib root). Imports that try to escape via `..`, an absolute path, or a symlink pointing out of the root are rejected before the file is read.

## Design
- `ModuleResolver::source_root: Option<PathBuf>` — canonicalized at construction; defaults to the parent of the entry file.
- `ModuleResolver::with_source_root(entry_file, root)` — explicit pin for callers that want the project root, not the entry file's dir.
- `.allow_stdlib_root(&Path)` builder — opt-in extra root for absolute imports (e.g. stdlib install dir). Non-existent paths silently dropped.
- `enforce_sandbox(candidate) -> Option<PathBuf>` — single security gate. Uses `std::fs::canonicalize` + `Path::starts_with` (no string matching). Both `resolve_file_path` and `resolve_module_path` route every existence-confirmed candidate through it.
- **Default for absolute paths: deny.** With no stdlib root configured, any absolute path outside `source_root` fails the check.

## Backward compatibility
- `Session::from_source(&str)` is filesystem-free and unaffected.
- `Session::from_file(&Path)` keeps its signature and inherits the sandbox.
- `cargo test -p gradient-compiler --lib` → 1099 passed (baseline preserved); all integration test suites still green.

## Test plan
New `codebase/compiler/tests/import_sandbox_tests.rs` (7 cases) covers all required acceptance criteria plus positive controls:

| Test | Asserts |
|---|---|
| `rejects_parent_dir_escape_via_use` | `../escape.gr` denied via `use` |
| `rejects_parent_dir_escape_via_import_statement` | `../escape.gr` denied via `import` |
| `rejects_absolute_path_import_outside_root` | absolute path denied |
| `rejects_symlink_pointing_outside_root` | canonicalize follows the link, fails `starts_with` |
| `allows_in_root_relative_imports` | normal same-dir import still works |
| `allows_absolute_path_when_under_stdlib_root` | stdlib allowlist works |
| `with_source_root_uses_explicit_root` | explicit root blocks `../../` escape |

```
cargo test -p gradient-compiler --test import_sandbox_tests
test result: ok. 7 passed; 0 failed
cargo test -p gradient-compiler --lib
test result: ok. 1099 passed; 0 failed; 1 ignored
```

No new clippy warnings.
