### PR TITLE
feat(self-hosting): wire parser.gr token access to real TokenList storage (#221)

### DIFF
--- a/codebase/compiler/src/bootstrap_parser_bridge.rs
+++ b/codebase/compiler/src/bootstrap_parser_bridge.rs
@@ -1,0 +1,414 @@
+//! Bridge that mirrors `compiler/parser.gr` token-access semantics over the
+//! runtime-backed [`BootstrapCollectionStore`].
+//!
+//! Issue #221: until the self-hosted runtime can execute `parser.gr` directly,
+//! we model `current_token`, `peek_token`, and `parser_advance` in Rust so
+//! that they exercise the *same* host store the rewritten Gradient functions
+//! call into via the `bootstrap_token_list_get_*` extern primitives. This
+//! gives downstream parser execution (parser differential gate, IR builder,
+//! checker) a stable substrate to consume real token streams from
+//! self-hosted code.
+//!
+//! The bridge intentionally maps to the FFI-primitive contract used by the
+//! self-hosted parser:
+//!   * `bootstrap_token_list_get_kind(handle, index) -> Int` (Eof tag on OOB)
+//!   * `bootstrap_token_list_get_file_id(handle, index) -> Int`
+//!   * `bootstrap_token_list_get_start_offset(handle, index) -> Int`
+//!   * `bootstrap_token_list_get_end_offset(handle, index) -> Int`
+//!
+//! Each accessor encodes the same out-of-bounds-as-Eof / zero-span semantics
+//! used by `parser.gr::current_token` / `peek_token`. Token *payloads*
+//! (identifier names, literal values) are intentionally lossy — the
+//! self-hosted parser cannot recover them through the primitive FFI yet, so
+//! parser direct execution remains gated until payload access lands.
+
+use crate::bootstrap_collections::{BootstrapCollectionStore, BootstrapHandle};
+use crate::bootstrap_lexer_bridge::{tokenize_via_bootstrap_store, BootstrapTokenList};
+use crate::lexer::token::{Position, Span, Token, TokenKind};
+
+/// Out-of-bounds sentinel: matches `lexer.gr::token_kind_tag(Eof) = 1`.
+pub const EOF_KIND_TAG: i64 = 1;
+
+/// Encode a [`TokenKind`] into the same integer space as
+/// `lexer.gr::token_kind_tag`.
+///
+/// Variants the self-hosted lexer doesn't surface (e.g. floats, char literals,
+/// multi-char operators not in the bootstrap subset) hit the dense catch-all
+/// tag `999`, mirroring the wildcard arm in `lexer.gr::token_kind_tag`.
+pub fn token_kind_tag(kind: &TokenKind) -> i64 {
+    match kind {
+        TokenKind::Eof => 1,
+        TokenKind::Error(_) => 2,
+        TokenKind::Ident(_) => 3,
+        TokenKind::IntLit(_) => 4,
+        TokenKind::FloatLit(_) => 5,
+        TokenKind::StringLit(_) => 6,
+        // The Rust reference TokenKind has no `BoolLit` variant — it tokenizes
+        // `true`/`false` as keyword tokens (`True` / `False`). Tag 7 is
+        // reserved by `lexer.gr::token_kind_tag` for self-hosted BoolLit; it
+        // will never appear in a stream produced by the Rust scanner.
+        TokenKind::Plus => 10,
+        TokenKind::Minus => 11,
+        TokenKind::Star => 12,
+        TokenKind::Slash => 13,
+        TokenKind::Percent => 14,
+        TokenKind::Eq => 15,
+        TokenKind::Ne => 16,
+        TokenKind::Lt => 17,
+        TokenKind::Gt => 18,
+        TokenKind::Le => 19,
+        TokenKind::Ge => 20,
+        TokenKind::Assign => 21,
+        TokenKind::Arrow => 22,
+        TokenKind::LParen => 30,
+        TokenKind::RParen => 31,
+        TokenKind::LBrace => 32,
+        TokenKind::RBrace => 33,
+        TokenKind::LBracket => 34,
+        TokenKind::RBracket => 35,
+        TokenKind::Colon => 36,
+        TokenKind::Comma => 37,
+        // The Rust reference lexer rejects `;` outright; the self-hosted lexer
+        // emits it under tag 38 only when token.gr's `Semi` variant is wired.
+        // Keep the tag stable for round-trip even if we never emit it here.
+        TokenKind::Dot => 39,
+        TokenKind::Fn => 50,
+        TokenKind::Let => 51,
+        TokenKind::Mut => 52,
+        TokenKind::If => 53,
+        TokenKind::Else => 54,
+        TokenKind::For => 55,
+        TokenKind::In => 56,
+        TokenKind::While => 57,
+        TokenKind::Ret => 58,
+        TokenKind::Type => 59,
+        TokenKind::Mod => 60,
+        TokenKind::Use => 61,
+        TokenKind::Impl => 62,
+        TokenKind::Match => 63,
+        TokenKind::True => 64,
+        TokenKind::False => 65,
+        TokenKind::And => 66,
+        TokenKind::Or => 67,
+        TokenKind::Not => 68,
+        TokenKind::Pub => 70,
+        // Catch-all keeps the tag space dense without aliasing onto any of the
+        // explicit tags above; new TokenKind variants surface here.
+        _ => 999,
+    }
+}
+
+/// Inverse of [`token_kind_tag`] for tags the self-hosted parser actually
+/// inspects.
+///
+/// Payload-bearing kinds (`Ident`, `IntLit`, `FloatLit`, `StringLit`,
+/// `BoolLit`, `Error`) lose their payload across the FFI boundary and are
+/// reconstructed with placeholder data. This matches the bootstrap-stage
+/// contract: parser execution can advance over a real token stream and
+/// branch on token kind, but cannot yet recover identifier names or literal
+/// values until a future issue widens the FFI.
+pub fn token_kind_from_tag(tag: i64) -> TokenKind {
+    match tag {
+        1 => TokenKind::Eof,
+        2 => TokenKind::Error(String::new()),
+        3 => TokenKind::Ident(String::new()),
+        4 => TokenKind::IntLit(0),
+        5 => TokenKind::FloatLit(0.0),
+        6 => TokenKind::StringLit(String::new()),
+        // Tag 7 is reserved by the self-hosted lexer for BoolLit but the Rust
+        // TokenKind models booleans as the `True` / `False` keyword variants.
+        // Map it to `Eof` defensively until the FFI carries payloads.
+        7 => TokenKind::Eof,
+        10 => TokenKind::Plus,
+        11 => TokenKind::Minus,
+        12 => TokenKind::Star,
+        13 => TokenKind::Slash,
+        14 => TokenKind::Percent,
+        15 => TokenKind::Eq,
+        16 => TokenKind::Ne,
+        17 => TokenKind::Lt,
+        18 => TokenKind::Gt,
+        19 => TokenKind::Le,
+        20 => TokenKind::Ge,
+        21 => TokenKind::Assign,
+        22 => TokenKind::Arrow,
+        30 => TokenKind::LParen,
+        31 => TokenKind::RParen,
+        32 => TokenKind::LBrace,
+        33 => TokenKind::RBrace,
+        34 => TokenKind::LBracket,
+        35 => TokenKind::RBracket,
+        36 => TokenKind::Colon,
+        37 => TokenKind::Comma,
+        39 => TokenKind::Dot,
+        50 => TokenKind::Fn,
+        51 => TokenKind::Let,
+        52 => TokenKind::Mut,
+        53 => TokenKind::If,
+        54 => TokenKind::Else,
+        55 => TokenKind::For,
+        56 => TokenKind::In,
+        57 => TokenKind::While,
+        58 => TokenKind::Ret,
+        59 => TokenKind::Type,
+        60 => TokenKind::Mod,
+        61 => TokenKind::Use,
+        62 => TokenKind::Impl,
+        63 => TokenKind::Match,
+        64 => TokenKind::True,
+        65 => TokenKind::False,
+        66 => TokenKind::And,
+        67 => TokenKind::Or,
+        68 => TokenKind::Not,
+        70 => TokenKind::Pub,
+        // Treat unknown tags (including the dense catch-all 999) as Eof so
+        // parser execution terminates safely instead of looping on garbage.
+        _ => TokenKind::Eof,
+    }
+}
+
+/// FFI-primitive accessor: kind tag at `index`, or `EOF_KIND_TAG` on OOB.
+pub fn bootstrap_token_list_get_kind(
+    store: &BootstrapCollectionStore<Token>,
+    handle: BootstrapHandle<Token>,
+    index: i64,
+) -> i64 {
+    if index < 0 {
+        return EOF_KIND_TAG;
+    }
+    match store.get(handle, index as usize) {
+        Ok(tok) => token_kind_tag(&tok.kind),
+        Err(_) => EOF_KIND_TAG,
+    }
+}
+
+fn span_field(
+    store: &BootstrapCollectionStore<Token>,
+    handle: BootstrapHandle<Token>,
+    index: i64,
+    f: impl Fn(&Span) -> u32,
+) -> i64 {
+    if index < 0 {
+        return 0;
+    }
+    match store.get(handle, index as usize) {
+        Ok(tok) => f(&tok.span) as i64,
+        Err(_) => 0,
+    }
+}
+
+/// FFI-primitive accessor: span file_id at `index`, or `0` on OOB.
+pub fn bootstrap_token_list_get_file_id(
+    store: &BootstrapCollectionStore<Token>,
+    handle: BootstrapHandle<Token>,
+    index: i64,
+) -> i64 {
+    span_field(store, handle, index, |s| s.file_id)
+}
+
+/// FFI-primitive accessor: span start offset at `index`, or `0` on OOB.
+pub fn bootstrap_token_list_get_start_offset(
+    store: &BootstrapCollectionStore<Token>,
+    handle: BootstrapHandle<Token>,
+    index: i64,
+) -> i64 {
+    span_field(store, handle, index, |s| s.start.offset)
+}
+
+/// FFI-primitive accessor: span end offset at `index`, or `0` on OOB.
+pub fn bootstrap_token_list_get_end_offset(
+    store: &BootstrapCollectionStore<Token>,
+    handle: BootstrapHandle<Token>,
+    index: i64,
+) -> i64 {
+    span_field(store, handle, index, |s| s.end.offset)
+}
+
+/// Mirror of `compiler/parser.gr::Parser`: a runtime-backed token list, the
+/// current cursor, and the file id used to synthesize spans for OOB reads.
+#[derive(Clone, Debug)]
+pub struct BootstrapParser {
+    pub store: BootstrapCollectionStore<Token>,
+    pub handle: BootstrapHandle<Token>,
+    pub pos: i64,
+    pub file_id: u32,
+}
+
+impl BootstrapParser {
+    /// Construct a parser by tokenizing `source` through the bootstrap lexer
+    /// bridge — exactly the path `parser.gr` will follow once it executes.
+    pub fn from_source(source: &str, file_id: u32) -> Self {
+        let BootstrapTokenList { store, handle } = tokenize_via_bootstrap_store(source, file_id);
+        Self {
+            store,
+            handle,
+            pos: 0,
+            file_id,
+        }
+    }
+
+    /// Mirror of `parser.gr::current_token`. Reads the kind tag and span at
+    /// `pos`, then reconstructs a [`Token`]. Out-of-bounds reads synthesize
+    /// a zero-span Eof token at the parser's `file_id`, matching the
+    /// self-hosted contract.
+    pub fn current_token(&self) -> Token {
+        self.token_at(self.pos)
+    }
+
+    /// Mirror of `parser.gr::peek_token(p, offset)`.
+    pub fn peek_token(&self, offset: i64) -> Token {
+        self.token_at(self.pos + offset)
+    }
+
+    /// Mirror of `parser.gr::parser_advance`.
+    pub fn advance(&self) -> Self {
+        let mut next = self.clone();
+        next.pos += 1;
+        next
+    }
+
+    /// Mirror of `parser.gr::is_at_end`.
+    pub fn is_at_end(&self) -> bool {
+        matches!(self.current_token().kind, TokenKind::Eof)
+    }
+
+    fn token_at(&self, index: i64) -> Token {
+        let tag = bootstrap_token_list_get_kind(&self.store, self.handle, index);
+        let kind = token_kind_from_tag(tag);
+
+        // OOB lookups (tag == EOF_KIND_TAG via the OOB sentinel path) get a
+        // zero-offset span at the parser's file_id. Real tokens get their
+        // actual span reconstituted from the primitive accessors so that
+        // diagnostics / span arithmetic remain meaningful.
+        let in_bounds = index >= 0
+            && self
+                .store
+                .len(self.handle)
+                .map(|len| (index as usize) < len)
+                .unwrap_or(false);
+
+        let (file_id, start_offset, end_offset) = if in_bounds {
+            (
+                bootstrap_token_list_get_file_id(&self.store, self.handle, index) as u32,
+                bootstrap_token_list_get_start_offset(&self.store, self.handle, index) as u32,
+                bootstrap_token_list_get_end_offset(&self.store, self.handle, index) as u32,
+            )
+        } else {
+            (self.file_id, 0, 0)
+        };
+
+        Token::new(
+            kind,
+            Span {
+                file_id,
+                start: Position {
+                    line: 0,
+                    col: 0,
+                    offset: start_offset,
+                },
+                end: Position {
+                    line: 0,
+                    col: 0,
+                    offset: end_offset,
+                },
+            },
+        )
+    }
+
+    /// Convenience: drive the cursor end-to-end and collect the kind sequence
+    /// the self-hosted parser would observe.
+    pub fn drain_kinds(&self) -> Vec<TokenKind> {
+        let mut out = Vec::new();
+        let mut cursor = self.clone();
+        loop {
+            let tok = cursor.current_token();
+            let is_eof = matches!(tok.kind, TokenKind::Eof);
+            out.push(tok.kind);
+            if is_eof {
+                break;
+            }
+            cursor = cursor.advance();
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_token_reads_real_first_token() {
+        let p = BootstrapParser::from_source("ret x", 7);
+        let tok = p.current_token();
+        assert!(matches!(tok.kind, TokenKind::Ret));
+        assert_eq!(tok.span.file_id, 7);
+    }
+
+    #[test]
+    fn peek_token_reads_offset_token() {
+        let p = BootstrapParser::from_source("ret x", 0);
+        let peeked = p.peek_token(1);
+        assert!(matches!(peeked.kind, TokenKind::Ident(_)));
+    }
+
+    #[test]
+    fn advance_preserves_token_list_identity() {
+        let p = BootstrapParser::from_source("a + 1", 0);
+        let q = p.advance();
+        assert_eq!(p.handle.raw(), q.handle.raw());
+        assert_eq!(q.pos, 1);
+        assert!(matches!(q.current_token().kind, TokenKind::Plus));
+    }
+
+    #[test]
+    fn out_of_bounds_returns_eof() {
+        let p = BootstrapParser::from_source("a", 11);
+        // Source produces [Ident, Eof]; peek beyond the end is Eof.
+        let far = p.peek_token(50);
+        assert!(matches!(far.kind, TokenKind::Eof));
+        assert_eq!(far.span.file_id, 11);
+    }
+
+    #[test]
+    fn drain_kinds_walks_the_real_stream() {
+        let p = BootstrapParser::from_source("x + 1", 0);
+        let ks = p.drain_kinds();
+        assert!(matches!(ks[0], TokenKind::Ident(_)));
+        assert!(matches!(ks[1], TokenKind::Plus));
+        assert!(matches!(ks[2], TokenKind::IntLit(_)));
+        assert!(matches!(ks.last(), Some(TokenKind::Eof)));
+    }
+
+    #[test]
+    fn negative_index_is_eof_safe() {
+        let p = BootstrapParser::from_source("x", 0);
+        let tag = bootstrap_token_list_get_kind(&p.store, p.handle, -1);
+        assert_eq!(tag, EOF_KIND_TAG);
+    }
+
+    #[test]
+    fn tag_round_trips_for_keywords_and_punctuation() {
+        for kind in [
+            TokenKind::Fn,
+            TokenKind::Let,
+            TokenKind::Match,
+            TokenKind::Plus,
+            TokenKind::Arrow,
+            TokenKind::LParen,
+            TokenKind::RBrace,
+            TokenKind::Dot,
+            TokenKind::Pub,
+        ] {
+            let tag = token_kind_tag(&kind);
+            let back = token_kind_from_tag(tag);
+            assert_eq!(
+                std::mem::discriminant(&kind),
+                std::mem::discriminant(&back),
+                "kind {:?} did not round-trip via tag {}",
+                kind,
+                tag
+            );
+        }
+    }
+}

--- a/codebase/compiler/src/lib.rs
+++ b/codebase/compiler/src/lib.rs
@@ -37,6 +37,7 @@ pub mod agent;
 pub mod ast;
 pub mod bootstrap_collections;
 pub mod bootstrap_lexer_bridge;
+pub mod bootstrap_parser_bridge;
 pub mod codegen;
 /// Compile-time expression evaluation.
 pub mod comptime;

--- a/codebase/compiler/src/typechecker/env.rs
+++ b/codebase/compiler/src/typechecker/env.rs
@@ -1030,6 +1030,73 @@ impl TypeEnv {
             },
         );
 
+        // bootstrap_token_list_get_kind(handle, index) -> Int
+        // Returns the token's kind tag (matching `lexer.gr::token_kind_tag`),
+        // or 1 (= Eof) when `index` is out of bounds. This is the inverse
+        // direction of `_append`: parser-side code reads kind tags by index
+        // and reconstructs a TokenKind. Out-of-bounds-as-Eof keeps parser
+        // execution safe past end-of-stream (#221).
+        self.define_fn(
+            "bootstrap_token_list_get_kind".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("handle".into(), Ty::Int, false),
+                    ("index".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+
+        // bootstrap_token_list_get_file_id(handle, index) -> Int
+        // Returns the token's span file_id, or 0 when `index` is out of
+        // bounds.
+        self.define_fn(
+            "bootstrap_token_list_get_file_id".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("handle".into(), Ty::Int, false),
+                    ("index".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+
+        // bootstrap_token_list_get_start_offset(handle, index) -> Int
+        // Returns the token's span start offset, or 0 when `index` is out of
+        // bounds.
+        self.define_fn(
+            "bootstrap_token_list_get_start_offset".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("handle".into(), Ty::Int, false),
+                    ("index".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+
+        // bootstrap_token_list_get_end_offset(handle, index) -> Int
+        // Returns the token's span end offset, or 0 when `index` is out of
+        // bounds.
+        self.define_fn(
+            "bootstrap_token_list_get_end_offset".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("handle".into(), Ty::Int, false),
+                    ("index".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+
         // ── Numeric operations ───────────────────────────────────────────
 
         // float_to_int(Float) -> Int

--- a/codebase/compiler/tests/self_hosted_parser_token_access.rs
+++ b/codebase/compiler/tests/self_hosted_parser_token_access.rs
@@ -1,0 +1,204 @@
+//! Self-hosted parser token-access parity (Issue #221 / Epic #116).
+//!
+//! Validates that `compiler/parser.gr::current_token`, `peek_token`, and
+//! `parser_advance` — modelled by [`bootstrap_parser_bridge`] — read from a
+//! real runtime-backed [`BootstrapTokenList`] and produce the same kind
+//! sequence as the Rust reference [`Lexer`] on the bootstrap corpus.
+//!
+//! Single-line scope: the current self-hosted lexer treats LF/INDENT/DEDENT
+//! as plain unexpected characters. Cross-line and indentation parity is
+//! tracked under follow-up issues (#224).
+
+use gradient_compiler::bootstrap_parser_bridge::{
+    bootstrap_token_list_get_end_offset, bootstrap_token_list_get_file_id,
+    bootstrap_token_list_get_kind, bootstrap_token_list_get_start_offset, BootstrapParser,
+    EOF_KIND_TAG,
+};
+use gradient_compiler::lexer::token::TokenKind;
+use gradient_compiler::Lexer;
+
+const PARITY_CORPUS: &[(&str, &str)] = &[
+    ("ident_plus_int", "x + 1"),
+    ("ret_eq", "ret x == y"),
+    ("call_two_args", "add(x, y)"),
+    ("nested_call", "f(g(x), h(y))"),
+    ("comparison_chain", "a <= b and c >= d"),
+    ("arrow_signature_fragment", "fn add(x: Int, y: Int) -> Int"),
+    ("not_and_or", "not a and b or c"),
+    ("string_literal", "let s = \"hi\""),
+    ("dot_access", "p.x"),
+    ("brackets", "[a, b, c]"),
+    ("braces", "{x, y}"),
+];
+
+#[derive(Debug, Clone, PartialEq)]
+enum TokenShape {
+    Plain(&'static str),
+    Ident,
+    IntLit,
+    FloatLit,
+    StringLit,
+    Error,
+}
+
+/// Coarse parity shape: parser.gr loses ident names / literal payloads across
+/// the FFI boundary, so parity is asserted on the discriminant only.
+fn shape(kind: &TokenKind) -> TokenShape {
+    match kind {
+        TokenKind::Ident(_) => TokenShape::Ident,
+        TokenKind::IntLit(_) => TokenShape::IntLit,
+        TokenKind::FloatLit(_) => TokenShape::FloatLit,
+        TokenKind::StringLit(_) => TokenShape::StringLit,
+        TokenKind::CharLit(_) => TokenShape::StringLit,
+        TokenKind::Error(_) => TokenShape::Error,
+        TokenKind::Fn => TokenShape::Plain("Fn"),
+        TokenKind::Let => TokenShape::Plain("Let"),
+        TokenKind::Mut => TokenShape::Plain("Mut"),
+        TokenKind::If => TokenShape::Plain("If"),
+        TokenKind::Else => TokenShape::Plain("Else"),
+        TokenKind::For => TokenShape::Plain("For"),
+        TokenKind::In => TokenShape::Plain("In"),
+        TokenKind::While => TokenShape::Plain("While"),
+        TokenKind::Ret => TokenShape::Plain("Ret"),
+        TokenKind::Type => TokenShape::Plain("Type"),
+        TokenKind::Mod => TokenShape::Plain("Mod"),
+        TokenKind::Use => TokenShape::Plain("Use"),
+        TokenKind::Pub => TokenShape::Plain("Pub"),
+        TokenKind::Impl => TokenShape::Plain("Impl"),
+        TokenKind::Match => TokenShape::Plain("Match"),
+        TokenKind::True => TokenShape::Plain("True"),
+        TokenKind::False => TokenShape::Plain("False"),
+        TokenKind::And => TokenShape::Plain("And"),
+        TokenKind::Or => TokenShape::Plain("Or"),
+        TokenKind::Not => TokenShape::Plain("Not"),
+        TokenKind::Plus => TokenShape::Plain("Plus"),
+        TokenKind::Minus => TokenShape::Plain("Minus"),
+        TokenKind::Star => TokenShape::Plain("Star"),
+        TokenKind::Slash => TokenShape::Plain("Slash"),
+        TokenKind::Percent => TokenShape::Plain("Percent"),
+        TokenKind::Eq => TokenShape::Plain("Eq"),
+        TokenKind::Ne => TokenShape::Plain("Ne"),
+        TokenKind::Lt => TokenShape::Plain("Lt"),
+        TokenKind::Gt => TokenShape::Plain("Gt"),
+        TokenKind::Le => TokenShape::Plain("Le"),
+        TokenKind::Ge => TokenShape::Plain("Ge"),
+        TokenKind::Assign => TokenShape::Plain("Assign"),
+        TokenKind::Arrow => TokenShape::Plain("Arrow"),
+        TokenKind::LParen => TokenShape::Plain("LParen"),
+        TokenKind::RParen => TokenShape::Plain("RParen"),
+        TokenKind::LBrace => TokenShape::Plain("LBrace"),
+        TokenKind::RBrace => TokenShape::Plain("RBrace"),
+        TokenKind::LBracket => TokenShape::Plain("LBracket"),
+        TokenKind::RBracket => TokenShape::Plain("RBracket"),
+        TokenKind::Colon => TokenShape::Plain("Colon"),
+        TokenKind::Comma => TokenShape::Plain("Comma"),
+        TokenKind::Dot => TokenShape::Plain("Dot"),
+        TokenKind::Eof => TokenShape::Plain("Eof"),
+        _ => TokenShape::Plain("Other"),
+    }
+}
+
+fn rust_shapes(src: &str) -> Vec<TokenShape> {
+    let mut lex = Lexer::new(src, 0);
+    let mut shapes = Vec::new();
+    for tok in lex.tokenize() {
+        // Skip Newline / Indent / Dedent: the self-hosted lexer doesn't emit
+        // them on this single-line corpus, so they would not appear in the
+        // bootstrap stream either.
+        match tok.kind {
+            TokenKind::Newline | TokenKind::Indent | TokenKind::Dedent => continue,
+            _ => {}
+        }
+        shapes.push(shape(&tok.kind));
+    }
+    // Ensure the stream is terminated by Eof regardless of trailing newlines.
+    if !matches!(shapes.last(), Some(TokenShape::Plain("Eof"))) {
+        shapes.push(TokenShape::Plain("Eof"));
+    }
+    shapes
+}
+
+#[test]
+fn current_token_kind_matches_rust_lexer_on_bootstrap_corpus() {
+    for (label, src) in PARITY_CORPUS {
+        let p = BootstrapParser::from_source(src, 0);
+        let bootstrap_shapes: Vec<TokenShape> = p.drain_kinds().iter().map(shape).collect();
+        let reference_shapes = rust_shapes(src);
+        assert_eq!(
+            bootstrap_shapes, reference_shapes,
+            "self-hosted parser token-access drifted from Rust lexer on `{label}`: src={src:?}"
+        );
+    }
+}
+
+#[test]
+fn current_token_advances_through_real_stream() {
+    let p = BootstrapParser::from_source("ret x == y", 0);
+
+    // current_token at pos=0 is `ret`; advancing must surface Ident, then Eq, etc.
+    let cur = p.current_token();
+    assert!(matches!(cur.kind, TokenKind::Ret));
+
+    let after_ret = p.advance();
+    assert!(matches!(
+        after_ret.current_token().kind,
+        TokenKind::Ident(_)
+    ));
+
+    let after_x = after_ret.advance();
+    assert!(matches!(after_x.current_token().kind, TokenKind::Eq));
+
+    // peek_token must respect offset rather than aliasing current_token.
+    let peeked = after_ret.peek_token(1);
+    assert!(matches!(peeked.kind, TokenKind::Eq));
+}
+
+#[test]
+fn out_of_bounds_token_access_yields_eof_safely() {
+    let p = BootstrapParser::from_source("x", 7);
+
+    // Walk the entire stream + one beyond the end. drain_kinds itself stops at
+    // the first Eof emitted by the runtime list; peek_token past that point
+    // must keep returning Eof rather than panicking or aliasing earlier tokens.
+    let beyond = p.peek_token(50);
+    assert!(matches!(beyond.kind, TokenKind::Eof));
+    assert_eq!(beyond.span.file_id, 7);
+
+    // Negative indices in the FFI map to the Eof tag without ever hitting
+    // the underlying Vec — guards against signed/unsigned mistakes in the
+    // self-hosted callsites.
+    let tag = bootstrap_token_list_get_kind(&p.store, p.handle, -3);
+    assert_eq!(tag, EOF_KIND_TAG);
+}
+
+#[test]
+fn span_offsets_round_trip_for_real_tokens() {
+    let p = BootstrapParser::from_source("x + 1", 0);
+    let len = p.store.len(p.handle).expect("bootstrap len");
+    assert!(len >= 4, "expected at least [Ident, Plus, IntLit, Eof]");
+
+    for index in 0..(len - 1) as i64 {
+        let start_extern = bootstrap_token_list_get_start_offset(&p.store, p.handle, index);
+        let end_extern = bootstrap_token_list_get_end_offset(&p.store, p.handle, index);
+        let file_id_extern = bootstrap_token_list_get_file_id(&p.store, p.handle, index);
+
+        let stored = p.store.get(p.handle, index as usize).expect("get");
+        assert_eq!(start_extern as u32, stored.span.start.offset);
+        assert_eq!(end_extern as u32, stored.span.end.offset);
+        assert_eq!(file_id_extern as u32, stored.span.file_id);
+    }
+}
+
+#[test]
+fn parser_advance_preserves_token_list_handle_identity() {
+    let p = BootstrapParser::from_source("a + b", 0);
+    let q = p.advance();
+    let r = q.advance();
+    // All three parser snapshots must point at the same runtime-backed list,
+    // mirroring `parser.gr::parser_advance`'s `tokens: p.tokens` propagation.
+    assert_eq!(p.handle.raw(), q.handle.raw());
+    assert_eq!(q.handle.raw(), r.handle.raw());
+    assert_eq!(p.pos, 0);
+    assert_eq!(q.pos, 1);
+    assert_eq!(r.pos, 2);
+}

--- a/codebase/compiler/tests/self_hosting_bootstrap.rs
+++ b/codebase/compiler/tests/self_hosting_bootstrap.rs
@@ -270,6 +270,75 @@ fn lexer_gr_tokenize_emits_real_token_list() {
     );
 }
 
+/// Issue #221: parser.gr token access must read through the runtime-backed
+/// TokenList store via the `bootstrap_token_list_get_*` extern primitives,
+/// not return a hard-coded Eof token.
+#[test]
+fn parser_gr_token_access_reads_real_token_list() {
+    let parser_src =
+        std::fs::read_to_string(compiler_path("parser.gr")).expect("Failed to read parser.gr");
+
+    // Reader-side externs must be declared so parser execution can recover
+    // a token's kind and span from a list handle + index. Signatures stay
+    // FFI-primitive (Int only) until the runtime can carry token payloads.
+    for extern_decl in [
+        "fn bootstrap_token_list_get_kind(handle: Int, index: Int) -> Int",
+        "fn bootstrap_token_list_get_file_id(handle: Int, index: Int) -> Int",
+        "fn bootstrap_token_list_get_start_offset(handle: Int, index: Int) -> Int",
+        "fn bootstrap_token_list_get_end_offset(handle: Int, index: Int) -> Int",
+    ] {
+        assert!(
+            parser_src.contains(extern_decl),
+            "parser.gr must declare bootstrap token access extern `{extern_decl}`"
+        );
+    }
+
+    // current_token / peek_token must drive the new accessors instead of
+    // returning a static Eof. Keep the assertions structural so cosmetic
+    // refactors stay free.
+    let current_body =
+        parser_gr_function_body(&parser_src, "fn current_token(p: Parser) -> Token:")
+            .expect("parser.gr must define fn current_token");
+    let peek_body = parser_gr_function_body(
+        &parser_src,
+        "fn peek_token(p: Parser, offset: Int) -> Token:",
+    )
+    .expect("parser.gr must define fn peek_token");
+
+    for (name, body) in [("current_token", current_body), ("peek_token", peek_body)] {
+        assert!(
+            !body.contains("Token { kind: Eof, span: Span { file_id: p.file_id"),
+            "parser.gr::{name} must not hard-code an Eof token"
+        );
+    }
+
+    // The shared lookup helper must hit all four reader externs so token
+    // identity (kind + span) round-trips through the runtime store.
+    let token_at_body =
+        parser_gr_function_body(&parser_src, "fn token_at(p: Parser, index: Int) -> Token:")
+            .expect("parser.gr must define a runtime-backed token_at lookup helper");
+    for required in [
+        "bootstrap_token_list_get_kind(p.tokens.handle",
+        "bootstrap_token_list_get_file_id(p.tokens.handle",
+        "bootstrap_token_list_get_start_offset(p.tokens.handle",
+        "bootstrap_token_list_get_end_offset(p.tokens.handle",
+        "kind_tag_to_token_kind(",
+    ] {
+        assert!(
+            token_at_body.contains(required),
+            "parser.gr::token_at must invoke `{required}` to materialize a runtime-backed token"
+        );
+    }
+
+    // peek_token must apply its offset relative to the parser cursor; a
+    // regression that drops `offset` and reads `p.pos` directly would silently
+    // alias current_token.
+    assert!(
+        peek_body.contains("p.pos + offset"),
+        "parser.gr::peek_token must read at p.pos + offset"
+    );
+}
+
 fn parser_gr_function_body<'a>(src: &'a str, signature: &str) -> Option<&'a str> {
     let start = src.find(signature)?;
     let after_signature = &src[start + signature.len()..];

--- a/compiler/parser.gr
+++ b/compiler/parser.gr
@@ -191,6 +191,21 @@ mod parser:
         file_id: Int
 
     // =========================================================================
+    // Bootstrap Token Access Externs (#221)
+    // =========================================================================
+    //
+    // These mirror the writer-side externs declared in lexer.gr and let the
+    // parser read tokens back out of the runtime-backed TokenList store.
+    // Signatures stay FFI-primitive (Int only) until the runtime can pass
+    // record values across the boundary; tokens are reconstructed from a
+    // kind tag plus span offsets. Out-of-bounds reads return Eof / zero
+    // span so parser execution never underflows past end-of-stream.
+    fn bootstrap_token_list_get_kind(handle: Int, index: Int) -> Int
+    fn bootstrap_token_list_get_file_id(handle: Int, index: Int) -> Int
+    fn bootstrap_token_list_get_start_offset(handle: Int, index: Int) -> Int
+    fn bootstrap_token_list_get_end_offset(handle: Int, index: Int) -> Int
+
+    // =========================================================================
     // Bootstrap AST Identity and Normalized Export
     // =========================================================================
 
@@ -481,12 +496,143 @@ mod parser:
     // =========================================================================
     // Token Access
     // =========================================================================
+    //
+    // Token access reads through the runtime-backed TokenList store using the
+    // `bootstrap_token_list_get_*` extern primitives. Each token is identified
+    // by its position inside the list; the kind tag matches the encoding in
+    // `lexer.gr::token_kind_tag`, and span offsets round-trip the writer-side
+    // span. Payload-bearing kinds (Ident / *Lit / Error) lose their payload
+    // across the FFI boundary today — `kind_tag_to_token_kind` returns
+    // placeholder payload data and `parser_direct_execution_ready` stays
+    // false until the FFI is widened to carry token payloads.
+
+    fn kind_tag_to_token_kind(kind_tag: Int) -> TokenKind:
+        if kind_tag == 1:
+            ret Eof
+        if kind_tag == 2:
+            ret Error("")
+        if kind_tag == 3:
+            ret Ident("")
+        if kind_tag == 4:
+            ret IntLit(0)
+        if kind_tag == 5:
+            ret FloatLit(0.0)
+        if kind_tag == 6:
+            ret StringLit("")
+        if kind_tag == 7:
+            ret BoolLit(false)
+        if kind_tag == 10:
+            ret Plus
+        if kind_tag == 11:
+            ret Minus
+        if kind_tag == 12:
+            ret Star
+        if kind_tag == 13:
+            ret Slash
+        if kind_tag == 14:
+            ret Percent
+        if kind_tag == 15:
+            ret Eq
+        if kind_tag == 16:
+            ret Ne
+        if kind_tag == 17:
+            ret Lt
+        if kind_tag == 18:
+            ret Gt
+        if kind_tag == 19:
+            ret Le
+        if kind_tag == 20:
+            ret Ge
+        if kind_tag == 21:
+            ret Assign
+        if kind_tag == 22:
+            ret Arrow
+        if kind_tag == 30:
+            ret LParen
+        if kind_tag == 31:
+            ret RParen
+        if kind_tag == 32:
+            ret LBrace
+        if kind_tag == 33:
+            ret RBrace
+        if kind_tag == 34:
+            ret LBracket
+        if kind_tag == 35:
+            ret RBracket
+        if kind_tag == 36:
+            ret Colon
+        if kind_tag == 37:
+            ret Comma
+        if kind_tag == 38:
+            ret Semi
+        if kind_tag == 39:
+            ret Dot
+        if kind_tag == 50:
+            ret Fn
+        if kind_tag == 51:
+            ret Let
+        if kind_tag == 52:
+            ret Mut
+        if kind_tag == 53:
+            ret If
+        if kind_tag == 54:
+            ret Else
+        if kind_tag == 55:
+            ret For
+        if kind_tag == 56:
+            ret In
+        if kind_tag == 57:
+            ret While
+        if kind_tag == 58:
+            ret Ret
+        if kind_tag == 59:
+            ret Type
+        if kind_tag == 60:
+            ret Mod
+        if kind_tag == 61:
+            ret Use
+        if kind_tag == 62:
+            ret Impl
+        if kind_tag == 63:
+            ret Match
+        if kind_tag == 64:
+            ret True
+        if kind_tag == 65:
+            ret False
+        if kind_tag == 66:
+            ret And
+        if kind_tag == 67:
+            ret Or
+        if kind_tag == 68:
+            ret Not
+        if kind_tag == 69:
+            ret Extern
+        if kind_tag == 70:
+            ret Pub
+        // Unknown / catch-all tags terminate parser execution as Eof rather
+        // than loop on garbage. New TokenKind variants must add an explicit
+        // arm above before parser execution can branch on them.
+        ret Eof
+
+    fn token_at(p: Parser, index: Int) -> Token:
+        let kind_tag = bootstrap_token_list_get_kind(p.tokens.handle, index)
+        let kind = kind_tag_to_token_kind(kind_tag)
+        let file_id = bootstrap_token_list_get_file_id(p.tokens.handle, index)
+        let start_offset = bootstrap_token_list_get_start_offset(p.tokens.handle, index)
+        let end_offset = bootstrap_token_list_get_end_offset(p.tokens.handle, index)
+        // OOB reads collapse to a zero-span Eof at the parser's file_id so
+        // diagnostics stay anchored to the source unit.
+        if kind_tag == 1 and start_offset == 0 and end_offset == 0:
+            let span = Span { file_id: p.file_id, start: Position { line: 0, col: 0, offset: 0 }, end: Position { line: 0, col: 0, offset: 0 } }
+            ret Token { kind: kind, span: span }
+        let span = Span { file_id: file_id, start: Position { line: 0, col: 0, offset: start_offset }, end: Position { line: 0, col: 0, offset: end_offset } }
+        ret Token { kind: kind, span: span }
 
     fn current_token(p: Parser) -> Token:
-        ret Token { kind: Eof, span: Span { file_id: p.file_id, start: Position { line: 0, col: 0, offset: 0 }, end: Position { line: 0, col: 0, offset: 0 } } }
+        ret token_at(p, p.pos)
 
     fn peek_token(p: Parser, offset: Int) -> Token:
-        ret Token { kind: Eof, span: Span { file_id: p.file_id, start: Position { line: 0, col: 0, offset: 0 }, end: Position { line: 0, col: 0, offset: 0 } } }
+        ret token_at(p, p.pos + offset)
 
     fn parser_advance(p: Parser) -> Parser:
         ret Parser { tokens: p.tokens, pos: p.pos + 1, file_id: p.file_id }


### PR DESCRIPTION
## Summary

Replaces hard-coded `Eof` returns in `compiler/parser.gr::current_token` and `peek_token` with reads against the runtime-backed bootstrap token list. Parser execution can now advance through the real tokens that `compiler/lexer.gr::tokenize` already accumulates (#220 / #237).

## Changes

**Self-hosted (`compiler/parser.gr`):**

- Declare reader-side externs (FFI-primitive `Int` only):
  - `bootstrap_token_list_get_kind`
  - `bootstrap_token_list_get_file_id`
  - `bootstrap_token_list_get_start_offset`
  - `bootstrap_token_list_get_end_offset`
- Add `kind_tag_to_token_kind(kind_tag)` — inverse of `lexer.gr::token_kind_tag`.
- Add `token_at(p, index)` that drives the four reader externs and reconstructs a `Token` with its real span. OOB reads collapse to a zero-span `Eof` at the parser's `file_id`.
- Rewrite `current_token` / `peek_token` to call `token_at` at `p.pos` and `p.pos + offset`. `parser_advance` keeps token-list identity by propagating `p.tokens` unchanged.
- `parser_direct_execution_ready()` stays `false`: payload recovery and multi-line lexer parity remain follow-up scope (#222 / #224).

**Rust host:**

- Register the four reader externs as Phase 0 builtins (`codebase/compiler/src/typechecker/env.rs`).
- New `bootstrap_parser_bridge` module mirroring the self-hosted token-access semantics over `BootstrapCollectionStore<Token>` so parser execution can be exercised end-to-end before the runtime executes `parser.gr` directly.

## Tests

- `self_hosting_bootstrap::parser_gr_token_access_reads_real_token_list` — pins the four extern declarations, the `token_at` lookup helper, and asserts `current_token` / `peek_token` no longer hard-code an `Eof` token.
- New `self_hosted_parser_token_access` (5 tests):
  - Kind-shape parity vs the Rust lexer on the bootstrap corpus
  - `current_token` advances through the real stream
  - Out-of-bounds `peek_token` returns Eof safely
  - Span offsets round-trip through the FFI accessors
  - `parser_advance` preserves handle identity
- `bootstrap_parser_bridge` unit tests cover OOB reads, tag round-trips, and stream draining.

## Verification

- `cargo test -p gradient-compiler`: 1126 unit tests + integration suites green
- `cargo clippy --workspace -- -D warnings`: clean
- New suites: `self_hosted_parser_token_access` (5/5), `self_hosting_bootstrap` (10/10), `self_hosting_smoke` (15/15), `self_hosted_lexer_parity` (5/5), `parser_differential_tests` (1/1)

## Out of scope (follow-up)

- Token payload (Ident name / IntLit value / StringLit value) recovery across the FFI — payload-bearing kinds reconstruct with placeholder data today. Direct execution readiness stays `false` until the FFI is widened.
- Multi-line / INDENT / DEDENT scanner parity in the bootstrap lexer (#224).
- Real parser AST / list storage (#222) and direct parser invocation in the differential gate (#223).

Fixes #221
