### PR TITLE
feat(self-hosting): store real parser AST nodes and lists

### DIFF
--- a/codebase/compiler/src/bootstrap_ast_bridge.rs
+++ b/codebase/compiler/src/bootstrap_ast_bridge.rs
@@ -1,0 +1,973 @@
+//! Runtime-backed AST node storage for the self-hosted parser.
+//!
+//! Issue #222: until the self-hosted runtime can execute `parser.gr` directly,
+//! we model the bootstrap AST node store in Rust so the rewritten Gradient
+//! parser exercises the same primitive FFI it will use once execution lands.
+//! Each `bootstrap_*_alloc_*` extern declared in `compiler/parser.gr` maps to
+//! a function on [`BootstrapAstStore`] that allocates a real node id and
+//! returns it as the handle the parser then plumbs into parent nodes.
+//!
+//! Scope: the bootstrap parser corpus (single-function modules with binary
+//! expressions, identifiers, integer/string/bool literals, calls, if/else,
+//! blocks, let/expr/ret statements, function params, named/Int/Bool/String
+//! return types). Variants outside that scope are stored as opaque payloads
+//! so future issues can extend the store without breaking the Phase-0
+//! contract.
+//!
+//! The accessor side (`bootstrap_*_get_*`) lets the normalized export walk
+//! the stored tree rather than re-derive it from in-memory `Expr` / `Stmt`
+//! values. Out-of-bounds and unknown ids return safe defaults (`tag = 0`,
+//! empty string, child id `0`) so parser execution can keep advancing
+//! without panicking.
+
+use std::cell::RefCell;
+use std::sync::Mutex;
+
+/// Discriminator tags for stored expression nodes.
+///
+/// Tags match the case order of `Expr` in `compiler/parser.gr`, so the
+/// self-hosted parser and the Rust mirror agree on the same encoding.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(i64)]
+pub enum ExprTag {
+    Unknown = 0,
+    IntLit = 1,
+    FloatLit = 2,
+    StringLit = 3,
+    BoolLit = 4,
+    Ident = 5,
+    Binary = 6,
+    Unary = 7,
+    Call = 8,
+    If = 9,
+    Block = 10,
+    Match = 11,
+    Lambda = 12,
+    FieldAccess = 13,
+    Index = 14,
+    Assign = 15,
+    Error = 16,
+}
+
+impl ExprTag {
+    pub fn from_i64(v: i64) -> Self {
+        match v {
+            1 => ExprTag::IntLit,
+            2 => ExprTag::FloatLit,
+            3 => ExprTag::StringLit,
+            4 => ExprTag::BoolLit,
+            5 => ExprTag::Ident,
+            6 => ExprTag::Binary,
+            7 => ExprTag::Unary,
+            8 => ExprTag::Call,
+            9 => ExprTag::If,
+            10 => ExprTag::Block,
+            11 => ExprTag::Match,
+            12 => ExprTag::Lambda,
+            13 => ExprTag::FieldAccess,
+            14 => ExprTag::Index,
+            15 => ExprTag::Assign,
+            16 => ExprTag::Error,
+            _ => ExprTag::Unknown,
+        }
+    }
+}
+
+/// Discriminator tags for stored statement nodes.
+///
+/// Tags match the case order of `Stmt` in `compiler/parser.gr`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(i64)]
+pub enum StmtTag {
+    Unknown = 0,
+    Let = 1,
+    Expr = 2,
+    Ret = 3,
+    If = 4,
+    While = 5,
+    For = 6,
+    Match = 7,
+    Break = 8,
+    Continue = 9,
+    Defer = 10,
+    Assign = 11,
+    Error = 12,
+}
+
+impl StmtTag {
+    pub fn from_i64(v: i64) -> Self {
+        match v {
+            1 => StmtTag::Let,
+            2 => StmtTag::Expr,
+            3 => StmtTag::Ret,
+            4 => StmtTag::If,
+            5 => StmtTag::While,
+            6 => StmtTag::For,
+            7 => StmtTag::Match,
+            8 => StmtTag::Break,
+            9 => StmtTag::Continue,
+            10 => StmtTag::Defer,
+            11 => StmtTag::Assign,
+            12 => StmtTag::Error,
+            _ => StmtTag::Unknown,
+        }
+    }
+}
+
+/// Discriminator tags for stored type expression nodes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(i64)]
+pub enum TypeTag {
+    Unknown = 0,
+    Int = 1,
+    Float = 2,
+    Bool = 3,
+    String = 4,
+    Unit = 5,
+    Named = 6,
+}
+
+impl TypeTag {
+    pub fn from_i64(v: i64) -> Self {
+        match v {
+            1 => TypeTag::Int,
+            2 => TypeTag::Float,
+            3 => TypeTag::Bool,
+            4 => TypeTag::String,
+            5 => TypeTag::Unit,
+            6 => TypeTag::Named,
+            _ => TypeTag::Unknown,
+        }
+    }
+}
+
+/// Discriminator tags for stored module items.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(i64)]
+pub enum ModuleItemTag {
+    Unknown = 0,
+    Function = 1,
+    Type = 2,
+    Trait = 3,
+    Impl = 4,
+    Use = 5,
+    Error = 6,
+}
+
+impl ModuleItemTag {
+    pub fn from_i64(v: i64) -> Self {
+        match v {
+            1 => ModuleItemTag::Function,
+            2 => ModuleItemTag::Type,
+            3 => ModuleItemTag::Trait,
+            4 => ModuleItemTag::Impl,
+            5 => ModuleItemTag::Use,
+            6 => ModuleItemTag::Error,
+            _ => ModuleItemTag::Unknown,
+        }
+    }
+}
+
+/// A single stored expression node. Slots are interpreted per [`ExprTag`].
+///
+/// Slot conventions (any unused slot is `0` / empty):
+/// - IntLit: `int_value`
+/// - BoolLit: `int_value` (0/1)
+/// - StringLit: `text`
+/// - Ident: `text = name`
+/// - Binary: `int_value = op_tag`, `child_a = left_id`, `child_b = right_id`
+/// - Unary: `int_value = op_tag`, `child_a = operand_id`
+/// - Call: `child_a = callee_id`, `child_b = args_list_handle`
+/// - If: `child_a = cond_id`, `child_b = then_id`, `child_c = else_id`
+/// - Block: `child_a = stmt_list_handle`, `child_b = final_expr_id`
+/// - FieldAccess: `child_a = obj_id`, `text = field`
+/// - Index: `child_a = obj_id`, `child_b = index_id`
+/// - Assign: `child_a = target_id`, `child_b = value_id`
+/// - Error: `text = message`
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ExprNode {
+    pub tag: i64,
+    pub int_value: i64,
+    pub child_a: i64,
+    pub child_b: i64,
+    pub child_c: i64,
+    pub text: String,
+}
+
+/// A single stored statement node.
+///
+/// Slot conventions:
+/// - Let: `int_value = is_mut (0/1)`, `child_a = type_id`, `child_b = value_expr_id`,
+///   `child_c = pattern_handle`, `text = pattern_name` (best-effort for Ident patterns).
+/// - Expr / Ret / Defer: `child_a = expr_id`.
+/// - If: `child_a = cond_id`, `child_b = then_block_handle`, `child_c = else_block_handle`.
+/// - While: `child_a = cond_id`, `child_b = body_block_handle`.
+/// - For: `child_a = iter_id`, `child_b = body_block_handle`, `child_c = pattern_handle`,
+///   `text = pattern_name`.
+/// - Assign: `child_a = target_id`, `child_b = value_id`.
+/// - Break / Continue: no slots used.
+/// - Error: `text = message`.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct StmtNode {
+    pub tag: i64,
+    pub int_value: i64,
+    pub child_a: i64,
+    pub child_b: i64,
+    pub child_c: i64,
+    pub text: String,
+}
+
+/// A stored function parameter. `type_tag` matches [`TypeTag`]; `type_name`
+/// carries the named-type label for [`TypeTag::Named`]. `default_id` is `0`
+/// when there is no default.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ParamNode {
+    pub name: String,
+    pub type_tag: i64,
+    pub type_name: String,
+    pub default_id: i64,
+}
+
+/// A stored function definition.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct FunctionNode {
+    pub name: String,
+    pub params_handle: i64,
+    pub ret_type_tag: i64,
+    pub ret_type_name: String,
+    pub body_handle: i64,
+    pub is_pub: i64,
+    pub is_extern: i64,
+}
+
+/// A stored module item.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ModuleItemNode {
+    pub tag: i64,
+    pub function_id: i64,
+    pub name: String,
+}
+
+/// Categories of node-id lists tracked by the AST store.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum AstListKind {
+    ExprList,
+    StmtList,
+    ParamList,
+    ModuleItemList,
+}
+
+/// Generic node-id list backing the `bootstrap_*_list_*` externs.
+#[derive(Clone, Debug, Default)]
+pub struct AstList {
+    pub kind: Option<AstListKind>,
+    pub items: Vec<i64>,
+}
+
+/// In-memory store for runtime-backed AST nodes used by the self-hosted parser.
+///
+/// All ids are non-zero `i64`s starting at 1; id `0` is reserved as the
+/// "no node" sentinel that propagates safely through the FFI when callers
+/// branch on `child == 0`. Each kind has its own id space — expr ids are
+/// distinct from stmt ids, etc. — so callers must use the matching getter
+/// for the kind they appended.
+#[derive(Clone, Debug, Default)]
+pub struct BootstrapAstStore {
+    exprs: Vec<ExprNode>,
+    stmts: Vec<StmtNode>,
+    params: Vec<ParamNode>,
+    functions: Vec<FunctionNode>,
+    module_items: Vec<ModuleItemNode>,
+    lists: Vec<AstList>,
+}
+
+impl BootstrapAstStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // ── Expression alloc / get ────────────────────────────────────────────
+
+    pub fn alloc_expr(&mut self, node: ExprNode) -> i64 {
+        self.exprs.push(node);
+        self.exprs.len() as i64
+    }
+
+    pub fn get_expr(&self, id: i64) -> Option<&ExprNode> {
+        if id <= 0 {
+            return None;
+        }
+        self.exprs.get((id - 1) as usize)
+    }
+
+    pub fn expr_count(&self) -> i64 {
+        self.exprs.len() as i64
+    }
+
+    // ── Statement alloc / get ─────────────────────────────────────────────
+
+    pub fn alloc_stmt(&mut self, node: StmtNode) -> i64 {
+        self.stmts.push(node);
+        self.stmts.len() as i64
+    }
+
+    pub fn get_stmt(&self, id: i64) -> Option<&StmtNode> {
+        if id <= 0 {
+            return None;
+        }
+        self.stmts.get((id - 1) as usize)
+    }
+
+    pub fn stmt_count(&self) -> i64 {
+        self.stmts.len() as i64
+    }
+
+    // ── Param alloc / get ─────────────────────────────────────────────────
+
+    pub fn alloc_param(&mut self, node: ParamNode) -> i64 {
+        self.params.push(node);
+        self.params.len() as i64
+    }
+
+    pub fn get_param(&self, id: i64) -> Option<&ParamNode> {
+        if id <= 0 {
+            return None;
+        }
+        self.params.get((id - 1) as usize)
+    }
+
+    // ── Function alloc / get ──────────────────────────────────────────────
+
+    pub fn alloc_function(&mut self, node: FunctionNode) -> i64 {
+        self.functions.push(node);
+        self.functions.len() as i64
+    }
+
+    pub fn get_function(&self, id: i64) -> Option<&FunctionNode> {
+        if id <= 0 {
+            return None;
+        }
+        self.functions.get((id - 1) as usize)
+    }
+
+    // ── Module item alloc / get ───────────────────────────────────────────
+
+    pub fn alloc_module_item(&mut self, node: ModuleItemNode) -> i64 {
+        self.module_items.push(node);
+        self.module_items.len() as i64
+    }
+
+    pub fn get_module_item(&self, id: i64) -> Option<&ModuleItemNode> {
+        if id <= 0 {
+            return None;
+        }
+        self.module_items.get((id - 1) as usize)
+    }
+
+    // ── Generic node-id lists ─────────────────────────────────────────────
+
+    pub fn list_alloc(&mut self, kind: AstListKind) -> i64 {
+        self.lists.push(AstList {
+            kind: Some(kind),
+            items: Vec::new(),
+        });
+        self.lists.len() as i64
+    }
+
+    pub fn list_append(&mut self, handle: i64, id: i64) -> i64 {
+        if let Some(list) = self.list_mut(handle) {
+            list.items.push(id);
+            list.items.len() as i64
+        } else {
+            0
+        }
+    }
+
+    pub fn list_len(&self, handle: i64) -> i64 {
+        self.list(handle)
+            .map(|l| l.items.len() as i64)
+            .unwrap_or(0)
+    }
+
+    pub fn list_get(&self, handle: i64, index: i64) -> i64 {
+        if index < 0 {
+            return 0;
+        }
+        self.list(handle)
+            .and_then(|l| l.items.get(index as usize).copied())
+            .unwrap_or(0)
+    }
+
+    pub fn list_kind(&self, handle: i64) -> Option<AstListKind> {
+        self.list(handle).and_then(|l| l.kind)
+    }
+
+    fn list(&self, handle: i64) -> Option<&AstList> {
+        if handle <= 0 {
+            return None;
+        }
+        self.lists.get((handle - 1) as usize)
+    }
+
+    fn list_mut(&mut self, handle: i64) -> Option<&mut AstList> {
+        if handle <= 0 {
+            return None;
+        }
+        self.lists.get_mut((handle - 1) as usize)
+    }
+}
+
+/// Process-wide ambient AST store used by the self-hosted parser bridge.
+///
+/// The self-hosted parser drives the bootstrap_* externs imperatively while
+/// constructing nodes; the externs need somewhere to land their state. A
+/// `Mutex<RefCell<...>>` keeps the contract single-threaded but explicit:
+/// each test that exercises the bridge calls [`reset_ast_store`] before
+/// running so prior state never leaks across cases.
+fn ast_store() -> &'static Mutex<RefCell<BootstrapAstStore>> {
+    use std::sync::OnceLock;
+    static STORE: OnceLock<Mutex<RefCell<BootstrapAstStore>>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(RefCell::new(BootstrapAstStore::new())))
+}
+
+/// Replace the ambient AST store with a fresh, empty one. Tests must call
+/// this before exercising the bridge to keep id spaces isolated.
+pub fn reset_ast_store() {
+    let cell = ast_store().lock().expect("ast store lock poisoned");
+    *cell.borrow_mut() = BootstrapAstStore::new();
+}
+
+/// Run `f` against a mutable view of the ambient AST store.
+pub fn with_ast_store<R>(f: impl FnOnce(&mut BootstrapAstStore) -> R) -> R {
+    let cell = ast_store().lock().expect("ast store lock poisoned");
+    let mut store = cell.borrow_mut();
+    f(&mut store)
+}
+
+/// Run `f` against a read-only view of the ambient AST store.
+pub fn with_ast_store_ref<R>(f: impl FnOnce(&BootstrapAstStore) -> R) -> R {
+    let cell = ast_store().lock().expect("ast store lock poisoned");
+    let store = cell.borrow();
+    f(&store)
+}
+
+// ── FFI-shaped accessors that mirror parser.gr externs ────────────────────
+//
+// Each extern declared in `compiler/parser.gr` has a corresponding free
+// function here. Callers in tests (and, eventually, the self-hosted runtime)
+// drive the same surface. The functions are intentionally narrow: they
+// accept `Int`/`String`-shaped arguments (i64 / &str / String) and return
+// the same types so the FFI contract is verifiable.
+
+pub fn bootstrap_expr_alloc_int_lit(value: i64) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_expr(ExprNode {
+            tag: ExprTag::IntLit as i64,
+            int_value: value,
+            ..Default::default()
+        })
+    })
+}
+
+pub fn bootstrap_expr_alloc_bool_lit(value: i64) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_expr(ExprNode {
+            tag: ExprTag::BoolLit as i64,
+            int_value: if value != 0 { 1 } else { 0 },
+            ..Default::default()
+        })
+    })
+}
+
+pub fn bootstrap_expr_alloc_string_lit(value: &str) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_expr(ExprNode {
+            tag: ExprTag::StringLit as i64,
+            text: value.to_string(),
+            ..Default::default()
+        })
+    })
+}
+
+pub fn bootstrap_expr_alloc_ident(name: &str) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_expr(ExprNode {
+            tag: ExprTag::Ident as i64,
+            text: name.to_string(),
+            ..Default::default()
+        })
+    })
+}
+
+pub fn bootstrap_expr_alloc_binary(op_tag: i64, left: i64, right: i64) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_expr(ExprNode {
+            tag: ExprTag::Binary as i64,
+            int_value: op_tag,
+            child_a: left,
+            child_b: right,
+            ..Default::default()
+        })
+    })
+}
+
+pub fn bootstrap_expr_alloc_unary(op_tag: i64, operand: i64) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_expr(ExprNode {
+            tag: ExprTag::Unary as i64,
+            int_value: op_tag,
+            child_a: operand,
+            ..Default::default()
+        })
+    })
+}
+
+pub fn bootstrap_expr_alloc_call(callee: i64, args_handle: i64) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_expr(ExprNode {
+            tag: ExprTag::Call as i64,
+            child_a: callee,
+            child_b: args_handle,
+            ..Default::default()
+        })
+    })
+}
+
+pub fn bootstrap_expr_alloc_if(cond: i64, then_b: i64, else_b: i64) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_expr(ExprNode {
+            tag: ExprTag::If as i64,
+            child_a: cond,
+            child_b: then_b,
+            child_c: else_b,
+            ..Default::default()
+        })
+    })
+}
+
+pub fn bootstrap_expr_alloc_block(stmts_handle: i64, final_expr: i64) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_expr(ExprNode {
+            tag: ExprTag::Block as i64,
+            child_a: stmts_handle,
+            child_b: final_expr,
+            ..Default::default()
+        })
+    })
+}
+
+pub fn bootstrap_expr_alloc_error(message: &str) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_expr(ExprNode {
+            tag: ExprTag::Error as i64,
+            text: message.to_string(),
+            ..Default::default()
+        })
+    })
+}
+
+// Reader-side expression accessors. Out-of-bounds / kind-mismatched ids
+// return safe defaults so the parser/normalizer can keep walking.
+
+pub fn bootstrap_expr_get_tag(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_expr(id).map(|n| n.tag).unwrap_or(0))
+}
+
+pub fn bootstrap_expr_get_int_value(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_expr(id).map(|n| n.int_value).unwrap_or(0))
+}
+
+pub fn bootstrap_expr_get_text(id: i64) -> String {
+    with_ast_store_ref(|s| s.get_expr(id).map(|n| n.text.clone()).unwrap_or_default())
+}
+
+pub fn bootstrap_expr_get_child_a(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_expr(id).map(|n| n.child_a).unwrap_or(0))
+}
+
+pub fn bootstrap_expr_get_child_b(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_expr(id).map(|n| n.child_b).unwrap_or(0))
+}
+
+pub fn bootstrap_expr_get_child_c(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_expr(id).map(|n| n.child_c).unwrap_or(0))
+}
+
+// ── Statement alloc / get ────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+pub fn bootstrap_stmt_alloc(
+    tag: i64,
+    int_value: i64,
+    child_a: i64,
+    child_b: i64,
+    child_c: i64,
+    text: &str,
+) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_stmt(StmtNode {
+            tag,
+            int_value,
+            child_a,
+            child_b,
+            child_c,
+            text: text.to_string(),
+        })
+    })
+}
+
+pub fn bootstrap_stmt_get_tag(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_stmt(id).map(|n| n.tag).unwrap_or(0))
+}
+
+pub fn bootstrap_stmt_get_int_value(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_stmt(id).map(|n| n.int_value).unwrap_or(0))
+}
+
+pub fn bootstrap_stmt_get_text(id: i64) -> String {
+    with_ast_store_ref(|s| s.get_stmt(id).map(|n| n.text.clone()).unwrap_or_default())
+}
+
+pub fn bootstrap_stmt_get_child_a(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_stmt(id).map(|n| n.child_a).unwrap_or(0))
+}
+
+pub fn bootstrap_stmt_get_child_b(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_stmt(id).map(|n| n.child_b).unwrap_or(0))
+}
+
+pub fn bootstrap_stmt_get_child_c(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_stmt(id).map(|n| n.child_c).unwrap_or(0))
+}
+
+// ── Param alloc / get ────────────────────────────────────────────────────
+
+pub fn bootstrap_param_alloc(
+    name: &str,
+    type_tag: i64,
+    type_name: &str,
+    default_id: i64,
+) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_param(ParamNode {
+            name: name.to_string(),
+            type_tag,
+            type_name: type_name.to_string(),
+            default_id,
+        })
+    })
+}
+
+pub fn bootstrap_param_get_name(id: i64) -> String {
+    with_ast_store_ref(|s| s.get_param(id).map(|p| p.name.clone()).unwrap_or_default())
+}
+
+pub fn bootstrap_param_get_type_tag(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_param(id).map(|p| p.type_tag).unwrap_or(0))
+}
+
+pub fn bootstrap_param_get_type_name(id: i64) -> String {
+    with_ast_store_ref(|s| {
+        s.get_param(id)
+            .map(|p| p.type_name.clone())
+            .unwrap_or_default()
+    })
+}
+
+pub fn bootstrap_param_get_default(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_param(id).map(|p| p.default_id).unwrap_or(0))
+}
+
+// ── Function alloc / get ─────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+pub fn bootstrap_function_alloc(
+    name: &str,
+    params_handle: i64,
+    ret_type_tag: i64,
+    ret_type_name: &str,
+    body_handle: i64,
+    is_pub: i64,
+    is_extern: i64,
+) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_function(FunctionNode {
+            name: name.to_string(),
+            params_handle,
+            ret_type_tag,
+            ret_type_name: ret_type_name.to_string(),
+            body_handle,
+            is_pub,
+            is_extern,
+        })
+    })
+}
+
+pub fn bootstrap_function_get_name(id: i64) -> String {
+    with_ast_store_ref(|s| {
+        s.get_function(id)
+            .map(|f| f.name.clone())
+            .unwrap_or_default()
+    })
+}
+
+pub fn bootstrap_function_get_params_handle(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_function(id).map(|f| f.params_handle).unwrap_or(0))
+}
+
+pub fn bootstrap_function_get_ret_type_tag(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_function(id).map(|f| f.ret_type_tag).unwrap_or(0))
+}
+
+pub fn bootstrap_function_get_ret_type_name(id: i64) -> String {
+    with_ast_store_ref(|s| {
+        s.get_function(id)
+            .map(|f| f.ret_type_name.clone())
+            .unwrap_or_default()
+    })
+}
+
+pub fn bootstrap_function_get_body_handle(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_function(id).map(|f| f.body_handle).unwrap_or(0))
+}
+
+// ── Module item alloc / get ──────────────────────────────────────────────
+
+pub fn bootstrap_module_item_alloc_function(function_id: i64) -> i64 {
+    with_ast_store(|s| {
+        s.alloc_module_item(ModuleItemNode {
+            tag: ModuleItemTag::Function as i64,
+            function_id,
+            ..Default::default()
+        })
+    })
+}
+
+pub fn bootstrap_module_item_get_tag(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_module_item(id).map(|m| m.tag).unwrap_or(0))
+}
+
+pub fn bootstrap_module_item_get_function_id(id: i64) -> i64 {
+    with_ast_store_ref(|s| s.get_module_item(id).map(|m| m.function_id).unwrap_or(0))
+}
+
+// ── Node-id list alloc / append / len / get ──────────────────────────────
+
+pub fn bootstrap_expr_list_alloc() -> i64 {
+    with_ast_store(|s| s.list_alloc(AstListKind::ExprList))
+}
+
+pub fn bootstrap_stmt_list_alloc() -> i64 {
+    with_ast_store(|s| s.list_alloc(AstListKind::StmtList))
+}
+
+pub fn bootstrap_param_list_alloc() -> i64 {
+    with_ast_store(|s| s.list_alloc(AstListKind::ParamList))
+}
+
+pub fn bootstrap_module_item_list_alloc() -> i64 {
+    with_ast_store(|s| s.list_alloc(AstListKind::ModuleItemList))
+}
+
+pub fn bootstrap_node_list_append(handle: i64, id: i64) -> i64 {
+    with_ast_store(|s| s.list_append(handle, id))
+}
+
+pub fn bootstrap_node_list_len(handle: i64) -> i64 {
+    with_ast_store_ref(|s| s.list_len(handle))
+}
+
+pub fn bootstrap_node_list_get(handle: i64, index: i64) -> i64 {
+    with_ast_store_ref(|s| s.list_get(handle, index))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh() -> BootstrapAstStore {
+        BootstrapAstStore::new()
+    }
+
+    #[test]
+    fn nested_binary_round_trips_through_storage() {
+        let mut s = fresh();
+        // Build (a + b) * c
+        let a = s.alloc_expr(ExprNode {
+            tag: ExprTag::Ident as i64,
+            text: "a".into(),
+            ..Default::default()
+        });
+        let b = s.alloc_expr(ExprNode {
+            tag: ExprTag::Ident as i64,
+            text: "b".into(),
+            ..Default::default()
+        });
+        let c = s.alloc_expr(ExprNode {
+            tag: ExprTag::Ident as i64,
+            text: "c".into(),
+            ..Default::default()
+        });
+        let sum = s.alloc_expr(ExprNode {
+            tag: ExprTag::Binary as i64,
+            int_value: 1, // add
+            child_a: a,
+            child_b: b,
+            ..Default::default()
+        });
+        let prod = s.alloc_expr(ExprNode {
+            tag: ExprTag::Binary as i64,
+            int_value: 3, // mul
+            child_a: sum,
+            child_b: c,
+            ..Default::default()
+        });
+
+        let prod_node = s.get_expr(prod).expect("prod stored");
+        assert_eq!(prod_node.tag, ExprTag::Binary as i64);
+        let lhs = s.get_expr(prod_node.child_a).expect("lhs stored");
+        assert_eq!(lhs.tag, ExprTag::Binary as i64);
+        let rhs = s.get_expr(prod_node.child_b).expect("rhs stored");
+        assert_eq!(rhs.tag, ExprTag::Ident as i64);
+        assert_eq!(rhs.text, "c");
+        let lhs_left = s.get_expr(lhs.child_a).expect("a stored");
+        let lhs_right = s.get_expr(lhs.child_b).expect("b stored");
+        assert_eq!(lhs_left.text, "a");
+        assert_eq!(lhs_right.text, "b");
+    }
+
+    #[test]
+    fn function_params_round_trip() {
+        let mut s = fresh();
+        let p1 = s.alloc_param(ParamNode {
+            name: "a".into(),
+            type_tag: TypeTag::Int as i64,
+            type_name: String::new(),
+            default_id: 0,
+        });
+        let p2 = s.alloc_param(ParamNode {
+            name: "b".into(),
+            type_tag: TypeTag::Int as i64,
+            type_name: String::new(),
+            default_id: 0,
+        });
+        let plist = s.list_alloc(AstListKind::ParamList);
+        s.list_append(plist, p1);
+        s.list_append(plist, p2);
+        assert_eq!(s.list_len(plist), 2);
+        let first = s.get_param(s.list_get(plist, 0)).unwrap();
+        let second = s.get_param(s.list_get(plist, 1)).unwrap();
+        assert_eq!(first.name, "a");
+        assert_eq!(second.name, "b");
+        assert_eq!(first.type_tag, TypeTag::Int as i64);
+    }
+
+    #[test]
+    fn statement_body_round_trips_with_let_and_ret() {
+        let mut s = fresh();
+        let value = s.alloc_expr(ExprNode {
+            tag: ExprTag::IntLit as i64,
+            int_value: 42,
+            ..Default::default()
+        });
+        let let_stmt = s.alloc_stmt(StmtNode {
+            tag: StmtTag::Let as i64,
+            int_value: 0,
+            child_a: 0,
+            child_b: value,
+            child_c: 0,
+            text: "x".into(),
+        });
+        let x_ref = s.alloc_expr(ExprNode {
+            tag: ExprTag::Ident as i64,
+            text: "x".into(),
+            ..Default::default()
+        });
+        let ret_stmt = s.alloc_stmt(StmtNode {
+            tag: StmtTag::Ret as i64,
+            child_a: x_ref,
+            ..Default::default()
+        });
+        let body = s.list_alloc(AstListKind::StmtList);
+        s.list_append(body, let_stmt);
+        s.list_append(body, ret_stmt);
+        assert_eq!(s.list_len(body), 2);
+        let first = s.get_stmt(s.list_get(body, 0)).unwrap();
+        assert_eq!(first.tag, StmtTag::Let as i64);
+        assert_eq!(first.text, "x");
+        let first_value = s.get_expr(first.child_b).unwrap();
+        assert_eq!(first_value.int_value, 42);
+        let last = s.get_stmt(s.list_get(body, 1)).unwrap();
+        assert_eq!(last.tag, StmtTag::Ret as i64);
+        let last_value = s.get_expr(last.child_a).unwrap();
+        assert_eq!(last_value.text, "x");
+    }
+
+    #[test]
+    fn unknown_id_reads_return_safe_defaults() {
+        let s = fresh();
+        assert!(s.get_expr(0).is_none());
+        assert!(s.get_expr(99).is_none());
+        assert_eq!(s.list_len(0), 0);
+        assert_eq!(s.list_get(0, 0), 0);
+    }
+
+    #[test]
+    fn ambient_store_round_trips_through_externs() {
+        let _guard = ambient_test_lock();
+        reset_ast_store();
+        let l = bootstrap_expr_alloc_ident("a");
+        let r = bootstrap_expr_alloc_ident("b");
+        let sum = bootstrap_expr_alloc_binary(1, l, r);
+        assert_eq!(bootstrap_expr_get_tag(sum), ExprTag::Binary as i64);
+        assert_eq!(bootstrap_expr_get_int_value(sum), 1);
+        assert_eq!(bootstrap_expr_get_child_a(sum), l);
+        assert_eq!(bootstrap_expr_get_child_b(sum), r);
+        assert_eq!(bootstrap_expr_get_text(l), "a");
+    }
+
+    #[test]
+    fn ambient_param_list_round_trips() {
+        let _guard = ambient_test_lock();
+        reset_ast_store();
+        let pa = bootstrap_param_alloc("a", TypeTag::Int as i64, "", 0);
+        let pb = bootstrap_param_alloc("b", TypeTag::Int as i64, "", 0);
+        let plist = bootstrap_param_list_alloc();
+        bootstrap_node_list_append(plist, pa);
+        bootstrap_node_list_append(plist, pb);
+        assert_eq!(bootstrap_node_list_len(plist), 2);
+        assert_eq!(
+            bootstrap_param_get_name(bootstrap_node_list_get(plist, 0)),
+            "a"
+        );
+        assert_eq!(
+            bootstrap_param_get_name(bootstrap_node_list_get(plist, 1)),
+            "b"
+        );
+    }
+
+    #[test]
+    fn ambient_function_round_trips() {
+        let _guard = ambient_test_lock();
+        reset_ast_store();
+        let body = bootstrap_stmt_list_alloc();
+        let fid = bootstrap_function_alloc("f", 0, TypeTag::Int as i64, "", body, 0, 0);
+        assert_eq!(bootstrap_function_get_name(fid), "f");
+        assert_eq!(
+            bootstrap_function_get_ret_type_tag(fid),
+            TypeTag::Int as i64
+        );
+        assert_eq!(bootstrap_function_get_body_handle(fid), body);
+    }
+
+    /// Serialize tests that exercise the process-wide ambient store. Cargo
+    /// runs tests in parallel by default, so without this guard one test's
+    /// `reset_ast_store` can race against another's appended nodes.
+    fn ambient_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        use std::sync::{Mutex, OnceLock};
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+}

--- a/codebase/compiler/src/lib.rs
+++ b/codebase/compiler/src/lib.rs
@@ -35,6 +35,7 @@
 
 pub mod agent;
 pub mod ast;
+pub mod bootstrap_ast_bridge;
 pub mod bootstrap_collections;
 pub mod bootstrap_lexer_bridge;
 pub mod bootstrap_parser_bridge;

--- a/codebase/compiler/src/typechecker/env.rs
+++ b/codebase/compiler/src/typechecker/env.rs
@@ -1097,6 +1097,322 @@ impl TypeEnv {
             },
         );
 
+        // ── Bootstrap AST node externs (#222) ─────────────────────────────
+        // Self-hosted parser allocates and reads back AST nodes through a
+        // runtime-backed store. Each kind has its own id space (expr ids
+        // distinct from stmt ids etc.); generic node-id lists back the
+        // parser's `*List` wrappers. Out-of-range / unknown ids return
+        // safe zero/empty defaults so parser execution can keep walking.
+
+        // Expression alloc primitives.
+        self.define_fn(
+            "bootstrap_expr_alloc_int_lit".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![("value".into(), Ty::Int, false)],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_expr_alloc_bool_lit".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![("value".into(), Ty::Int, false)],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_expr_alloc_string_lit".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![("value".into(), Ty::String, false)],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_expr_alloc_ident".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![("name".into(), Ty::String, false)],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_expr_alloc_binary".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("op_tag".into(), Ty::Int, false),
+                    ("left".into(), Ty::Int, false),
+                    ("right".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_expr_alloc_unary".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("op_tag".into(), Ty::Int, false),
+                    ("operand".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_expr_alloc_call".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("callee".into(), Ty::Int, false),
+                    ("args_handle".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_expr_alloc_if".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("cond".into(), Ty::Int, false),
+                    ("then_branch".into(), Ty::Int, false),
+                    ("else_branch".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_expr_alloc_block".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("stmts_handle".into(), Ty::Int, false),
+                    ("final_expr".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_expr_alloc_error".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![("message".into(), Ty::String, false)],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+
+        // Expression read primitives.
+        for (name, ret) in [
+            ("bootstrap_expr_get_tag", Ty::Int),
+            ("bootstrap_expr_get_int_value", Ty::Int),
+            ("bootstrap_expr_get_text", Ty::String),
+            ("bootstrap_expr_get_child_a", Ty::Int),
+            ("bootstrap_expr_get_child_b", Ty::Int),
+            ("bootstrap_expr_get_child_c", Ty::Int),
+        ] {
+            self.define_fn(
+                name.into(),
+                FnSig {
+                    type_params: vec![],
+                    params: vec![("id".into(), Ty::Int, false)],
+                    ret,
+                    effects: vec![],
+                },
+            );
+        }
+
+        // Statement alloc + read.
+        self.define_fn(
+            "bootstrap_stmt_alloc".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("node_tag".into(), Ty::Int, false),
+                    ("int_value".into(), Ty::Int, false),
+                    ("child_a".into(), Ty::Int, false),
+                    ("child_b".into(), Ty::Int, false),
+                    ("child_c".into(), Ty::Int, false),
+                    ("text".into(), Ty::String, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        for (name, ret) in [
+            ("bootstrap_stmt_get_tag", Ty::Int),
+            ("bootstrap_stmt_get_int_value", Ty::Int),
+            ("bootstrap_stmt_get_text", Ty::String),
+            ("bootstrap_stmt_get_child_a", Ty::Int),
+            ("bootstrap_stmt_get_child_b", Ty::Int),
+            ("bootstrap_stmt_get_child_c", Ty::Int),
+        ] {
+            self.define_fn(
+                name.into(),
+                FnSig {
+                    type_params: vec![],
+                    params: vec![("id".into(), Ty::Int, false)],
+                    ret,
+                    effects: vec![],
+                },
+            );
+        }
+
+        // Param alloc + read.
+        self.define_fn(
+            "bootstrap_param_alloc".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("name".into(), Ty::String, false),
+                    ("type_tag".into(), Ty::Int, false),
+                    ("type_name".into(), Ty::String, false),
+                    ("default_id".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        for (name, ret) in [
+            ("bootstrap_param_get_name", Ty::String),
+            ("bootstrap_param_get_type_tag", Ty::Int),
+            ("bootstrap_param_get_type_name", Ty::String),
+            ("bootstrap_param_get_default", Ty::Int),
+        ] {
+            self.define_fn(
+                name.into(),
+                FnSig {
+                    type_params: vec![],
+                    params: vec![("id".into(), Ty::Int, false)],
+                    ret,
+                    effects: vec![],
+                },
+            );
+        }
+
+        // Function alloc + read.
+        self.define_fn(
+            "bootstrap_function_alloc".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("name".into(), Ty::String, false),
+                    ("params_handle".into(), Ty::Int, false),
+                    ("ret_type_tag".into(), Ty::Int, false),
+                    ("ret_type_name".into(), Ty::String, false),
+                    ("body_handle".into(), Ty::Int, false),
+                    ("is_pub".into(), Ty::Int, false),
+                    ("is_extern".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        for (name, ret) in [
+            ("bootstrap_function_get_name", Ty::String),
+            ("bootstrap_function_get_params_handle", Ty::Int),
+            ("bootstrap_function_get_ret_type_tag", Ty::Int),
+            ("bootstrap_function_get_ret_type_name", Ty::String),
+            ("bootstrap_function_get_body_handle", Ty::Int),
+        ] {
+            self.define_fn(
+                name.into(),
+                FnSig {
+                    type_params: vec![],
+                    params: vec![("id".into(), Ty::Int, false)],
+                    ret,
+                    effects: vec![],
+                },
+            );
+        }
+
+        // Module item alloc + read.
+        self.define_fn(
+            "bootstrap_module_item_alloc_function".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![("function_id".into(), Ty::Int, false)],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        for (name, ret) in [
+            ("bootstrap_module_item_get_tag", Ty::Int),
+            ("bootstrap_module_item_get_function_id", Ty::Int),
+        ] {
+            self.define_fn(
+                name.into(),
+                FnSig {
+                    type_params: vec![],
+                    params: vec![("id".into(), Ty::Int, false)],
+                    ret,
+                    effects: vec![],
+                },
+            );
+        }
+
+        // Generic node-id lists.
+        for name in [
+            "bootstrap_expr_list_alloc",
+            "bootstrap_stmt_list_alloc",
+            "bootstrap_param_list_alloc",
+            "bootstrap_module_item_list_alloc",
+        ] {
+            self.define_fn(
+                name.into(),
+                FnSig {
+                    type_params: vec![],
+                    params: vec![],
+                    ret: Ty::Int,
+                    effects: vec![],
+                },
+            );
+        }
+        self.define_fn(
+            "bootstrap_node_list_append".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("handle".into(), Ty::Int, false),
+                    ("id".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_node_list_len".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![("handle".into(), Ty::Int, false)],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+        self.define_fn(
+            "bootstrap_node_list_get".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("handle".into(), Ty::Int, false),
+                    ("index".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+
         // ── Numeric operations ───────────────────────────────────────────
 
         // float_to_int(Float) -> Int

--- a/codebase/compiler/tests/self_hosted_parser_ast_storage.rs
+++ b/codebase/compiler/tests/self_hosted_parser_ast_storage.rs
@@ -1,0 +1,247 @@
+//! Issue #222: parser AST storage parity gate.
+//!
+//! Drives the runtime-backed bootstrap AST store through the operations the
+//! self-hosted parser will issue when it executes — `bootstrap_*_alloc_*`
+//! to materialize nodes, `bootstrap_*_get_*` to walk them — and asserts
+//! that the resulting tree round-trips for nested binary expressions,
+//! function parameter lists, and statement bodies. This is the concrete
+//! evidence behind the `#222` acceptance criterion: parser-owned storage
+//! can carry every parser-differential corpus construct end-to-end.
+//!
+//! The bridge mirrors the semantics of the rewritten `compiler/parser.gr`
+//! `*_bootstrap_handle` builders. Once the self-hosted runtime can execute
+//! `parser.gr` directly, this gate flips from "Rust mirrors the .gr code"
+//! to "the .gr code drives the same store" without test changes.
+
+use gradient_compiler::bootstrap_ast_bridge::{
+    bootstrap_expr_alloc_binary, bootstrap_expr_alloc_ident, bootstrap_expr_alloc_int_lit,
+    bootstrap_expr_get_child_a, bootstrap_expr_get_child_b, bootstrap_expr_get_int_value,
+    bootstrap_expr_get_tag, bootstrap_expr_get_text, bootstrap_function_alloc,
+    bootstrap_function_get_body_handle, bootstrap_function_get_name,
+    bootstrap_function_get_params_handle, bootstrap_function_get_ret_type_tag,
+    bootstrap_module_item_alloc_function, bootstrap_module_item_get_function_id,
+    bootstrap_module_item_get_tag, bootstrap_module_item_list_alloc, bootstrap_node_list_append,
+    bootstrap_node_list_get, bootstrap_node_list_len, bootstrap_param_alloc,
+    bootstrap_param_get_name, bootstrap_param_get_type_tag, bootstrap_param_list_alloc,
+    bootstrap_stmt_alloc, bootstrap_stmt_get_child_a, bootstrap_stmt_get_child_b,
+    bootstrap_stmt_get_tag, bootstrap_stmt_get_text, bootstrap_stmt_list_alloc, reset_ast_store,
+    ExprTag, ModuleItemTag, StmtTag, TypeTag,
+};
+
+/// Serialize parity tests that share the process-wide ambient store.
+fn parity_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+}
+
+/// Mirror of `compiler/parser.gr::binop_bootstrap_code(AddOp) = 1`.
+const ADD_OP: i64 = 1;
+/// Mirror of `binop_bootstrap_code(EqOp) = 6`.
+const EQ_OP: i64 = 6;
+/// Mirror of `binop_bootstrap_code(AndOp) = 12`.
+const AND_OP: i64 = 12;
+
+#[test]
+fn nested_binary_expressions_round_trip_through_storage() {
+    let _g = parity_lock();
+    reset_ast_store();
+
+    // (a + b) == (a + b) and a + 1 — three levels of nesting plus a literal.
+    let a1 = bootstrap_expr_alloc_ident("a");
+    let b1 = bootstrap_expr_alloc_ident("b");
+    let sum1 = bootstrap_expr_alloc_binary(ADD_OP, a1, b1);
+
+    let a2 = bootstrap_expr_alloc_ident("a");
+    let b2 = bootstrap_expr_alloc_ident("b");
+    let sum2 = bootstrap_expr_alloc_binary(ADD_OP, a2, b2);
+
+    let eq = bootstrap_expr_alloc_binary(EQ_OP, sum1, sum2);
+
+    let a3 = bootstrap_expr_alloc_ident("a");
+    let one = bootstrap_expr_alloc_int_lit(1);
+    let sum3 = bootstrap_expr_alloc_binary(ADD_OP, a3, one);
+
+    let conj = bootstrap_expr_alloc_binary(AND_OP, eq, sum3);
+
+    // Walk the tree and assert each layer.
+    assert_eq!(bootstrap_expr_get_tag(conj), ExprTag::Binary as i64);
+    assert_eq!(bootstrap_expr_get_int_value(conj), AND_OP);
+
+    let lhs = bootstrap_expr_get_child_a(conj);
+    let rhs = bootstrap_expr_get_child_b(conj);
+    assert_eq!(bootstrap_expr_get_tag(lhs), ExprTag::Binary as i64);
+    assert_eq!(bootstrap_expr_get_int_value(lhs), EQ_OP);
+    assert_eq!(bootstrap_expr_get_tag(rhs), ExprTag::Binary as i64);
+    assert_eq!(bootstrap_expr_get_int_value(rhs), ADD_OP);
+
+    let lhs_left = bootstrap_expr_get_child_a(lhs);
+    let lhs_right = bootstrap_expr_get_child_b(lhs);
+    assert_eq!(bootstrap_expr_get_tag(lhs_left), ExprTag::Binary as i64);
+    assert_eq!(bootstrap_expr_get_tag(lhs_right), ExprTag::Binary as i64);
+
+    // Deepest leaves must materialize the original identifier text.
+    let inner_a = bootstrap_expr_get_child_a(lhs_left);
+    let inner_b = bootstrap_expr_get_child_b(lhs_left);
+    assert_eq!(bootstrap_expr_get_tag(inner_a), ExprTag::Ident as i64);
+    assert_eq!(bootstrap_expr_get_text(inner_a), "a");
+    assert_eq!(bootstrap_expr_get_text(inner_b), "b");
+
+    // The right-hand sum walks through to its int literal.
+    let rhs_right = bootstrap_expr_get_child_b(rhs);
+    assert_eq!(bootstrap_expr_get_tag(rhs_right), ExprTag::IntLit as i64);
+    assert_eq!(bootstrap_expr_get_int_value(rhs_right), 1);
+}
+
+#[test]
+fn function_param_list_round_trips_through_storage() {
+    let _g = parity_lock();
+    reset_ast_store();
+
+    let p_a = bootstrap_param_alloc("a", TypeTag::Int as i64, "", 0);
+    let p_b = bootstrap_param_alloc("b", TypeTag::Int as i64, "", 0);
+    let p_c = bootstrap_param_alloc("c", TypeTag::Bool as i64, "", 0);
+
+    let plist = bootstrap_param_list_alloc();
+    bootstrap_node_list_append(plist, p_a);
+    bootstrap_node_list_append(plist, p_b);
+    bootstrap_node_list_append(plist, p_c);
+
+    assert_eq!(bootstrap_node_list_len(plist), 3);
+    let names: Vec<String> = (0..3)
+        .map(|i| bootstrap_param_get_name(bootstrap_node_list_get(plist, i)))
+        .collect();
+    assert_eq!(names, vec!["a", "b", "c"]);
+
+    let tags: Vec<i64> = (0..3)
+        .map(|i| bootstrap_param_get_type_tag(bootstrap_node_list_get(plist, i)))
+        .collect();
+    assert_eq!(
+        tags,
+        vec![
+            TypeTag::Int as i64,
+            TypeTag::Int as i64,
+            TypeTag::Bool as i64
+        ]
+    );
+}
+
+#[test]
+fn statement_body_round_trips_with_let_and_ret() {
+    let _g = parity_lock();
+    reset_ast_store();
+
+    // Body equivalent to:
+    //   let x = 42
+    //   ret x + 1
+    let lit_42 = bootstrap_expr_alloc_int_lit(42);
+    let let_stmt = bootstrap_stmt_alloc(StmtTag::Let as i64, 0, 0, lit_42, 0, "x");
+
+    let x_ref = bootstrap_expr_alloc_ident("x");
+    let one = bootstrap_expr_alloc_int_lit(1);
+    let sum = bootstrap_expr_alloc_binary(ADD_OP, x_ref, one);
+    let ret_stmt = bootstrap_stmt_alloc(StmtTag::Ret as i64, 0, sum, 0, 0, "");
+
+    let body = bootstrap_stmt_list_alloc();
+    bootstrap_node_list_append(body, let_stmt);
+    bootstrap_node_list_append(body, ret_stmt);
+
+    assert_eq!(bootstrap_node_list_len(body), 2);
+
+    let first_id = bootstrap_node_list_get(body, 0);
+    assert_eq!(bootstrap_stmt_get_tag(first_id), StmtTag::Let as i64);
+    assert_eq!(bootstrap_stmt_get_text(first_id), "x");
+    let first_value = bootstrap_stmt_get_child_b(first_id);
+    assert_eq!(bootstrap_expr_get_tag(first_value), ExprTag::IntLit as i64);
+    assert_eq!(bootstrap_expr_get_int_value(first_value), 42);
+
+    let last_id = bootstrap_node_list_get(body, 1);
+    assert_eq!(bootstrap_stmt_get_tag(last_id), StmtTag::Ret as i64);
+    let ret_value = bootstrap_stmt_get_child_a(last_id);
+    assert_eq!(bootstrap_expr_get_tag(ret_value), ExprTag::Binary as i64);
+    let ret_left = bootstrap_expr_get_child_a(ret_value);
+    let ret_right = bootstrap_expr_get_child_b(ret_value);
+    assert_eq!(bootstrap_expr_get_tag(ret_left), ExprTag::Ident as i64);
+    assert_eq!(bootstrap_expr_get_text(ret_left), "x");
+    assert_eq!(bootstrap_expr_get_tag(ret_right), ExprTag::IntLit as i64);
+    assert_eq!(bootstrap_expr_get_int_value(ret_right), 1);
+}
+
+#[test]
+fn full_function_with_module_item_list_round_trips() {
+    let _g = parity_lock();
+    reset_ast_store();
+
+    // Mirrors corpus/01_fn_add_int.gr at the storage level:
+    //   fn add(a: Int, b: Int) -> Int:
+    //       a + b
+    let p_a = bootstrap_param_alloc("a", TypeTag::Int as i64, "", 0);
+    let p_b = bootstrap_param_alloc("b", TypeTag::Int as i64, "", 0);
+    let plist = bootstrap_param_list_alloc();
+    bootstrap_node_list_append(plist, p_a);
+    bootstrap_node_list_append(plist, p_b);
+
+    let a = bootstrap_expr_alloc_ident("a");
+    let b = bootstrap_expr_alloc_ident("b");
+    let sum = bootstrap_expr_alloc_binary(ADD_OP, a, b);
+    let body_stmt = bootstrap_stmt_alloc(StmtTag::Expr as i64, 0, sum, 0, 0, "");
+    let body = bootstrap_stmt_list_alloc();
+    bootstrap_node_list_append(body, body_stmt);
+
+    let fid = bootstrap_function_alloc("add", plist, TypeTag::Int as i64, "", body, 0, 0);
+    let mid = bootstrap_module_item_alloc_function(fid);
+    let items = bootstrap_module_item_list_alloc();
+    bootstrap_node_list_append(items, mid);
+
+    // Walk module item -> function -> params -> body and assert structure
+    // matches the originally-allocated tree.
+    assert_eq!(bootstrap_node_list_len(items), 1);
+    let item_id = bootstrap_node_list_get(items, 0);
+    assert_eq!(
+        bootstrap_module_item_get_tag(item_id),
+        ModuleItemTag::Function as i64
+    );
+    let fn_id = bootstrap_module_item_get_function_id(item_id);
+    assert_eq!(bootstrap_function_get_name(fn_id), "add");
+    assert_eq!(
+        bootstrap_function_get_ret_type_tag(fn_id),
+        TypeTag::Int as i64
+    );
+
+    let recovered_params = bootstrap_function_get_params_handle(fn_id);
+    assert_eq!(bootstrap_node_list_len(recovered_params), 2);
+    let p1 = bootstrap_node_list_get(recovered_params, 0);
+    let p2 = bootstrap_node_list_get(recovered_params, 1);
+    assert_eq!(bootstrap_param_get_name(p1), "a");
+    assert_eq!(bootstrap_param_get_name(p2), "b");
+
+    let recovered_body = bootstrap_function_get_body_handle(fn_id);
+    assert_eq!(bootstrap_node_list_len(recovered_body), 1);
+    let s = bootstrap_node_list_get(recovered_body, 0);
+    assert_eq!(bootstrap_stmt_get_tag(s), StmtTag::Expr as i64);
+    let body_expr = bootstrap_stmt_get_child_a(s);
+    assert_eq!(bootstrap_expr_get_tag(body_expr), ExprTag::Binary as i64);
+    assert_eq!(bootstrap_expr_get_int_value(body_expr), ADD_OP);
+    let bl = bootstrap_expr_get_child_a(body_expr);
+    let br = bootstrap_expr_get_child_b(body_expr);
+    assert_eq!(bootstrap_expr_get_text(bl), "a");
+    assert_eq!(bootstrap_expr_get_text(br), "b");
+}
+
+#[test]
+fn missing_node_ids_are_safely_zero() {
+    let _g = parity_lock();
+    reset_ast_store();
+
+    // Empty store: every accessor must return safe defaults (`tag = 0`,
+    // empty text, child id `0`) so parser execution can keep walking.
+    assert_eq!(bootstrap_expr_get_tag(0), 0);
+    assert_eq!(bootstrap_expr_get_tag(99), 0);
+    assert_eq!(bootstrap_expr_get_int_value(0), 0);
+    assert_eq!(bootstrap_expr_get_text(0), "");
+    assert_eq!(bootstrap_expr_get_child_a(0), 0);
+    assert_eq!(bootstrap_node_list_len(0), 0);
+    assert_eq!(bootstrap_node_list_get(0, 5), 0);
+}

--- a/codebase/compiler/tests/self_hosting_bootstrap.rs
+++ b/codebase/compiler/tests/self_hosting_bootstrap.rs
@@ -339,6 +339,225 @@ fn parser_gr_token_access_reads_real_token_list() {
     );
 }
 
+/// Issue #222: parser.gr must allocate real AST nodes / lists through the
+/// runtime-backed bootstrap AST store rather than collapsing children into
+/// structural-fingerprint integers. The body of every `*_bootstrap_handle`
+/// builder must call into the new `bootstrap_*_alloc*` externs, the list
+/// helpers must drive `bootstrap_<kind>_list_alloc` + `bootstrap_node_list_append`,
+/// and the normalized export must walk via `bootstrap_*_get_*` accessors.
+#[test]
+fn parser_gr_stores_real_ast_nodes_and_lists() {
+    let parser_src =
+        std::fs::read_to_string(compiler_path("parser.gr")).expect("Failed to read parser.gr");
+
+    // The new AST externs must be declared at the top of the module so the
+    // host typechecker accepts them as Phase 0 builtins.
+    for extern_decl in [
+        "fn bootstrap_expr_alloc_int_lit(value: Int) -> Int",
+        "fn bootstrap_expr_alloc_ident(name: String) -> Int",
+        "fn bootstrap_expr_alloc_binary(op_tag: Int, left: Int, right: Int) -> Int",
+        "fn bootstrap_expr_alloc_call(callee: Int, args_handle: Int) -> Int",
+        "fn bootstrap_expr_alloc_if(cond: Int, then_branch: Int, else_branch: Int) -> Int",
+        "fn bootstrap_expr_alloc_block(stmts_handle: Int, final_expr: Int) -> Int",
+        "fn bootstrap_expr_get_tag(id: Int) -> Int",
+        "fn bootstrap_expr_get_child_a(id: Int) -> Int",
+        "fn bootstrap_stmt_alloc(node_tag: Int, int_value: Int, child_a: Int, child_b: Int, child_c: Int, text: String) -> Int",
+        "fn bootstrap_stmt_get_tag(id: Int) -> Int",
+        "fn bootstrap_param_alloc(name: String, type_tag: Int, type_name: String, default_id: Int) -> Int",
+        "fn bootstrap_function_alloc(name: String, params_handle: Int, ret_type_tag: Int, ret_type_name: String, body_handle: Int, is_pub: Int, is_extern: Int) -> Int",
+        "fn bootstrap_module_item_alloc_function(function_id: Int) -> Int",
+        "fn bootstrap_expr_list_alloc() -> Int",
+        "fn bootstrap_stmt_list_alloc() -> Int",
+        "fn bootstrap_param_list_alloc() -> Int",
+        "fn bootstrap_module_item_list_alloc() -> Int",
+        "fn bootstrap_node_list_append(handle: Int, id: Int) -> Int",
+        "fn bootstrap_node_list_len(handle: Int) -> Int",
+        "fn bootstrap_node_list_get(handle: Int, index: Int) -> Int",
+    ] {
+        assert!(
+            parser_src.contains(extern_decl),
+            "parser.gr must declare bootstrap AST extern `{extern_decl}`"
+        );
+    }
+
+    // The expression / statement handle builders must hit the new
+    // alloc externs instead of returning hard-coded `3100 + value` style
+    // structural fingerprints.
+    let expr_handle_body =
+        parser_gr_function_body(&parser_src, "fn expr_bootstrap_handle(expr: Expr) -> Int:")
+            .expect("parser.gr must define fn expr_bootstrap_handle");
+    for required in [
+        "bootstrap_expr_alloc_int_lit(",
+        "bootstrap_expr_alloc_ident(",
+        "bootstrap_expr_alloc_binary(",
+        "bootstrap_expr_alloc_unary(",
+        "bootstrap_expr_alloc_call(",
+        "bootstrap_expr_alloc_if(",
+        "bootstrap_expr_alloc_block(",
+    ] {
+        assert!(
+            expr_handle_body.contains(required),
+            "expr_bootstrap_handle must call `{required}` to store real AST nodes"
+        );
+    }
+
+    // The legacy fingerprint encoding must be gone: no arithmetic on integer
+    // literals like `3100`/`3700` to derive expr handles.
+    for forbidden in ["3100 + value", "3700 +", "3800 +", "3900 +", "4000 +"] {
+        assert!(
+            !expr_handle_body.contains(forbidden),
+            "expr_bootstrap_handle still uses fingerprint encoding `{forbidden}`"
+        );
+    }
+
+    let stmt_handle_body =
+        parser_gr_function_body(&parser_src, "fn stmt_bootstrap_handle(stmt: Stmt) -> Int:")
+            .expect("parser.gr must define fn stmt_bootstrap_handle");
+    for required in [
+        "bootstrap_stmt_alloc(stmt_tag_let()",
+        "bootstrap_stmt_alloc(stmt_tag_expr()",
+        "bootstrap_stmt_alloc(stmt_tag_ret()",
+    ] {
+        assert!(
+            stmt_handle_body.contains(required),
+            "stmt_bootstrap_handle must call `{required}` to store real Stmt nodes"
+        );
+    }
+    for forbidden in ["5100 +", "5200 +", "5300 +", "5400 +"] {
+        assert!(
+            !stmt_handle_body.contains(forbidden),
+            "stmt_bootstrap_handle still uses fingerprint encoding `{forbidden}`"
+        );
+    }
+
+    // Param / Function / ModuleItem builders must allocate real nodes.
+    let param_body =
+        parser_gr_function_body(&parser_src, "fn param_bootstrap_handle(param: Param) -> Int:")
+            .expect("parser.gr must define fn param_bootstrap_handle");
+    assert!(
+        param_body.contains("bootstrap_param_alloc(param.name"),
+        "param_bootstrap_handle must allocate via bootstrap_param_alloc"
+    );
+    assert!(
+        !param_body.contains("7100 +"),
+        "param_bootstrap_handle still uses fingerprint encoding"
+    );
+
+    let function_body = parser_gr_function_body(
+        &parser_src,
+        "fn function_bootstrap_handle(fn_def: Function) -> Int:",
+    )
+    .expect("parser.gr must define fn function_bootstrap_handle");
+    assert!(
+        function_body.contains("bootstrap_function_alloc(fn_def.name"),
+        "function_bootstrap_handle must allocate via bootstrap_function_alloc"
+    );
+    assert!(
+        !function_body.contains("8100 +"),
+        "function_bootstrap_handle still uses fingerprint encoding"
+    );
+
+    // List helpers must drive runtime list handles, not accumulate count
+    // integers via `count + *_bootstrap_handle(...)`.
+    let stmt_list_body =
+        parser_gr_function_body(&parser_src, "fn parse_stmt_list(p: Parser) -> (Parser, StmtList):")
+            .expect("parser.gr must define fn parse_stmt_list");
+    assert!(
+        stmt_list_body.contains("bootstrap_stmt_list_alloc()"),
+        "parse_stmt_list must allocate a runtime stmt-id list via bootstrap_stmt_list_alloc"
+    );
+    let stmt_list_helper = parser_gr_function_body(
+        &parser_src,
+        "fn parse_stmt_list_helper(p: Parser, list_handle: Int) -> (Parser, StmtList):",
+    )
+    .expect("parser.gr must define fn parse_stmt_list_helper with list_handle");
+    assert!(
+        stmt_list_helper.contains("bootstrap_node_list_append(list_handle"),
+        "parse_stmt_list_helper must append stmt ids via bootstrap_node_list_append"
+    );
+    assert!(
+        !stmt_list_helper.contains("count + stmt_bootstrap_handle"),
+        "parse_stmt_list_helper still folds counts instead of appending node ids"
+    );
+
+    let param_list_helper = parser_gr_function_body(
+        &parser_src,
+        "fn parse_param_list_helper(p: Parser, list_handle: Int) -> (Parser, ParamList):",
+    )
+    .expect("parser.gr must define fn parse_param_list_helper with list_handle");
+    assert!(
+        param_list_helper.contains("bootstrap_node_list_append(list_handle"),
+        "parse_param_list_helper must append param ids via bootstrap_node_list_append"
+    );
+
+    // Normalized export must walk via the new accessors. The legacy
+    // `*_handle` JSON form is replaced with tree-shaped `left` / `right` /
+    // `operand` / `cond` / `then` / `else` / `value` / `pattern` / `body` /
+    // `params` / `items` payloads.
+    let export_body = parser_gr_function_body(
+        &parser_src,
+        "fn normalized_expr_to_json_by_id(id: Int) -> String:",
+    )
+    .expect("parser.gr must define fn normalized_expr_to_json_by_id");
+    for required in [
+        "bootstrap_expr_get_tag(id)",
+        "bootstrap_expr_get_int_value(id)",
+        "bootstrap_expr_get_text(id)",
+        "bootstrap_expr_get_child_a(id)",
+        "bootstrap_expr_get_child_b(id)",
+    ] {
+        assert!(
+            export_body.contains(required),
+            "normalized_expr_to_json_by_id must call `{required}`"
+        );
+    }
+
+    let function_export_body = parser_gr_function_body(
+        &parser_src,
+        "fn normalized_function_to_json_by_id(id: Int) -> String:",
+    )
+    .expect("parser.gr must define fn normalized_function_to_json_by_id");
+    assert!(
+        function_export_body.contains("bootstrap_function_get_name(id)"),
+        "normalized_function_to_json_by_id must walk via bootstrap_function_get_name"
+    );
+    assert!(
+        function_export_body.contains("normalized_param_list_to_json"),
+        "normalized_function_to_json_by_id must walk params via normalized_param_list_to_json"
+    );
+    assert!(
+        function_export_body.contains("normalized_stmt_list_to_json"),
+        "normalized_function_to_json_by_id must walk body via normalized_stmt_list_to_json"
+    );
+
+    // The legacy `*_handle` keys must be gone from the canonical JSON form.
+    // A few legacy strings are still used by the comment header / readiness
+    // doc, so anchor the check on the JSON keys themselves.
+    for forbidden in [
+        "\\\"left_handle\\\":",
+        "\\\"right_handle\\\":",
+        "\\\"operand_handle\\\":",
+        "\\\"callee_handle\\\":",
+        "\\\"args_handle\\\":",
+        "\\\"cond_handle\\\":",
+        "\\\"then_handle\\\":",
+        "\\\"else_handle\\\":",
+        "\\\"stmts_handle\\\":",
+        "\\\"final_expr_handle\\\":",
+        "\\\"pattern_handle\\\":",
+        "\\\"type_handle\\\":",
+        "\\\"value_handle\\\":",
+        "\\\"params_handle\\\":",
+        "\\\"body_handle\\\":",
+        "\\\"items_handle\\\":",
+    ] {
+        assert!(
+            !parser_src.contains(forbidden),
+            "parser.gr normalized export still emits legacy `{forbidden}` key"
+        );
+    }
+}
+
 fn parser_gr_function_body<'a>(src: &'a str, signature: &str) -> Option<&'a str> {
     let start = src.find(signature)?;
     let after_signature = &src[start + signature.len()..];
@@ -358,8 +577,8 @@ fn parser_gr_exposes_direct_execution_readiness_metadata() {
         "parser.gr should expose a normalized export contract version"
     );
     assert!(
-        parser_content.contains("ret \"canonical-json-v1\""),
-        "parser.gr normalized export contract version should be canonical-json-v1"
+        parser_content.contains("ret \"canonical-json-v2\""),
+        "parser.gr normalized export contract version should be canonical-json-v2 (#222)"
     );
 
     let readiness_body = parser_gr_function_body(

--- a/compiler/parser.gr
+++ b/compiler/parser.gr
@@ -206,6 +206,178 @@ mod parser:
     fn bootstrap_token_list_get_end_offset(handle: Int, index: Int) -> Int
 
     // =========================================================================
+    // Bootstrap AST Node Externs (#222)
+    // =========================================================================
+    //
+    // These plumb runtime-backed AST node storage. Each `bootstrap_*_alloc_*`
+    // returns a non-zero node id that uniquely identifies the appended node
+    // inside its kind's id space (expr ids are distinct from stmt / param /
+    // function / module-item ids). Reader-side accessors return safe defaults
+    // (`tag = 0`, empty string, child id `0`) for unknown ids so parser
+    // execution can keep walking.
+    //
+    // Generic node-id lists back the parser's `*List` wrappers — `parse_stmt_list`
+    // produces a `StmtList { handle: Int }` whose handle is the runtime list
+    // handle and whose items are stored stmt ids. The list handles are produced
+    // by `bootstrap_<kind>_list_alloc()` and items appended with
+    // `bootstrap_node_list_append(handle, id)`.
+    //
+    // FFI signatures stay primitive (Int / String) until the runtime can pass
+    // record values across the boundary.
+
+    // --- Expression alloc primitives ------------------------------------------
+    fn bootstrap_expr_alloc_int_lit(value: Int) -> Int
+    fn bootstrap_expr_alloc_bool_lit(value: Int) -> Int
+    fn bootstrap_expr_alloc_string_lit(value: String) -> Int
+    fn bootstrap_expr_alloc_ident(name: String) -> Int
+    fn bootstrap_expr_alloc_binary(op_tag: Int, left: Int, right: Int) -> Int
+    fn bootstrap_expr_alloc_unary(op_tag: Int, operand: Int) -> Int
+    fn bootstrap_expr_alloc_call(callee: Int, args_handle: Int) -> Int
+    fn bootstrap_expr_alloc_if(cond: Int, then_branch: Int, else_branch: Int) -> Int
+    fn bootstrap_expr_alloc_block(stmts_handle: Int, final_expr: Int) -> Int
+    fn bootstrap_expr_alloc_error(message: String) -> Int
+
+    // --- Expression read primitives -------------------------------------------
+    fn bootstrap_expr_get_tag(id: Int) -> Int
+    fn bootstrap_expr_get_int_value(id: Int) -> Int
+    fn bootstrap_expr_get_text(id: Int) -> String
+    fn bootstrap_expr_get_child_a(id: Int) -> Int
+    fn bootstrap_expr_get_child_b(id: Int) -> Int
+    fn bootstrap_expr_get_child_c(id: Int) -> Int
+
+    // --- Statement alloc + read -----------------------------------------------
+    fn bootstrap_stmt_alloc(node_tag: Int, int_value: Int, child_a: Int, child_b: Int, child_c: Int, text: String) -> Int
+    fn bootstrap_stmt_get_tag(id: Int) -> Int
+    fn bootstrap_stmt_get_int_value(id: Int) -> Int
+    fn bootstrap_stmt_get_text(id: Int) -> String
+    fn bootstrap_stmt_get_child_a(id: Int) -> Int
+    fn bootstrap_stmt_get_child_b(id: Int) -> Int
+    fn bootstrap_stmt_get_child_c(id: Int) -> Int
+
+    // --- Param alloc + read ---------------------------------------------------
+    fn bootstrap_param_alloc(name: String, type_tag: Int, type_name: String, default_id: Int) -> Int
+    fn bootstrap_param_get_name(id: Int) -> String
+    fn bootstrap_param_get_type_tag(id: Int) -> Int
+    fn bootstrap_param_get_type_name(id: Int) -> String
+    fn bootstrap_param_get_default(id: Int) -> Int
+
+    // --- Function alloc + read ------------------------------------------------
+    fn bootstrap_function_alloc(name: String, params_handle: Int, ret_type_tag: Int, ret_type_name: String, body_handle: Int, is_pub: Int, is_extern: Int) -> Int
+    fn bootstrap_function_get_name(id: Int) -> String
+    fn bootstrap_function_get_params_handle(id: Int) -> Int
+    fn bootstrap_function_get_ret_type_tag(id: Int) -> Int
+    fn bootstrap_function_get_ret_type_name(id: Int) -> String
+    fn bootstrap_function_get_body_handle(id: Int) -> Int
+
+    // --- Module item alloc + read ---------------------------------------------
+    fn bootstrap_module_item_alloc_function(function_id: Int) -> Int
+    fn bootstrap_module_item_get_tag(id: Int) -> Int
+    fn bootstrap_module_item_get_function_id(id: Int) -> Int
+
+    // --- Generic node-id lists ------------------------------------------------
+    fn bootstrap_expr_list_alloc() -> Int
+    fn bootstrap_stmt_list_alloc() -> Int
+    fn bootstrap_param_list_alloc() -> Int
+    fn bootstrap_module_item_list_alloc() -> Int
+    fn bootstrap_node_list_append(handle: Int, id: Int) -> Int
+    fn bootstrap_node_list_len(handle: Int) -> Int
+    fn bootstrap_node_list_get(handle: Int, index: Int) -> Int
+
+    // =========================================================================
+    // AST Tag Encoding
+    // =========================================================================
+    //
+    // Tags match the case order of Expr / Stmt / TypeExpr / ModuleItem in this
+    // module so the Rust mirror (`bootstrap_ast_bridge.rs`) and the
+    // self-hosted parser agree on the same encoding. Tag 0 is reserved as
+    // "unknown / not stored".
+
+    // ExprTag values
+    fn expr_tag_int_lit() -> Int:
+        ret 1
+    fn expr_tag_float_lit() -> Int:
+        ret 2
+    fn expr_tag_string_lit() -> Int:
+        ret 3
+    fn expr_tag_bool_lit() -> Int:
+        ret 4
+    fn expr_tag_ident() -> Int:
+        ret 5
+    fn expr_tag_binary() -> Int:
+        ret 6
+    fn expr_tag_unary() -> Int:
+        ret 7
+    fn expr_tag_call() -> Int:
+        ret 8
+    fn expr_tag_if() -> Int:
+        ret 9
+    fn expr_tag_block() -> Int:
+        ret 10
+    fn expr_tag_error_kind() -> Int:
+        ret 16
+
+    // StmtTag values
+    fn stmt_tag_let() -> Int:
+        ret 1
+    fn stmt_tag_expr() -> Int:
+        ret 2
+    fn stmt_tag_ret() -> Int:
+        ret 3
+    fn stmt_tag_if() -> Int:
+        ret 4
+    fn stmt_tag_while() -> Int:
+        ret 5
+    fn stmt_tag_for() -> Int:
+        ret 6
+    fn stmt_tag_break() -> Int:
+        ret 8
+    fn stmt_tag_continue() -> Int:
+        ret 9
+    fn stmt_tag_defer() -> Int:
+        ret 10
+    fn stmt_tag_assign() -> Int:
+        ret 11
+    fn stmt_tag_error_kind() -> Int:
+        ret 12
+
+    // TypeTag values
+    fn type_tag_int() -> Int:
+        ret 1
+    fn type_tag_float() -> Int:
+        ret 2
+    fn type_tag_bool() -> Int:
+        ret 3
+    fn type_tag_string() -> Int:
+        ret 4
+    fn type_tag_unit() -> Int:
+        ret 5
+    fn type_tag_named() -> Int:
+        ret 6
+
+    fn type_to_tag_and_name(t: TypeExpr) -> (Int, String):
+        match t:
+            IntType:
+                ret (1, "")
+            FloatType:
+                ret (2, "")
+            BoolType:
+                ret (3, "")
+            StringType:
+                ret (4, "")
+            UnitType:
+                ret (5, "")
+            NamedType(name):
+                ret (6, name)
+            _:
+                ret (0, "")
+
+    fn bool_to_int(b: Bool) -> Int:
+        if b:
+            ret 1
+        ret 0
+
+
+    // =========================================================================
     // Bootstrap AST Identity and Normalized Export
     // =========================================================================
 
@@ -286,94 +458,107 @@ mod parser:
             NotOp:
                 ret 2
 
+    // Bootstrap AST node allocation. Each match arm calls the runtime-backed
+    // `bootstrap_expr_alloc_*` extern, which appends a real node to the host
+    // AST store and returns a non-zero id. Because parser construction is
+    // bottom-up, `left` / `right` / `cond` / etc. fields already carry real
+    // ids from earlier `expr_bootstrap_handle` calls, so the returned id
+    // identifies a fully-stored sub-tree the normalized export and downstream
+    // phases can walk via the `bootstrap_expr_get_*` accessors.
+    //
+    // Variants outside the bootstrap subset still hit `bootstrap_expr_alloc_error`
+    // so the id space stays dense and unknown nodes don't alias real ones.
     fn expr_bootstrap_handle(expr: Expr) -> Int:
         match expr:
             IntLitExpr(value):
-                ret 3100 + value
+                ret bootstrap_expr_alloc_int_lit(value)
             FloatLitExpr(_):
-                ret 32
-            StringLitExpr(_):
-                ret 33
+                ret bootstrap_expr_alloc_error("float literal outside bootstrap subset")
+            StringLitExpr(value):
+                ret bootstrap_expr_alloc_string_lit(value)
             BoolLitExpr(value):
-                if value:
-                    ret 34
-                ret 35
-            IdentExpr(_):
-                ret 36
+                ret bootstrap_expr_alloc_bool_lit(bool_to_int(value))
+            IdentExpr(name):
+                ret bootstrap_expr_alloc_ident(name)
             BinaryExpr(op, left, right):
-                ret 3700 + binop_bootstrap_code(op) + left + right
+                ret bootstrap_expr_alloc_binary(binop_bootstrap_code(op), left, right)
             UnaryExpr(op, operand):
-                ret 3800 + unop_bootstrap_code(op) + operand
+                ret bootstrap_expr_alloc_unary(unop_bootstrap_code(op), operand)
             CallExpr(callee, args):
-                ret 3900 + callee + args
+                ret bootstrap_expr_alloc_call(callee, args)
             IfExpr(cond, then_branch, else_branch):
-                ret 4000 + cond + then_branch + else_branch
-            MatchExpr(value, arms):
-                ret 4100 + value + arms
+                ret bootstrap_expr_alloc_if(cond, then_branch, else_branch)
+            MatchExpr(_, _):
+                ret bootstrap_expr_alloc_error("match expr outside bootstrap subset")
             BlockExpr(stmts, final_expr):
-                ret 4200 + stmts + final_expr
-            LambdaExpr(params, body):
-                ret 4300 + params + body
-            FieldAccessExpr(obj, _):
-                ret 4400 + obj
-            IndexExpr(obj, index):
-                ret 4500 + obj + index
-            AssignmentExpr(target, value):
-                ret 4600 + target + value
-            ExprError(_):
-                ret 47
+                ret bootstrap_expr_alloc_block(stmts, final_expr)
+            LambdaExpr(_, _):
+                ret bootstrap_expr_alloc_error("lambda outside bootstrap subset")
+            FieldAccessExpr(_, _):
+                ret bootstrap_expr_alloc_error("field access outside bootstrap subset")
+            IndexExpr(_, _):
+                ret bootstrap_expr_alloc_error("index expr outside bootstrap subset")
+            AssignmentExpr(_, _):
+                ret bootstrap_expr_alloc_error("assignment expr outside bootstrap subset")
+            ExprError(message):
+                ret bootstrap_expr_alloc_error(message)
+
+    fn pattern_text(pat: Pattern) -> String:
+        match pat:
+            IdentPattern(name):
+                ret name
+            _:
+                ret ""
 
     fn stmt_bootstrap_handle(stmt: Stmt) -> Int:
         match stmt:
             LetStmt(pat, type_ann, value, is_mut):
-                let mut_part = if is_mut:
-                    1
-                else:
-                    0
-                ret 5100 + pattern_bootstrap_handle(pat) + type_ann + value + mut_part
+                ret bootstrap_stmt_alloc(stmt_tag_let(), bool_to_int(is_mut), type_ann, value, pattern_bootstrap_handle(pat), pattern_text(pat))
             ExprStmt(expr):
-                ret 5200 + expr
+                ret bootstrap_stmt_alloc(stmt_tag_expr(), 0, expr, 0, 0, "")
             RetStmt(value):
-                ret 5300 + value
+                ret bootstrap_stmt_alloc(stmt_tag_ret(), 0, value, 0, 0, "")
             IfStmt(cond, then_block, else_block):
-                ret 5400 + cond + then_block + else_block
+                ret bootstrap_stmt_alloc(stmt_tag_if(), 0, cond, then_block, else_block, "")
             WhileStmt(cond, body):
-                ret 5500 + cond + body
+                ret bootstrap_stmt_alloc(stmt_tag_while(), 0, cond, body, 0, "")
             ForStmt(pat, iter, body):
-                ret 5600 + pattern_bootstrap_handle(pat) + iter + body
-            MatchStmt(value, arms):
-                ret 5700 + value + arms
+                ret bootstrap_stmt_alloc(stmt_tag_for(), 0, iter, body, pattern_bootstrap_handle(pat), pattern_text(pat))
+            MatchStmt(_, _):
+                ret bootstrap_stmt_alloc(stmt_tag_error_kind(), 0, 0, 0, 0, "match stmt outside bootstrap subset")
             BreakStmt:
-                ret 58
+                ret bootstrap_stmt_alloc(stmt_tag_break(), 0, 0, 0, 0, "")
             ContinueStmt:
-                ret 59
+                ret bootstrap_stmt_alloc(stmt_tag_continue(), 0, 0, 0, 0, "")
             DeferStmt(expr):
-                ret 6000 + expr
+                ret bootstrap_stmt_alloc(stmt_tag_defer(), 0, expr, 0, 0, "")
             AssignStmt(target, value):
-                ret 6100 + target + value
-            StmtError(_):
-                ret 62
+                ret bootstrap_stmt_alloc(stmt_tag_assign(), 0, target, value, 0, "")
+            StmtError(message):
+                ret bootstrap_stmt_alloc(stmt_tag_error_kind(), 0, 0, 0, 0, message)
 
     fn param_bootstrap_handle(param: Param) -> Int:
-        ret 7100 + type_bootstrap_handle(param.type_ann) + param.default_value
+        let (type_tag, type_name) = type_to_tag_and_name(param.type_ann)
+        ret bootstrap_param_alloc(param.name, type_tag, type_name, param.default_value)
 
     fn function_bootstrap_handle(fn_def: Function) -> Int:
-        ret 8100 + fn_def.params + type_bootstrap_handle(fn_def.ret_type) + fn_def.effects + fn_def.body
+        let (ret_tag, ret_name) = type_to_tag_and_name(fn_def.ret_type)
+        ret bootstrap_function_alloc(fn_def.name, fn_def.params, ret_tag, ret_name, fn_def.body, bool_to_int(fn_def.is_pub), bool_to_int(fn_def.is_extern))
 
     fn module_item_bootstrap_handle(item: ModuleItem) -> Int:
         match item:
             FunctionItem(fn_handle):
-                ret 9100 + fn_handle
-            TypeItem(_, def):
-                ret 9200 + def
-            TraitItem(_, def):
-                ret 9300 + def
-            ImplItem(_, _, impl_def):
-                ret 9400 + impl_def
+                ret bootstrap_module_item_alloc_function(fn_handle)
+            TypeItem(_, _):
+                ret bootstrap_module_item_alloc_function(0)
+            TraitItem(_, _):
+                ret bootstrap_module_item_alloc_function(0)
+            ImplItem(_, _, _):
+                ret bootstrap_module_item_alloc_function(0)
             UseItemDecl(_):
-                ret 95
+                ret bootstrap_module_item_alloc_function(0)
             ModuleItemError(_):
-                ret 96
+                ret bootstrap_module_item_alloc_function(0)
 
     fn json_string(value: String) -> String:
         // Bootstrap subset strings are currently identifier/literal payloads
@@ -428,7 +613,210 @@ mod parser:
             NotOp:
                 ret "not"
 
+    fn binop_tag_to_json_name(op_tag: Int) -> String:
+        if op_tag == 1:
+            ret "add"
+        if op_tag == 2:
+            ret "sub"
+        if op_tag == 3:
+            ret "mul"
+        if op_tag == 4:
+            ret "div"
+        if op_tag == 5:
+            ret "mod"
+        if op_tag == 6:
+            ret "eq"
+        if op_tag == 7:
+            ret "ne"
+        if op_tag == 8:
+            ret "lt"
+        if op_tag == 9:
+            ret "le"
+        if op_tag == 10:
+            ret "gt"
+        if op_tag == 11:
+            ret "ge"
+        if op_tag == 12:
+            ret "and"
+        if op_tag == 13:
+            ret "or"
+        ret "unsupported"
+
+    fn unop_tag_to_json_name(op_tag: Int) -> String:
+        if op_tag == 1:
+            ret "neg"
+        if op_tag == 2:
+            ret "not"
+        ret "unsupported"
+
+    fn normalized_type_tag_to_json(type_tag: Int, type_name: String) -> String:
+        if type_tag == 1:
+            ret "{\"kind\":\"named\",\"name\":\"Int\"}"
+        if type_tag == 2:
+            ret "{\"kind\":\"named\",\"name\":\"Float\"}"
+        if type_tag == 3:
+            ret "{\"kind\":\"named\",\"name\":\"Bool\"}"
+        if type_tag == 4:
+            ret "{\"kind\":\"named\",\"name\":\"String\"}"
+        if type_tag == 5:
+            ret "{\"kind\":\"named\",\"name\":\"Unit\"}"
+        if type_tag == 6:
+            ret "{\"kind\":\"named\",\"name\":" + json_string(type_name) + "}"
+        ret "{\"kind\":\"unsupported\",\"reason\":\"type outside bootstrap subset\"}"
+
+    // Walk an expression node by id, dereferencing children through the
+    // bootstrap AST store. Replaces the older `*_handle` JSON form with a
+    // tree-shaped "left" / "right" / "operand" / etc. payload that matches
+    // the Rust reference normalized export.
+    fn normalized_expr_to_json_by_id(id: Int) -> String:
+        if id == 0:
+            ret "{\"kind\":\"unsupported\",\"reason\":\"missing expr\"}"
+        let node_tag = bootstrap_expr_get_tag(id)
+        if node_tag == 1:
+            ret "{\"kind\":\"int_lit\",\"value\":" + bootstrap_expr_get_int_value(id).to_string() + "}"
+        if node_tag == 4:
+            if bootstrap_expr_get_int_value(id) == 1:
+                ret "{\"kind\":\"bool_lit\",\"value\":true}"
+            ret "{\"kind\":\"bool_lit\",\"value\":false}"
+        if node_tag == 3:
+            ret "{\"kind\":\"string_lit\",\"value\":" + json_string(bootstrap_expr_get_text(id)) + "}"
+        if node_tag == 5:
+            ret "{\"kind\":\"ident\",\"name\":" + json_string(bootstrap_expr_get_text(id)) + "}"
+        if node_tag == 6:
+            let op_tag = bootstrap_expr_get_int_value(id)
+            let left = normalized_expr_to_json_by_id(bootstrap_expr_get_child_a(id))
+            let right = normalized_expr_to_json_by_id(bootstrap_expr_get_child_b(id))
+            ret "{\"kind\":\"binary\",\"left\":" + left + ",\"op\":" + json_string(binop_tag_to_json_name(op_tag)) + ",\"right\":" + right + "}"
+        if node_tag == 7:
+            let op_tag = bootstrap_expr_get_int_value(id)
+            let operand = normalized_expr_to_json_by_id(bootstrap_expr_get_child_a(id))
+            ret "{\"kind\":\"unary\",\"op\":" + json_string(unop_tag_to_json_name(op_tag)) + ",\"operand\":" + operand + "}"
+        if node_tag == 8:
+            let callee = normalized_expr_to_json_by_id(bootstrap_expr_get_child_a(id))
+            let args_handle = bootstrap_expr_get_child_b(id)
+            let args = normalized_expr_list_to_json(args_handle)
+            ret "{\"kind\":\"call\",\"args\":" + args + ",\"callee\":" + callee + "}"
+        if node_tag == 9:
+            let cond = normalized_expr_to_json_by_id(bootstrap_expr_get_child_a(id))
+            let then_b = normalized_expr_to_json_by_id(bootstrap_expr_get_child_b(id))
+            let else_b = normalized_expr_to_json_by_id(bootstrap_expr_get_child_c(id))
+            ret "{\"kind\":\"if\",\"cond\":" + cond + ",\"else\":" + else_b + ",\"then\":" + then_b + "}"
+        if node_tag == 10:
+            let stmts_handle = bootstrap_expr_get_child_a(id)
+            let final_expr = normalized_expr_to_json_by_id(bootstrap_expr_get_child_b(id))
+            let stmts = normalized_stmt_list_to_json(stmts_handle)
+            ret "{\"kind\":\"block\",\"final\":" + final_expr + ",\"stmts\":" + stmts + "}"
+        if node_tag == 16:
+            ret "{\"kind\":\"unsupported\",\"reason\":" + json_string(bootstrap_expr_get_text(id)) + "}"
+        ret "{\"kind\":\"unsupported\",\"reason\":\"expr outside bootstrap subset\"}"
+
+    fn normalized_expr_list_to_json(handle: Int) -> String:
+        let len = bootstrap_node_list_len(handle)
+        ret "[" + normalized_expr_list_to_json_helper(handle, 0, len, "") + "]"
+
+    fn normalized_expr_list_to_json_helper(handle: Int, idx: Int, len: Int, acc: String) -> String:
+        if idx >= len:
+            ret acc
+        let entry = normalized_expr_to_json_by_id(bootstrap_node_list_get(handle, idx))
+        let next_acc = if idx == 0:
+            entry
+        else:
+            acc + "," + entry
+        ret normalized_expr_list_to_json_helper(handle, idx + 1, len, next_acc)
+
+    fn normalized_stmt_list_to_json(handle: Int) -> String:
+        let len = bootstrap_node_list_len(handle)
+        ret "[" + normalized_stmt_list_to_json_helper(handle, 0, len, "") + "]"
+
+    fn normalized_stmt_list_to_json_helper(handle: Int, idx: Int, len: Int, acc: String) -> String:
+        if idx >= len:
+            ret acc
+        let entry = normalized_stmt_to_json_by_id(bootstrap_node_list_get(handle, idx))
+        let next_acc = if idx == 0:
+            entry
+        else:
+            acc + "," + entry
+        ret normalized_stmt_list_to_json_helper(handle, idx + 1, len, next_acc)
+
+    fn normalized_param_list_to_json(handle: Int) -> String:
+        let len = bootstrap_node_list_len(handle)
+        ret "[" + normalized_param_list_to_json_helper(handle, 0, len, "") + "]"
+
+    fn normalized_param_list_to_json_helper(handle: Int, idx: Int, len: Int, acc: String) -> String:
+        if idx >= len:
+            ret acc
+        let pid = bootstrap_node_list_get(handle, idx)
+        let pname = bootstrap_param_get_name(pid)
+        let ptag = bootstrap_param_get_type_tag(pid)
+        let ptname = bootstrap_param_get_type_name(pid)
+        let entry = "{\"name\":" + json_string(pname) + ",\"ty\":" + normalized_type_tag_to_json(ptag, ptname) + "}"
+        let next_acc = if idx == 0:
+            entry
+        else:
+            acc + "," + entry
+        ret normalized_param_list_to_json_helper(handle, idx + 1, len, next_acc)
+
+    fn normalized_module_item_list_to_json(handle: Int) -> String:
+        let len = bootstrap_node_list_len(handle)
+        ret "[" + normalized_module_item_list_to_json_helper(handle, 0, len, "") + "]"
+
+    fn normalized_module_item_list_to_json_helper(handle: Int, idx: Int, len: Int, acc: String) -> String:
+        if idx >= len:
+            ret acc
+        let mid = bootstrap_node_list_get(handle, idx)
+        let mtag = bootstrap_module_item_get_tag(mid)
+        let entry = if mtag == 1:
+            normalized_function_to_json_by_id(bootstrap_module_item_get_function_id(mid))
+        else:
+            "{\"kind\":\"unsupported\",\"reason\":\"module item outside bootstrap subset\"}"
+        let next_acc = if idx == 0:
+            entry
+        else:
+            acc + "," + entry
+        ret normalized_module_item_list_to_json_helper(handle, idx + 1, len, next_acc)
+
+    fn normalized_stmt_to_json_by_id(id: Int) -> String:
+        if id == 0:
+            ret "{\"kind\":\"unsupported\",\"reason\":\"missing stmt\"}"
+        let node_tag = bootstrap_stmt_get_tag(id)
+        if node_tag == 1:
+            // Let
+            let mut_part = if bootstrap_stmt_get_int_value(id) == 1:
+                "true"
+            else:
+                "false"
+            let value_id = bootstrap_stmt_get_child_b(id)
+            let value_json = normalized_expr_to_json_by_id(value_id)
+            let pat_name = bootstrap_stmt_get_text(id)
+            let pat_json = "{\"kind\":\"ident\",\"name\":" + json_string(pat_name) + "}"
+            ret "{\"kind\":\"let\",\"mutable\":" + mut_part + ",\"pattern\":" + pat_json + ",\"value\":" + value_json + "}"
+        if node_tag == 2:
+            ret "{\"kind\":\"expr\",\"value\":" + normalized_expr_to_json_by_id(bootstrap_stmt_get_child_a(id)) + "}"
+        if node_tag == 3:
+            ret "{\"kind\":\"ret\",\"value\":" + normalized_expr_to_json_by_id(bootstrap_stmt_get_child_a(id)) + "}"
+        if node_tag == 12:
+            ret "{\"kind\":\"unsupported\",\"reason\":" + json_string(bootstrap_stmt_get_text(id)) + "}"
+        ret "{\"kind\":\"unsupported\",\"reason\":\"stmt outside bootstrap subset\"}"
+
+    fn normalized_function_to_json_by_id(id: Int) -> String:
+        if id == 0:
+            ret "{\"kind\":\"unsupported\",\"reason\":\"missing function\"}"
+        let name = bootstrap_function_get_name(id)
+        let params_handle = bootstrap_function_get_params_handle(id)
+        let body_handle = bootstrap_function_get_body_handle(id)
+        let ret_tag = bootstrap_function_get_ret_type_tag(id)
+        let ret_name = bootstrap_function_get_ret_type_name(id)
+        ret "{\"body\":" + normalized_stmt_list_to_json(body_handle) + ",\"kind\":\"function\",\"name\":" + json_string(name) + ",\"params\":" + normalized_param_list_to_json(params_handle) + ",\"ret_type\":" + normalized_type_tag_to_json(ret_tag, ret_name) + "}"
+
+    fn normalized_module_to_json_by_id(items_handle: Int, name: String) -> String:
+        ret "{\"items\":" + normalized_module_item_list_to_json(items_handle) + ",\"module\":" + json_string(name) + "}"
+
     fn normalized_expr_to_json(expr: Expr) -> String:
+        // Legacy entry point: walks the in-memory Expr the parser still
+        // returns. The runtime-backed contract goes through
+        // `normalized_expr_to_json_by_id`; this wrapper exists so existing
+        // callers that hold an `Expr` keep functioning while every code path
+        // migrates to id-based traversal.
         match expr:
             IntLitExpr(value):
                 ret "{\"kind\":\"int_lit\",\"value\":" + value.to_string() + "}"
@@ -441,15 +829,15 @@ mod parser:
             IdentExpr(name):
                 ret "{\"kind\":\"ident\",\"name\":" + json_string(name) + "}"
             BinaryExpr(op, left, right):
-                ret "{\"kind\":\"binary\",\"op\":" + json_string(binop_to_json_name(op)) + ",\"left_handle\":" + left.to_string() + ",\"right_handle\":" + right.to_string() + "}"
+                ret "{\"kind\":\"binary\",\"left\":" + normalized_expr_to_json_by_id(left) + ",\"op\":" + json_string(binop_to_json_name(op)) + ",\"right\":" + normalized_expr_to_json_by_id(right) + "}"
             UnaryExpr(op, operand):
-                ret "{\"kind\":\"unary\",\"op\":" + json_string(unop_to_json_name(op)) + ",\"operand_handle\":" + operand.to_string() + "}"
+                ret "{\"kind\":\"unary\",\"op\":" + json_string(unop_to_json_name(op)) + ",\"operand\":" + normalized_expr_to_json_by_id(operand) + "}"
             CallExpr(callee, args):
-                ret "{\"kind\":\"call\",\"callee_handle\":" + callee.to_string() + ",\"args_handle\":" + args.to_string() + "}"
+                ret "{\"kind\":\"call\",\"args\":" + normalized_expr_list_to_json(args) + ",\"callee\":" + normalized_expr_to_json_by_id(callee) + "}"
             IfExpr(cond, then_branch, else_branch):
-                ret "{\"kind\":\"if\",\"cond_handle\":" + cond.to_string() + ",\"then_handle\":" + then_branch.to_string() + ",\"else_handle\":" + else_branch.to_string() + "}"
+                ret "{\"kind\":\"if\",\"cond\":" + normalized_expr_to_json_by_id(cond) + ",\"else\":" + normalized_expr_to_json_by_id(else_branch) + ",\"then\":" + normalized_expr_to_json_by_id(then_branch) + "}"
             BlockExpr(stmts, final_expr):
-                ret "{\"kind\":\"block\",\"stmts_handle\":" + stmts.to_string() + ",\"final_expr_handle\":" + final_expr.to_string() + "}"
+                ret "{\"kind\":\"block\",\"final\":" + normalized_expr_to_json_by_id(final_expr) + ",\"stmts\":" + normalized_stmt_list_to_json(stmts) + "}"
             ExprError(message):
                 ret "{\"kind\":\"unsupported\",\"reason\":" + json_string(message) + "}"
             _:
@@ -457,29 +845,38 @@ mod parser:
 
     fn normalized_stmt_to_json(stmt: Stmt) -> String:
         match stmt:
-            LetStmt(pat, type_ann, value, is_mut):
+            LetStmt(pat, _, value, is_mut):
                 let mut_part = if is_mut:
                     "true"
                 else:
                     "false"
-                ret "{\"kind\":\"let\",\"pattern_handle\":" + pattern_bootstrap_handle(pat).to_string() + ",\"mutable\":" + mut_part + ",\"type_handle\":" + type_ann.to_string() + ",\"value_handle\":" + value.to_string() + "}"
+                let pat_json = match pat:
+                    IdentPattern(name):
+                        "{\"kind\":\"ident\",\"name\":" + json_string(name) + "}"
+                    _:
+                        "{\"kind\":\"unsupported\",\"reason\":\"pattern outside bootstrap subset\"}"
+                ret "{\"kind\":\"let\",\"mutable\":" + mut_part + ",\"pattern\":" + pat_json + ",\"value\":" + normalized_expr_to_json_by_id(value) + "}"
             ExprStmt(expr):
-                ret "{\"kind\":\"expr\",\"value_handle\":" + expr.to_string() + "}"
+                ret "{\"kind\":\"expr\",\"value\":" + normalized_expr_to_json_by_id(expr) + "}"
             RetStmt(value):
-                ret "{\"kind\":\"ret\",\"value_handle\":" + value.to_string() + "}"
+                ret "{\"kind\":\"ret\",\"value\":" + normalized_expr_to_json_by_id(value) + "}"
             StmtError(message):
                 ret "{\"kind\":\"unsupported\",\"reason\":" + json_string(message) + "}"
             _:
                 ret "{\"kind\":\"unsupported\",\"reason\":\"stmt outside bootstrap subset\"}"
 
     fn normalized_function_to_json(fn_def: Function) -> String:
-        ret "{\"kind\":\"function\",\"name\":" + json_string(fn_def.name) + ",\"params_handle\":" + fn_def.params.to_string() + ",\"ret_type\":" + normalized_type_to_json(fn_def.ret_type) + ",\"body_handle\":" + fn_def.body.to_string() + "}"
+        let (ret_tag, ret_name) = type_to_tag_and_name(fn_def.ret_type)
+        ret "{\"body\":" + normalized_stmt_list_to_json(fn_def.body) + ",\"kind\":\"function\",\"name\":" + json_string(fn_def.name) + ",\"params\":" + normalized_param_list_to_json(fn_def.params) + ",\"ret_type\":" + normalized_type_tag_to_json(ret_tag, ret_name) + "}"
 
     fn normalized_module_to_json(module: Module) -> String:
-        ret "{\"items_handle\":" + module.items.to_string() + ",\"module\":" + json_string(module.name) + "}"
+        ret "{\"items\":" + normalized_module_item_list_to_json(module.items) + ",\"module\":" + json_string(module.name) + "}"
 
     fn normalized_export_contract_version() -> String:
-        ret "canonical-json-v1"
+        // v2 marks the runtime-backed AST traversal — children are walked
+        // through `bootstrap_*_get_*` accessors instead of being reported as
+        // bare `*_handle` integers (#222).
+        ret "canonical-json-v2"
 
     fn parser_direct_execution_ready() -> Bool:
         // Flip to true only when TokenList/list-backed parser state is runtime-backed
@@ -998,19 +1395,25 @@ mod parser:
                 ret parse_expr_stmt(p)
 
     fn parse_stmt_list(p: Parser) -> (Parser, StmtList):
-        // Parse statements until RBrace or Eof using recursion
-        ret parse_stmt_list_helper(p, 0)
+        // Allocate a runtime-backed stmt-id list and append parsed stmt ids
+        // until the closing brace / EOF. The returned StmtList wraps the
+        // allocated handle so the body can be replayed via
+        // bootstrap_node_list_get(handle, idx).
+        let list_handle = bootstrap_stmt_list_alloc()
+        ret parse_stmt_list_helper(p, list_handle)
 
-    fn parse_stmt_list_helper(p: Parser, count: Int) -> (Parser, StmtList):
+    fn parse_stmt_list_helper(p: Parser, list_handle: Int) -> (Parser, StmtList):
         let tok = current_token(p)
         match tok.kind:
             RBrace:
-                ret (p, StmtList { handle: count })
+                ret (p, StmtList { handle: list_handle })
             Eof:
-                ret (p, StmtList { handle: count })
+                ret (p, StmtList { handle: list_handle })
             _:
                 let (new_p, stmt) = parse_stmt(p)
-                parse_stmt_list_helper(new_p, count + stmt_bootstrap_handle(stmt))
+                let stmt_id = stmt_bootstrap_handle(stmt)
+                let _ = bootstrap_node_list_append(list_handle, stmt_id)
+                parse_stmt_list_helper(new_p, list_handle)
 
     // =========================================================================
     // Function Parsing
@@ -1023,20 +1426,22 @@ mod parser:
         ret (after_type, Param { name: name, type_ann: type_ann, default_value: 0 })
 
     fn parse_param_list(p: Parser) -> (Parser, ParamList):
-        // Parse parameters until RParen using recursion
-        ret parse_param_list_helper(p, 0)
+        let list_handle = bootstrap_param_list_alloc()
+        ret parse_param_list_helper(p, list_handle)
 
-    fn parse_param_list_helper(p: Parser, count: Int) -> (Parser, ParamList):
+    fn parse_param_list_helper(p: Parser, list_handle: Int) -> (Parser, ParamList):
         let tok = current_token(p)
         match tok.kind:
             RParen:
-                ret (p, ParamList { handle: count })
+                ret (p, ParamList { handle: list_handle })
             Comma:
                 let after_comma = parser_advance(p)
-                parse_param_list_helper(after_comma, count)
+                parse_param_list_helper(after_comma, list_handle)
             _:
                 let (new_p, param) = parse_param(p)
-                parse_param_list_helper(new_p, count + param_bootstrap_handle(param))
+                let param_id = param_bootstrap_handle(param)
+                let _ = bootstrap_node_list_append(list_handle, param_id)
+                parse_param_list_helper(new_p, list_handle)
 
     fn parse_effect_set(p: Parser) -> (Parser, EffectList):
         ret (p, EffectList { handle: 1 })
@@ -1110,17 +1515,19 @@ mod parser:
                 ret (p, ModuleItemError("expected module item"))
 
     fn parse_module_item_list(p: Parser) -> (Parser, ModuleItemList):
-        // Parse module items until Eof using recursion
-        ret parse_module_item_list_helper(p, 0)
+        let list_handle = bootstrap_module_item_list_alloc()
+        ret parse_module_item_list_helper(p, list_handle)
 
-    fn parse_module_item_list_helper(p: Parser, count: Int) -> (Parser, ModuleItemList):
+    fn parse_module_item_list_helper(p: Parser, list_handle: Int) -> (Parser, ModuleItemList):
         let tok = current_token(p)
         match tok.kind:
             Eof:
-                ret (p, ModuleItemList { handle: count })
+                ret (p, ModuleItemList { handle: list_handle })
             _:
                 let (new_p, item) = parse_module_item(p)
-                parse_module_item_list_helper(new_p, count + module_item_bootstrap_handle(item))
+                let item_id = module_item_bootstrap_handle(item)
+                let _ = bootstrap_node_list_append(list_handle, item_id)
+                parse_module_item_list_helper(new_p, list_handle)
 
     // =========================================================================
     // Module Parsing


### PR DESCRIPTION
## Summary

Replaces parser.gr's structural-fingerprint integer encoding with runtime-backed AST node storage. Every `*_bootstrap_handle` builder now allocates a real node id via new `bootstrap_*_alloc_*` externs; list helpers drive `bootstrap_<kind>_list_alloc` + `bootstrap_node_list_append`; the normalized export walks via `bootstrap_*_get_*` accessors.

Fixes #222.

## What changed

- **`compiler/parser.gr`** — declare expr / stmt / param / function / module-item alloc + reader externs and node-id list externs; rewrite `*_bootstrap_handle` builders to allocate real nodes; switch `parse_stmt_list` / `parse_param_list` / `parse_module_item_list` to runtime list handles; add `normalized_*_to_json_by_id` walkers; bump normalized export contract version to `canonical-json-v2`. Renamed locals away from reserved keywords (`tag` → `node_tag`, `child` → `entry`).
- **`codebase/compiler/src/bootstrap_ast_bridge.rs` (new)** — Rust mirror of the AST store with FFI-shaped accessors. Tag enums (`ExprTag`, `StmtTag`, `TypeTag`, `ModuleItemTag`) match the variant order used by parser.gr.
- **`codebase/compiler/src/typechecker/env.rs`** — register all new bootstrap AST externs as Phase 0 builtins.
- **`codebase/compiler/tests/self_hosting_bootstrap.rs`** — new `parser_gr_stores_real_ast_nodes_and_lists` source-text gate that pins extern declarations, alloc calls in every handle builder, list-handle plumbing in list helpers, accessor calls in the normalized export, and the absence of the legacy `*_handle` JSON keys. Contract-version assertion bumped to `canonical-json-v2`.
- **`codebase/compiler/tests/self_hosted_parser_ast_storage.rs` (new)** — five parity tests proving nested binary expressions, function parameter lists, statement bodies, full `fn add(a, b) -> Int` module items, and missing-id reads all round-trip safely through the runtime-backed store.

## Acceptance criteria

- ✅ Parser can store and retrieve child AST data for all existing parser differential corpus constructs (binary, unary, call, if, block, let, ret, expr stmts, params, function definitions, module items).
- ✅ Normalized export walks parser-owned AST storage via `bootstrap_*_get_*` accessors rather than reporting bare `*_handle` integers.
- ✅ Checker / IR / codegen can dereference parser AST handles through the new accessors instead of fake `get_expr_kind` fallbacks.
- ✅ Tests prove nested binary expressions, function params, and statement bodies round-trip through storage.

## Verification

```
cargo build -p gradient-compiler                                  ok
cargo test  -p gradient-compiler                                  pass
cargo test  -p gradient-compiler --test self_hosting_smoke        15 pass
cargo test  -p gradient-compiler --test self_hosting_bootstrap    11 pass
cargo test  -p gradient-compiler --test self_hosted_parser_ast_storage   5 pass
cargo test  -p gradient-compiler --test self_hosted_parser_token_access  5 pass
cargo test  -p gradient-compiler --test self_hosted_lexer_parity         5 pass
cargo test  -p gradient-compiler --test parser_differential_tests        1 pass + 1 ignored
cargo clippy --workspace -- -D warnings                           clean
```

## Deferred

- Direct parser execution stays gated (`parser_direct_execution_ready() = false`). Token payload recovery, multi-line lexer parity, and direct-from-.gr execution are downstream follow-ups (#223 / #224 / token-payload FFI).
- Pattern storage beyond `IdentPattern` (currently the parser stores a best-effort name in the stmt's text slot) — picked up by checker-side work in #225.