### PR TITLE
fix(wasm): trap on bump-allocator overflow + cap memory.maximum (#183)

### DIFF
--- a/codebase/compiler/Cargo.toml
+++ b/codebase/compiler/Cargo.toml
@@ -83,3 +83,7 @@ features = ["v4"]
 [dev-dependencies]
 # Temporary directories for multi-file module resolution tests.
 tempfile = "3"
+# GRA-183: parse emitted WASM modules in regression tests to assert on
+# overflow-guard structure and the memory `maximum` field. Pinned to a
+# version compatible with `wasm-encoder 0.200`.
+wasmparser = "0.200"

--- a/codebase/compiler/src/backend/wasm.rs
+++ b/codebase/compiler/src/backend/wasm.rs
@@ -107,6 +107,12 @@ pub struct WasmBackend {
     /// Function index counter for internal functions
     next_func_idx: u32,
 
+    /// Maximum number of WASM pages the emitted memory may grow to.
+    ///
+    /// Used as `MemoryType.maximum`. Defaults to [`Self::DEFAULT_MAX_PAGES`]
+    /// (256 MiB at 64 KiB per page). Configure with [`Self::with_max_pages`].
+    max_pages: u32,
+
     /// Export section builder
     exports: ExportSection,
 
@@ -142,6 +148,19 @@ pub struct WasmBackend {
 }
 
 impl WasmBackend {
+    /// Default maximum number of WASM pages the emitted linear memory may grow to.
+    ///
+    /// At 64 KiB per page this is 256 MiB. Set on the emitted `MemoryType.maximum`
+    /// to bound host RSS when running untrusted modules. Override with
+    /// [`Self::with_max_pages`] if a host needs a different ceiling.
+    ///
+    /// WASM32 hard limit is 65_536 pages (4 GiB); values above that are clamped
+    /// by [`Self::with_max_pages`].
+    pub const DEFAULT_MAX_PAGES: u32 = 4096;
+
+    /// Absolute hard limit per WASM32 spec (4 GiB / 64 KiB).
+    pub const WASM32_MAX_PAGES: u32 = 65_536;
+
     /// Create a new WASM backend with initial memory setup.
     ///
     /// Initializes:
@@ -149,6 +168,16 @@ impl WasmBackend {
     /// - Heap pointer global starting after the data section
     /// - WASI imports for fd_write and proc_exit
     pub fn new() -> Result<Self, WasmCodegenError> {
+        Self::with_max_pages(Self::DEFAULT_MAX_PAGES)
+    }
+
+    /// Create a new WASM backend with a custom maximum page count.
+    ///
+    /// `max_pages` is the upper bound on `memory.grow`. Values are clamped to
+    /// `[1, WASM32_MAX_PAGES]`. Embedders that need a smaller sandbox (e.g. 16
+    /// pages = 1 MiB for a fuzzer) or a larger one can override the default.
+    pub fn with_max_pages(max_pages: u32) -> Result<Self, WasmCodegenError> {
+        let max_pages = max_pages.clamp(1, Self::WASM32_MAX_PAGES);
         let mut exports = ExportSection::new();
         let functions = FunctionSection::new();
         let code = CodeSection::new();
@@ -158,10 +187,11 @@ impl WasmBackend {
         let data = DataSection::new();
         let types = TypeSection::new();
 
-        // Memory: 1 page (64KB) minimum, no maximum
+        // Memory: 1 page (64KB) minimum, max bounded by `max_pages` to cap host
+        // RSS when executing untrusted modules (sec/GRA-183).
         memories.memory(MemoryType {
             minimum: 1,
-            maximum: None,
+            maximum: Some(max_pages as u64),
             memory64: false,
             shared: false,
         });
@@ -197,6 +227,7 @@ impl WasmBackend {
             needs_fd_write: false,
             needs_proc_exit: false,
             next_func_idx: 0, // C-2: import slots allocated lazily; internal funcs start at 0
+            max_pages,
             exports,
             functions,
             code,
@@ -285,14 +316,19 @@ impl WasmBackend {
     /// Emit the malloc builtin function.
     ///
     /// C-1 fix: safe bump allocator with memory.grow + unreachable trap.
+    /// sec/GRA-183: explicit u32 overflow guards in front of every `i32.add`
+    /// that could wrap a 32-bit pointer arithmetic.
     ///
     /// Algorithm (matches spec):
     ///   current_ptr = global.get $__heap_ptr
+    ///   // GRA-183: trap if size > u32::MAX - current_ptr (would overflow new_ptr)
     ///   new_ptr     = current_ptr + size
+    ///   // GRA-183: trap if new_ptr > u32::MAX - 65535 (would overflow needed_pages calc)
     ///   needed_pages = (new_ptr + 65535) >> 16
     ///   if needed_pages > memory.size:
     ///     grown = memory.grow(needed_pages - memory.size)
-    ///     if grown == -1: unreachable   // trap; no -1 sentinel escapes
+    ///     if grown == -1: unreachable   // trap; no -1 sentinel escapes,
+    ///                                   // and memory.maximum bounds total RSS
     ///   global.set $__heap_ptr new_ptr
     ///   return current_ptr
     ///
@@ -313,11 +349,36 @@ impl WasmBackend {
         func.instruction(&WasmInstr::GlobalGet(self.heap_ptr_global_idx));
         func.instruction(&WasmInstr::LocalSet(1));
 
+        // GRA-183 overflow guard #1: trap if size > u32::MAX - current_ptr.
+        //
+        // Compute headroom = 0xFFFF_FFFF - current_ptr (unsigned subtract; cannot
+        // wrap because current_ptr is itself a u32 in [0, u32::MAX]).
+        // Then if size (treated unsigned) > headroom, the bump add would wrap.
+        // We materialise 0xFFFF_FFFF as the i32 const -1 (same bit pattern).
+        func.instruction(&WasmInstr::I32Const(-1i32)); // 0xFFFF_FFFF
+        func.instruction(&WasmInstr::LocalGet(1)); // current_ptr
+        func.instruction(&WasmInstr::I32Sub); // headroom = u32::MAX - current_ptr
+        func.instruction(&WasmInstr::LocalGet(0)); // size
+        func.instruction(&WasmInstr::I32LtU); // headroom <u size  ↔  size > headroom
+        func.instruction(&WasmInstr::If(BlockType::Empty));
+        func.instruction(&WasmInstr::Unreachable);
+        func.instruction(&WasmInstr::End);
+
         // new_ptr = current_ptr + size  → local 2
         func.instruction(&WasmInstr::LocalGet(1));
         func.instruction(&WasmInstr::LocalGet(0)); // size param
         func.instruction(&WasmInstr::I32Add);
         func.instruction(&WasmInstr::LocalSet(2));
+
+        // GRA-183 overflow guard #2: trap if new_ptr > u32::MAX - 65535
+        // (the next add for the page-rounding would otherwise wrap).
+        // Equivalent: if new_ptr > 0xFFFF_0000.
+        func.instruction(&WasmInstr::LocalGet(2));
+        func.instruction(&WasmInstr::I32Const(0xFFFF_0000u32 as i32));
+        func.instruction(&WasmInstr::I32GtU);
+        func.instruction(&WasmInstr::If(BlockType::Empty));
+        func.instruction(&WasmInstr::Unreachable);
+        func.instruction(&WasmInstr::End);
 
         // needed_pages = (new_ptr + 65535) >> 16  → local 3
         func.instruction(&WasmInstr::LocalGet(2));
@@ -338,6 +399,10 @@ impl WasmBackend {
         func.instruction(&WasmInstr::If(BlockType::Empty));
         {
             // grown = memory.grow(needed_pages - current_pages)  → local 5
+            //
+            // sec/GRA-183: memory.grow returns -1 when the request would exceed
+            // the static `MemoryType.maximum` we now emit, so a malicious huge
+            // `needed_pages` is bounded both by the engine *and* by us.
             func.instruction(&WasmInstr::LocalGet(3));
             func.instruction(&WasmInstr::LocalGet(4));
             func.instruction(&WasmInstr::I32Sub);

--- a/codebase/compiler/src/codegen/wasm.rs
+++ b/codebase/compiler/src/codegen/wasm.rs
@@ -90,16 +90,35 @@ pub struct WasmBackend {
     /// Builtin function indices.
     malloc_idx: Option<u32>,
     println_idx: Option<u32>,
+
+    /// Maximum number of WASM pages the emitted memory may grow to.
+    /// Mirrors `backend::wasm::WasmBackend::max_pages`.
+    max_pages: u32,
 }
 
 #[allow(dead_code)] // helpers staged for upcoming codegen passes
 impl WasmBackend {
+    /// Default maximum number of WASM pages (256 MiB at 64 KiB per page).
+    /// See `backend::wasm::WasmBackend::DEFAULT_MAX_PAGES` (sec/GRA-183).
+    pub const DEFAULT_MAX_PAGES: u32 = 4096;
+
+    /// WASM32 spec hard limit (4 GiB / 64 KiB).
+    pub const WASM32_MAX_PAGES: u32 = 65_536;
+
     /// Create a new WASM backend.
     ///
     /// C-2: WASI imports are NOT added at construction time.  They are computed
     /// in `compile_module` by scanning the IR for IO/FS-effect calls, so a pure
     /// module never imports `fd_write` or `proc_exit`.
     pub fn new() -> Result<Self, CodegenError> {
+        Self::with_max_pages(Self::DEFAULT_MAX_PAGES)
+    }
+
+    /// Create a new WASM backend with a custom maximum page count (sec/GRA-183).
+    ///
+    /// `max_pages` is clamped to `[1, WASM32_MAX_PAGES]`.
+    pub fn with_max_pages(max_pages: u32) -> Result<Self, CodegenError> {
+        let max_pages = max_pages.clamp(1, Self::WASM32_MAX_PAGES);
         let module = Module::new();
 
         Ok(WasmBackend {
@@ -116,6 +135,7 @@ impl WasmBackend {
             internal_function_base: 0, // updated after scanning imports
             malloc_idx: None,
             println_idx: None,
+            max_pages,
         })
     }
 
@@ -863,10 +883,12 @@ impl CodegenBackend for WasmBackend {
         // Phase 4: Memory Section
         // ============================================
         let mut memory_section = wasm_encoder::MemorySection::new();
-        // C-1: no hard cap — let memory.grow handle expansion dynamically.
+        // C-1: memory.grow handles dynamic expansion at runtime.
+        // sec/GRA-183: cap maximum at `self.max_pages` (default 4096 = 256 MiB)
+        // so a malicious or buggy guest cannot exhaust host RSS.
         memory_section.memory(wasm_encoder::MemoryType {
             minimum: 1,
-            maximum: None,
+            maximum: Some(self.max_pages as u64),
             memory64: false,
             shared: false,
         });
@@ -921,11 +943,31 @@ impl CodegenBackend for WasmBackend {
             malloc_func.instruction(&WasmInstr::GlobalGet(0));
             malloc_func.instruction(&WasmInstr::LocalSet(1));
 
+            // sec/GRA-183 overflow guard #1: trap if size > u32::MAX - current_ptr.
+            // headroom = 0xFFFF_FFFF - current_ptr; if headroom <u size → trap.
+            malloc_func.instruction(&WasmInstr::I32Const(-1i32)); // 0xFFFF_FFFF
+            malloc_func.instruction(&WasmInstr::LocalGet(1));
+            malloc_func.instruction(&WasmInstr::I32Sub);
+            malloc_func.instruction(&WasmInstr::LocalGet(0));
+            malloc_func.instruction(&WasmInstr::I32LtU);
+            malloc_func.instruction(&WasmInstr::If(wasm_encoder::BlockType::Empty));
+            malloc_func.instruction(&WasmInstr::Unreachable);
+            malloc_func.instruction(&WasmInstr::End);
+
             // new_ptr = current_ptr + size  → local 2
             malloc_func.instruction(&WasmInstr::LocalGet(1));
             malloc_func.instruction(&WasmInstr::LocalGet(0));
             malloc_func.instruction(&WasmInstr::I32Add);
             malloc_func.instruction(&WasmInstr::LocalSet(2));
+
+            // sec/GRA-183 overflow guard #2: trap if new_ptr > 0xFFFF_0000
+            // (the next add `new_ptr + 65535` for the page-rounding would wrap).
+            malloc_func.instruction(&WasmInstr::LocalGet(2));
+            malloc_func.instruction(&WasmInstr::I32Const(0xFFFF_0000u32 as i32));
+            malloc_func.instruction(&WasmInstr::I32GtU);
+            malloc_func.instruction(&WasmInstr::If(wasm_encoder::BlockType::Empty));
+            malloc_func.instruction(&WasmInstr::Unreachable);
+            malloc_func.instruction(&WasmInstr::End);
 
             // needed_pages = (new_ptr + 65535) >> 16  → local 3
             malloc_func.instruction(&WasmInstr::LocalGet(2));

--- a/codebase/compiler/tests/wasm_allocator_overflow_tests.rs
+++ b/codebase/compiler/tests/wasm_allocator_overflow_tests.rs
@@ -1,0 +1,204 @@
+//! GRA-183 regression tests: WASM allocator overflow guards + memory cap.
+//!
+//! These tests verify the emitted WASM module:
+//! 1. carries an explicit `MemoryType.maximum` (DoS protection),
+//! 2. contains the overflow-guard `Unreachable` traps in the bump
+//!    allocator that prevent `current_ptr + size` from wrapping past
+//!    `u32::MAX`, and
+//! 3. honors the per-backend `with_max_pages` override.
+//!
+//! We don't link wasmtime at the unit-test layer — instead we parse the
+//! emitted bytes with `wasmparser` (already a transitive dep through
+//! `wasm-encoder`) and assert on the structural shape. This keeps the
+//! suite offline and fast.
+
+#[cfg(feature = "wasm")]
+mod wasm_overflow_tests {
+    use gradient_compiler::backend::WasmBackend;
+    use gradient_compiler::ir::{BasicBlock, BlockRef, Function, Instruction, Module, Type};
+    use std::collections::HashMap;
+
+    fn empty_main_module() -> Module {
+        // Smallest legal IR: one function `main` with a single block
+        // returning. Mirrors `create_add_function` from wasm_tests.rs.
+        let entry_block = BasicBlock {
+            label: BlockRef(0),
+            instructions: vec![Instruction::Ret(None)],
+        };
+        let main = Function {
+            name: "main".to_string(),
+            params: vec![],
+            return_type: Type::I32,
+            blocks: vec![entry_block],
+            value_types: HashMap::new(),
+            is_export: true,
+            extern_lib: None,
+        };
+        Module {
+            name: "test".to_string(),
+            functions: vec![main],
+            func_refs: {
+                let mut r = HashMap::new();
+                r.insert(gradient_compiler::ir::FuncRef(0), "main".to_string());
+                r
+            },
+        }
+    }
+
+    fn compile(backend: &mut WasmBackend, module: &Module) -> Vec<u8> {
+        backend
+            .compile_module(module)
+            .expect("compile_module failed");
+        // `finish` consumes the backend; replace with a fresh one so the
+        // caller doesn't see a moved value. The caller never reuses the
+        // borrow after this returns.
+        let taken = std::mem::replace(backend, WasmBackend::new().expect("new"));
+        taken.finish().expect("finish failed")
+    }
+
+    /// Default `WasmBackend::new()` must emit `memory.maximum = DEFAULT_MAX_PAGES`.
+    /// Without an upper bound, `memory.grow` is unbounded and a malicious guest
+    /// can DoS the host by allocating until OOM.
+    #[test]
+    fn emitted_memory_has_default_maximum() {
+        let module = empty_main_module();
+        let mut backend = WasmBackend::new().expect("backend");
+        let bytes = compile(&mut backend, &module);
+
+        let parser = wasmparser::Parser::new(0);
+        let mut saw_memory = false;
+        for payload in parser.parse_all(&bytes) {
+            if let Ok(wasmparser::Payload::MemorySection(reader)) = payload {
+                for mem in reader {
+                    let mem = mem.expect("memory entry");
+                    saw_memory = true;
+                    let max = mem.maximum.expect(
+                        "GRA-183: emitted memory must declare a `maximum`; \
+                         unbounded `memory.grow` is a host-DoS vector",
+                    );
+                    assert!(
+                        max <= WasmBackend::WASM32_MAX_PAGES as u64,
+                        "max {} above WASM32 hard limit",
+                        max
+                    );
+                    assert_eq!(
+                        max, WasmBackend::DEFAULT_MAX_PAGES as u64,
+                        "default backend should emit DEFAULT_MAX_PAGES",
+                    );
+                }
+            }
+        }
+        assert!(saw_memory, "no memory section found in emitted module");
+    }
+
+    /// `WasmBackend::with_max_pages(n)` must propagate `n` (clamped to
+    /// `[1, WASM32_MAX_PAGES]`) to the emitted `MemoryType.maximum`. This
+    /// lets embedders tighten the sandbox below the default.
+    #[test]
+    fn with_max_pages_overrides_emitted_maximum() {
+        let module = empty_main_module();
+        // Use a tight cap — 16 pages = 1 MiB — typical fuzzer sandbox size.
+        let mut backend = WasmBackend::with_max_pages(16).expect("backend");
+        let bytes = compile(&mut backend, &module);
+
+        let parser = wasmparser::Parser::new(0);
+        for payload in parser.parse_all(&bytes) {
+            if let Ok(wasmparser::Payload::MemorySection(reader)) = payload {
+                for mem in reader {
+                    let mem = mem.expect("memory entry");
+                    assert_eq!(mem.maximum, Some(16), "with_max_pages(16) not honored");
+                }
+            }
+        }
+    }
+
+    /// `with_max_pages` must clamp to `[1, WASM32_MAX_PAGES]`. Specifically:
+    /// - 0 must clamp up to 1 (a memory with `min=1, max=0` is malformed).
+    /// - Values > WASM32_MAX_PAGES must clamp down (avoid emitting an
+    ///   illegal memory type that wasmtime / browsers reject).
+    #[test]
+    fn with_max_pages_clamps_extremes() {
+        let module = empty_main_module();
+
+        let mut zero = WasmBackend::with_max_pages(0).expect("zero");
+        let bytes = compile(&mut zero, &module);
+        for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+            if let Ok(wasmparser::Payload::MemorySection(reader)) = payload {
+                for mem in reader {
+                    assert_eq!(mem.unwrap().maximum, Some(1), "0 must clamp up to 1");
+                }
+            }
+        }
+
+        let mut big = WasmBackend::with_max_pages(u32::MAX).expect("big");
+        let bytes = compile(&mut big, &module);
+        for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+            if let Ok(wasmparser::Payload::MemorySection(reader)) = payload {
+                for mem in reader {
+                    assert_eq!(
+                        mem.unwrap().maximum,
+                        Some(WasmBackend::WASM32_MAX_PAGES as u64),
+                        "u32::MAX must clamp down to WASM32 hard limit"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The bump allocator must contain at least two `Unreachable` instructions
+    /// guarding integer-overflow conditions before the `i32.add` for the
+    /// pointer bump and the page-rounding `i32.add`. We don't try to match
+    /// the exact byte sequence (that's brittle); we just assert the malloc
+    /// function body contains ≥ 2 `unreachable` opcodes, which is the
+    /// minimum count consistent with the GRA-183 patch.
+    #[test]
+    fn bump_allocator_has_overflow_traps() {
+        let module = empty_main_module();
+        let mut backend = WasmBackend::new().expect("backend");
+        let bytes = compile(&mut backend, &module);
+
+        // The emitted module must contain at least 3 `0x00` (unreachable)
+        // opcodes inside function bodies: 2 from the overflow guards and
+        // ≥1 from the existing memory.grow == -1 trap added in PR #168.
+        // We scan the code section as a whole — counting per-function would
+        // require full operator iteration which is heavier than necessary
+        // for a regression test. The number of `Unreachable` opcodes is
+        // monotonically non-decreasing relative to PR #168's baseline.
+        let mut total_unreachable = 0usize;
+        let mut total_funcs = 0usize;
+        let parser = wasmparser::Parser::new(0);
+        for payload in parser.parse_all(&bytes) {
+            if let Ok(wasmparser::Payload::CodeSectionEntry(body)) = payload {
+                total_funcs += 1;
+                let ops = body.get_operators_reader().expect("operators");
+                for op in ops {
+                    if matches!(op.expect("op"), wasmparser::Operator::Unreachable) {
+                        total_unreachable += 1;
+                    }
+                }
+            }
+        }
+        assert!(total_funcs >= 1, "no function bodies emitted");
+        assert!(
+            total_unreachable >= 3,
+            "GRA-183: expected ≥3 Unreachable traps across the module \
+             (2 new overflow guards + ≥1 memory.grow guard from PR #168), \
+             saw {}",
+            total_unreachable,
+        );
+    }
+
+    /// Sanity: the emitted bytes still parse as a valid WASM module after
+    /// the overflow guards are inserted. If the trap sequence is malformed
+    /// (e.g. unbalanced `If` / `End`), `wasmparser` will reject it.
+    #[test]
+    fn emitted_module_is_structurally_valid() {
+        let module = empty_main_module();
+        let mut backend = WasmBackend::new().expect("backend");
+        let bytes = compile(&mut backend, &module);
+        let parser = wasmparser::Parser::new(0);
+        for payload in parser.parse_all(&bytes) {
+            payload.expect("WASM module must round-trip through wasmparser");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #183

Follow-up to merged PR #168 (sec/wave-2 WASM hardening).

## Summary
Two hardening changes to the WASM backend:

### 1. Overflow guards in the bump allocator
The `malloc` builtin previously emitted raw `i32.add` for both `new_ptr = current_ptr + size` and the page-rounding `new_ptr + 65535`. Both wrap at the 32-bit boundary; a malicious or buggy guest could allocate overlapping objects in linear memory.

Two explicit `unreachable` traps now run before each add:
- trap if `size > u32::MAX - current_ptr` (the bump add would wrap)
- trap if `new_ptr > 0xFFFF_0000` (the page-rounding add would wrap)

### 2. Bounded `MemoryType.maximum`
The emitted memory previously had `maximum: None`, so a guest could `memory.grow` indefinitely and exhaust host RSS.

- Default cap: `DEFAULT_MAX_PAGES = 4096` (= 256 MiB at 64 KiB / page).
- Hard ceiling: `WASM32_MAX_PAGES = 65_536` (4 GiB, the spec maximum).
- Configurable via `WasmBackend::with_max_pages(n)`; values clamped to `[1, WASM32_MAX_PAGES]`.

Both changes are applied symmetrically to `codebase/compiler/src/codegen/wasm.rs` (the live backend used by `BackendWrapper`) and `codebase/compiler/src/backend/wasm.rs` (used by the unit tests).

## Test plan
New `codebase/compiler/tests/wasm_allocator_overflow_tests.rs` (5 cases). Tests parse the emitted bytes with `wasmparser` (added as a dev-dep, pinned to 0.200 to match `wasm-encoder` 0.200) and assert structural invariants:

| Test | Asserts |
|---|---|
| `emitted_memory_has_default_maximum` | `MemoryType.maximum = Some(DEFAULT_MAX_PAGES)` |
| `with_max_pages_overrides_emitted_maximum` | per-backend override propagates |
| `with_max_pages_clamps_extremes` | 0 → 1, `u32::MAX` → `WASM32_MAX_PAGES` |
| `bump_allocator_has_overflow_traps` | ≥ 3 `unreachable` opcodes across the module (2 new + ≥ 1 from #168) |
| `emitted_module_is_structurally_valid` | full `wasmparser` round-trip |

```
cargo test -p gradient-compiler --features wasm --test wasm_allocator_overflow_tests
test result: ok. 5 passed; 0 failed
cargo test -p gradient-compiler --features wasm --test wasm_tests
test result: ok. 10 passed; 0 failed
cargo clippy -p gradient-compiler --features wasm --lib -- -D warnings
clean
```
