### PR TITLE
feat(self-hosting): harden parser export readiness contract

### DIFF
--- a/codebase/compiler/tests/parser_differential_tests.rs
+++ b/codebase/compiler/tests/parser_differential_tests.rs
@@ -529,6 +529,8 @@ fn assert_self_hosted_parser_export_contract() {
         "fn normalized_stmt_to_json",
         "fn normalized_function_to_json",
         "fn normalized_module_to_json",
+        "fn normalized_export_contract_version",
+        "fn parser_direct_execution_ready",
     ];
     for export in required_exports {
         assert!(
@@ -546,6 +548,16 @@ fn assert_self_hosted_parser_export_contract() {
         "Function { name: name, params: 0",
         "FunctionItem(0)",
         "Module { name: name, items: 0 }",
+        "ret \"module:\"",
+        "ret \"function:\"",
+        "ret \"named:Int\"",
+        "ret \"int:\"",
+        "ret \"bool:true\"",
+        "ret \"string:\"",
+        "ret \"ident:\"",
+        "ret \"unsupported:expr\"",
+        "ret \"unsupported:stmt\"",
+        "ret \"unsupported:type\"",
     ];
     for placeholder in forbidden_placeholders {
         assert!(
@@ -555,15 +567,24 @@ fn assert_self_hosted_parser_export_contract() {
     }
 }
 
+fn parser_gr_function_body<'a>(src: &'a str, signature: &str) -> Option<&'a str> {
+    let start = src.find(signature)?;
+    let after_signature = &src[start + signature.len()..];
+    let end = after_signature
+        .find("\n\n    fn ")
+        .unwrap_or(after_signature.len());
+    Some(&after_signature[..end])
+}
+
 fn parser_gr_direct_execution_available() -> bool {
     let src = fs::read_to_string(self_hosted_parser_path()).expect("read compiler/parser.gr");
 
-    // Direct execution is not meaningful while parser.gr token access is stubbed:
-    // parse_module would observe Eof immediately and produce an empty module.
-    !src.contains("fn current_token(p: Parser) -> Token:\n        ret Token { kind: Eof")
-        && !src.contains(
-            "fn peek_token(p: Parser, offset: Int) -> Token:\n        ret Token { kind: Eof",
-        )
+    // Direct execution is intentionally gated by an explicit self-hosted marker,
+    // not by brittle token-stub substring matching. The marker must flip to true
+    // only when parser.gr can execute over real TokenList/list-backed values.
+    parser_gr_function_body(&src, "fn parser_direct_execution_ready() -> Bool:")
+        .map(|body| body.contains("ret true") && !body.contains("ret false"))
+        .unwrap_or(false)
 }
 
 fn direct_parser_gr_parse_source_to_canonical_json(_src: &str) -> Option<String> {

--- a/codebase/compiler/tests/self_hosting_bootstrap.rs
+++ b/codebase/compiler/tests/self_hosting_bootstrap.rs
@@ -204,6 +204,40 @@ fn lexer_parser_query_have_no_dummy_collection_fields() {
     }
 }
 
+fn parser_gr_function_body<'a>(src: &'a str, signature: &str) -> Option<&'a str> {
+    let start = src.find(signature)?;
+    let after_signature = &src[start + signature.len()..];
+    let end = after_signature
+        .find("\n\n    fn ")
+        .unwrap_or(after_signature.len());
+    Some(&after_signature[..end])
+}
+
+#[test]
+fn parser_gr_exposes_direct_execution_readiness_metadata() {
+    let parser_content =
+        std::fs::read_to_string(compiler_path("parser.gr")).expect("Failed to read parser.gr");
+
+    assert!(
+        parser_content.contains("fn normalized_export_contract_version() -> String:"),
+        "parser.gr should expose a normalized export contract version"
+    );
+    assert!(
+        parser_content.contains("ret \"canonical-json-v1\""),
+        "parser.gr normalized export contract version should be canonical-json-v1"
+    );
+
+    let readiness_body = parser_gr_function_body(
+        &parser_content,
+        "fn parser_direct_execution_ready() -> Bool:",
+    )
+    .expect("parser.gr should expose explicit direct-execution readiness metadata");
+    assert!(
+        readiness_body.contains("ret false") && !readiness_body.contains("ret true"),
+        "parser.gr direct execution must remain false until TokenList/list storage is real"
+    );
+}
+
 /// Count functions defined in self-hosted code
 #[test]
 fn self_hosted_function_count() {

--- a/compiler/parser.gr
+++ b/compiler/parser.gr
@@ -360,16 +360,22 @@ mod parser:
             ModuleItemError(_):
                 ret 96
 
+    fn json_string(value: String) -> String:
+        // Bootstrap subset strings are currently identifier/literal payloads
+        // without escape processing. Keep this seam explicit until the runtime
+        // provides full JSON escaping.
+        ret "\"" + value + "\""
+
     fn normalized_type_to_json(t: TypeExpr) -> String:
         match t:
             IntType:
-                ret "named:Int"
+                ret "{\"kind\":\"named\",\"name\":\"Int\"}"
             BoolType:
-                ret "named:Bool"
+                ret "{\"kind\":\"named\",\"name\":\"Bool\"}"
             StringType:
-                ret "named:String"
+                ret "{\"kind\":\"named\",\"name\":\"String\"}"
             _:
-                ret "unsupported:type"
+                ret "{\"kind\":\"unsupported\",\"reason\":\"type outside bootstrap subset\"}"
 
     fn binop_to_json_name(op: BinOp) -> String:
         match op:
@@ -410,52 +416,60 @@ mod parser:
     fn normalized_expr_to_json(expr: Expr) -> String:
         match expr:
             IntLitExpr(value):
-                ret "int:" + value.to_string()
+                ret "{\"kind\":\"int_lit\",\"value\":" + value.to_string() + "}"
             BoolLitExpr(value):
                 if value:
-                    ret "bool:true"
-                ret "bool:false"
+                    ret "{\"kind\":\"bool_lit\",\"value\":true}"
+                ret "{\"kind\":\"bool_lit\",\"value\":false}"
             StringLitExpr(value):
-                ret "string:" + value
+                ret "{\"kind\":\"string_lit\",\"value\":" + json_string(value) + "}"
             IdentExpr(name):
-                ret "ident:" + name
+                ret "{\"kind\":\"ident\",\"name\":" + json_string(name) + "}"
             BinaryExpr(op, left, right):
-                ret "binary:" + binop_to_json_name(op) + ":" + left.to_string() + ":" + right.to_string()
+                ret "{\"kind\":\"binary\",\"op\":" + json_string(binop_to_json_name(op)) + ",\"left_handle\":" + left.to_string() + ",\"right_handle\":" + right.to_string() + "}"
             UnaryExpr(op, operand):
-                ret "unary:" + unop_to_json_name(op) + ":" + operand.to_string()
+                ret "{\"kind\":\"unary\",\"op\":" + json_string(unop_to_json_name(op)) + ",\"operand_handle\":" + operand.to_string() + "}"
             CallExpr(callee, args):
-                ret "call:" + callee.to_string() + ":" + args.to_string()
+                ret "{\"kind\":\"call\",\"callee_handle\":" + callee.to_string() + ",\"args_handle\":" + args.to_string() + "}"
             IfExpr(cond, then_branch, else_branch):
-                ret "if:" + cond.to_string() + ":" + then_branch.to_string() + ":" + else_branch.to_string()
+                ret "{\"kind\":\"if\",\"cond_handle\":" + cond.to_string() + ",\"then_handle\":" + then_branch.to_string() + ",\"else_handle\":" + else_branch.to_string() + "}"
             BlockExpr(stmts, final_expr):
-                ret "block:" + stmts.to_string() + ":" + final_expr.to_string()
+                ret "{\"kind\":\"block\",\"stmts_handle\":" + stmts.to_string() + ",\"final_expr_handle\":" + final_expr.to_string() + "}"
             ExprError(message):
-                ret "unsupported:" + message
+                ret "{\"kind\":\"unsupported\",\"reason\":" + json_string(message) + "}"
             _:
-                ret "unsupported:expr"
+                ret "{\"kind\":\"unsupported\",\"reason\":\"expr outside bootstrap subset\"}"
 
     fn normalized_stmt_to_json(stmt: Stmt) -> String:
         match stmt:
             LetStmt(pat, type_ann, value, is_mut):
                 let mut_part = if is_mut:
-                    "mut"
+                    "true"
                 else:
-                    "let"
-                ret mut_part + ":" + pattern_bootstrap_handle(pat).to_string() + ":" + type_ann.to_string() + ":" + value.to_string()
+                    "false"
+                ret "{\"kind\":\"let\",\"pattern_handle\":" + pattern_bootstrap_handle(pat).to_string() + ",\"mutable\":" + mut_part + ",\"type_handle\":" + type_ann.to_string() + ",\"value_handle\":" + value.to_string() + "}"
             ExprStmt(expr):
-                ret "expr:" + expr.to_string()
+                ret "{\"kind\":\"expr\",\"value_handle\":" + expr.to_string() + "}"
             RetStmt(value):
-                ret "ret:" + value.to_string()
+                ret "{\"kind\":\"ret\",\"value_handle\":" + value.to_string() + "}"
             StmtError(message):
-                ret "unsupported:" + message
+                ret "{\"kind\":\"unsupported\",\"reason\":" + json_string(message) + "}"
             _:
-                ret "unsupported:stmt"
+                ret "{\"kind\":\"unsupported\",\"reason\":\"stmt outside bootstrap subset\"}"
 
     fn normalized_function_to_json(fn_def: Function) -> String:
-        ret "function:" + fn_def.name + ":" + fn_def.params.to_string() + ":" + normalized_type_to_json(fn_def.ret_type) + ":" + fn_def.body.to_string()
+        ret "{\"kind\":\"function\",\"name\":" + json_string(fn_def.name) + ",\"params_handle\":" + fn_def.params.to_string() + ",\"ret_type\":" + normalized_type_to_json(fn_def.ret_type) + ",\"body_handle\":" + fn_def.body.to_string() + "}"
 
     fn normalized_module_to_json(module: Module) -> String:
-        ret "module:" + module.name + ":" + module.items.to_string()
+        ret "{\"items_handle\":" + module.items.to_string() + ",\"module\":" + json_string(module.name) + "}"
+
+    fn normalized_export_contract_version() -> String:
+        ret "canonical-json-v1"
+
+    fn parser_direct_execution_ready() -> Bool:
+        // Flip to true only when TokenList/list-backed parser state is runtime-backed
+        // and parse_module + normalized_module_to_json execute over real tokens.
+        ret false
 
     // =========================================================================
     // Parser Construction


### PR DESCRIPTION
## Summary
Hardens the self-hosted parser export/readiness contract while keeping #207 direct execution blocked until real token/list-backed execution exists.

## Changes
- Replaces legacy compact normalized export helper strings with JSON-shaped output in `compiler/parser.gr`
- Adds `normalized_export_contract_version() -> "canonical-json-v1"`
- Adds explicit `parser_direct_execution_ready() -> Bool` marker, currently `false`
- Updates parser differential readiness probing to use the explicit marker instead of token-stub substring matching
- Adds bootstrap test coverage for parser export/readiness metadata

## Testing
- `cargo test -p gradient-compiler --test self_hosting_bootstrap --quiet`
- `cargo test -p gradient-compiler --test parser_differential_tests --quiet`
- `cargo test -p gradient-compiler --test self_hosting_smoke --quiet`
- `cargo build -p gradient-compiler --quiet`
- `cargo test -p gradient-compiler --quiet`
- `git diff --check`

Note: `cargo fmt --check` still reports pre-existing formatting drift outside this PR's edited files.

## Related
Fixes #214
Fixes #215
Fixes #216

References #207
