### PR TITLE
docs(self-hosting): refresh public bootstrap status

### DIFF
--- a/codebase/compiler/tests/self_hosting_bootstrap.rs
+++ b/codebase/compiler/tests/self_hosting_bootstrap.rs
@@ -3,10 +3,9 @@
 //! Validates that the self-hosted compiler can be loaded and its
 //! structure is correct. This is the first step toward full bootstrap.
 //!
-//! Note: The self-hosted compiler implementations are currently stubs.
-//! This test validates the structure (types, function signatures)
-//! is correct. Full compilation will be tested once implementations
-//! are complete.
+//! Note: The self-hosted compiler is bootstrap-stage, not fully self-hosted.
+//! Lexer/parser/checker substrate now includes runtime-backed stores and
+//! parity gates; IR/codegen/pipeline execution remains intentionally bounded.
 
 use std::path::PathBuf;
 

--- a/codebase/wasm-demo/README.md
+++ b/codebase/wasm-demo/README.md
@@ -7,7 +7,7 @@ A browser-based demo showing Gradient code compiling to WebAssembly and running 
 Open `index.html` in any modern browser:
 
 ```bash
-cd /home/gray/TestingGround/Gradient/codebase/wasm-demo
+cd codebase/wasm-demo
 python -m http.server 8080
 # Then open http://localhost:8080
 ```

--- a/docs/RUNTIME_AUTHORITY.md
+++ b/docs/RUNTIME_AUTHORITY.md
@@ -164,7 +164,7 @@ gcc -o test test.o compiler/runtime/gradient_runtime.c -lcurl
 
 ## References
 
-- Adversarial synthesis: `/home/gray/TestingGround/Research/gradient_v1_adversarial_synthesis_for_Hermes_agent.md`
+- Adversarial synthesis: internal April 2026 research review summarized by the public roadmap and self-hosting docs
 - Current runtime: `codebase/compiler/runtime/gradient_runtime.c`
 - New runtime: `codebase/runtime/`
 - Cranelift backend: `codebase/compiler/src/codegen/cranelift.rs`

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,284 +1,140 @@
 # Self-Hosting Roadmap
 
-Gradient's self-hosting plan is to move more of the compiler into Gradient while keeping a small Rust host kernel for platform-sensitive primitives and code generation.
+Gradient is moving compiler ownership from the Rust host compiler into `compiler/*.gr` while keeping a small, explicit Rust kernel for runtime/platform primitives and backend machinery.
 
-This document is the detailed execution plan for that effort.
+Status: active bootstrap-stage work, not fully self-hosted.
 
-It is aligned with the April 2026 research review and with the public project roadmap.
-
-## Objective
-
-Target state:
-
-- the Rust compiler remains the trusted host implementation
-- the self-hosted compiler becomes the primary dogfooded compiler implementation
-- the boundary between the two is explicit and small
+## Target State
 
 Rust should keep:
 
 - platform and runtime primitives
-- file and process integration
-- backend code generation engines
-- bootstrap-critical low-level functionality
+- file/process integration
+- low-level bootstrap storage and FFI-shaped host services
+- backend engines where host integration is still required
+- the trusted fallback/compiler kernel until self-hosted parity is proven
 
 Gradient should increasingly own:
 
-- compiler front-end logic
+- lexer and parser logic
 - semantic analysis
-- agent-facing compiler services
-- higher-level orchestration
+- IR construction
+- codegen orchestration and emission policy
+- compiler driver flow
+- query/LSP services useful to agents
 
 ## Current State
 
-Stable facts from the repository and research:
+Current active self-hosted source tree: `compiler/*.gr`.
 
-- the Rust compiler is the production-leading implementation
-- string primitives needed for self-hosted lexer/parser work are present
-- self-hosted compiler files already exist in `compiler/*.gr`
-- parser work is still the most important self-hosting bottleneck
-- list/collection ergonomics remain a structural constraint for cleaner self-hosted implementations
+| Area | Current status |
+|---|---|
+| Self-hosted source inventory | 14 modules, over 7,000 lines under `compiler/*.gr` |
+| Bootstrap collections | runtime-backed typed handles landed in #236 |
+| Lexer | `lexer.gr::tokenize` accumulates real runtime-backed `TokenList` values via #237 |
+| Parser token access | `parser.gr::current_token` and `peek_token` read runtime-backed token kind/span data via #238 |
+| Parser AST storage | parser node/list storage and normalized export walk runtime-backed AST stores via #239 |
+| Checker env/dispatch | `checker.gr` uses runtime-backed env/fn/var storage and AST dispatch via #240 |
+| Parser differential gate | bridged Rust-vs-parser-shaped comparison exists for the current bootstrap corpus |
+| Lexer parity gate | bridge-mirrored token shape parity exists for the current single-line bootstrap corpus |
+| Checker parity gate | not implemented; tracked by #226 |
+| IR/codegen/pipeline | structural/bootstrap-stage; tracked by #227-#230 |
+| Driver/query/LSP | structural/bootstrap-stage; tracked by #231-#233 |
+| Trust/kernel boundary | not measured/enforced yet; tracked by #234/#235 |
+
+## What Is Proven
+
+The repository currently proves:
+
+- the self-hosted compiler module set exists and typechecks as source
+- bootstrap collection handles are real runtime-backed values, not dummy fields
+- self-hosted lexer code can append real tokens into a host-backed `TokenList`
+- self-hosted parser token access can read token kind/span values from that list
+- parser AST nodes/lists can round-trip through host-backed stores
+- checker env storage supports let-bound locals, function params, shadowing, parent chains, function signatures, safe defaults, and primitive type round-trips
+- source-text gates reject regression toward legacy dummy/placeholder collection shapes
+
+## Known Gaps
+
+These are expected blockers, not regressions:
+
+1. Token payloads are incomplete.
+   - Ident names, literal values, string payloads, and error messages are not fully recoverable through the bootstrap token FFI.
+   - This blocks stronger direct parser execution claims.
+
+2. Lexer parity is narrow.
+   - Current parity is single-line bootstrap token-shape coverage.
+   - `lexer.gr::next_token` still needs newline handling plus `INDENT`/`DEDENT` coverage.
+   - Numeric literal parity still ignores literal payload values.
+
+3. Parser direct execution is not complete.
+   - Current differential coverage is bridge-shaped.
+   - #223 tracks invoking `parser.gr` directly through the Gradient runtime/comptime path.
+
+4. Parser corpus is too small.
+   - #224 tracks expanding coverage across syntax used by `compiler/*.gr`.
+
+5. Checker needs differential parity.
+   - #240 provides runtime-backed env/AST dispatch substrate.
+   - #226 should now focus on normalized diagnostics/type-result parity against the Rust checker.
+
+6. IR/codegen/pipeline are not executable compiler phases yet.
+   - #227/#228 track AST-to-IR lowering and IR parity.
+   - #229/#230 track executable codegen and real phase pipeline execution.
+
+7. Driver/query/LSP are not production self-hosted services yet.
+   - #231 tracks `main.gr` driver usability.
+   - #232/#233 track query/session and LSP backing data.
+
+8. Trust and kernel boundary are not quantified.
+   - #234 tracks end-to-end bootstrap trust checks.
+   - #235 tracks measuring and shrinking the Rust kernel boundary.
+
+## Active Issue Map
+
+| Issue | Role |
+|---|---|
+| #116 | full self-hosting umbrella |
+| #223 | invoke `parser.gr` directly in the differential gate |
+| #224 | expand parser parity corpus beyond bootstrap basics |
+| #226 | add checker differential parity gate |
+| #227 | make `ir_builder.gr` lower real AST to IR |
+| #228 | add IR differential/golden parity tests |
+| #229 | implement executable codegen/emission slice |
+| #230 | make `compiler.gr` pipeline execute real phases |
+| #231 | make `main.gr` a usable bootstrap compiler driver |
+| #232 | back `query.gr` with real sessions and diagnostics |
+| #233 | back `lsp.gr` with query/session data |
+| #234 | add end-to-end bootstrap trust checks |
+| #235 | define and shrink the Rust kernel boundary |
+
+## Execution Order
+
+Recommended near-term order:
+
+1. #223 parser direct-execution prerequisites and direct invocation.
+2. #224 parser corpus expansion.
+3. #226 checker differential parity gate.
+4. #227/#228 IR execution and parity.
+5. #229/#230 codegen and full compiler pipeline execution.
+6. #231/#232/#233 driver, query, and LSP backing.
+7. #234/#235 trust checks and Rust-kernel boundary metrics.
 
 ## Execution Principles
 
 1. Keep the bootstrap parser intentionally narrow.
-2. Prefer local correctness and comparison tests over early completeness.
-3. Localize temporary workarounds so they do not spread through later phases.
-4. Do not block self-hosting on advanced type-system work beyond comptime polish.
-5. Keep the Rust compiler usable and documented while self-hosting evolves.
-
-## Step-By-Step Plan
-
-### Step 1: Freeze the bootstrap parser subset
-
-Purpose:
-
-- define the minimum grammar slice required to bootstrap meaningful self-hosted progress
-
-Must decide:
-
-- which declarations are in the first milestone
-- which expressions are in the first milestone
-- whether initial parsing is scannerless or staged through a narrow token abstraction
-- which temporary sequence representation will stand in for richer list support
-
-Output:
-
-- a parser bootstrap scope note
-- a corpus of accepted source examples
-- a written list of intentionally unsupported constructs for the first milestone
-
-### Step 2: Implement parser state threading in `compiler/parser.gr`
-
-Purpose:
-
-- establish the parser architecture recommended by the research
-
-Required characteristics:
-
-- immutable parser state
-- parse functions return updated state with result data
-- precedence-aware expression parsing
-- simple failure behavior first
-
-Recommended first parser milestone:
-
-- module shell
-- function definitions
-- let-bindings
-- literals
-- identifiers
-- arithmetic and comparison expressions
-
-Do not optimize for:
-
-- rich recovery
-- complete syntax parity
-- elegant list accumulation
-
-### Step 3: Constrain the temporary collection strategy
-
-Purpose:
-
-- avoid architectural drift while list primitives remain incomplete or awkward
-
-Rules:
-
-- use one temporary representation for parser-built sequences
-- document where the representation enters and leaves the parser
-- do not allow ad hoc sequence encodings to spread into checker and IR logic
-
-Expected replacement path:
-
-- once cleaner list support lands, replace the temporary representation behind stable boundaries
-
-### Step 4: Add parser comparison infrastructure
-
-Purpose:
-
-- make self-hosted parser progress measurable
-
-Build:
-
-- a normalized AST or parse-output representation
-- a shared test corpus between Rust and self-hosted parsers
-- golden tests for syntax categories
-- differential checks for the bootstrap subset
-
-Success condition:
-
-- self-hosted parser behavior can be compared automatically against the host parser for a known subset
-
-### Step 5: Finish comptime polish in the Rust compiler
-
-Purpose:
-
-- land the highest-value near-term advanced-types work without derailing self-hosting
-
-Focus:
-
-- clearer diagnostics for non-comptime arguments
-- explicit compile-time failure behavior
-- evaluation budget limits or similar guardrails
-
-Why inside the self-hosting roadmap:
-
-- comptime strengthens the language used to write future self-hosted compiler code
-
-### Step 6: Move into self-hosted semantic passes
-
-Target files:
-
-- `compiler/checker.gr`
-- `compiler/ir.gr`
-- `compiler/ir_builder.gr`
-- `compiler/codegen.gr`
-
-Prerequisites:
-
-- parser bootstrap works
-- parser outputs are testable
-- temporary collection boundaries are understood
-
-Success condition:
-
-- self-hosted compilation covers meaningfully more than syntax
-
-### Step 7: Build a repeatable bootstrap path
-
-Purpose:
-
-- make self-hosting practical, not just possible
-
-Deliverables:
-
-- documented stage ordering
-- commands/scripts for bootstrap validation
-- "same result" or equivalent trust checks where feasible
-- failure diagnosis notes for stage mismatches
-
-### Step 8: Expand the self-hosted compiler surface deliberately
-
-After front-end stability improves, expand in this order:
-
-1. query/compiler services useful to agents
-2. orchestration and build flow
-3. additional compiler subsystems where the self-hosted implementation is clearly paying for itself
-
-Reason:
-
-- the project's differentiator is not just self-hosting
-- it is self-hosting in a compiler stack designed for agent use
-
-## Dependencies And Ordering
-
-The important dependency chain is:
-
-1. parser scope
-2. parser implementation
-3. parser comparison infrastructure
-4. self-hosted checker and IR work
-5. repeatable bootstrap flow
-6. broader self-hosted compiler services
-
-Comptime can proceed in parallel because it is a contained host-compiler improvement with direct language value.
-
-LLVM completion, production WASM strategy, refinement types, and session types should not sit on the critical path for this plan.
-
-## Risks
-
-### Risk: Parser scope expands too early
-
-Impact:
-
-- slower delivery
-- more rewrite churn
-
-Mitigation:
-
-- freeze the bootstrap subset before implementation accelerates
-
-### Risk: Temporary list workarounds leak everywhere
-
-Impact:
-
-- later checker/IR code becomes harder to replace cleanly
-
-Mitigation:
-
-- isolate the workaround behind parser-local boundaries
-
-### Risk: Progress is judged by anecdotes instead of comparison tests
-
-Impact:
-
-- false confidence
-- hard-to-debug semantic drift
-
-Mitigation:
-
-- build differential and golden tests early
-
-### Risk: Advanced research pulls focus from execution
-
-Impact:
-
-- roadmap churn
-- delayed self-hosting milestones
-
-Mitigation:
-
-- keep agent-language theory as a parallel design track, not a blocker
-
-## What This Roadmap Does Not Assume
-
-It does not assume:
-
-- full parser parity before value is created
-- immediate LLVM completion
-- production-ready WASM output in the short term
-- refinement or session types as near-term prerequisites
-
-## Success Markers
-
-Near-term success:
-
-- bootstrap parser subset documented
-- first parser milestone implemented
-- parser comparison harness started
-- comptime polish completed
-
-Mid-term success:
-
-- self-hosted checker and IR work progress on top of stable parser outputs
-- bootstrap flow is reproducible
-
-Long-term success:
-
-- self-hosted compiler becomes a practical part of the project's own development loop
-- the Rust compiler and self-hosted compiler have a clear, durable boundary
-
-## Related Documents
-
-- [Project Roadmap](./roadmap.md)
-- [Architecture](./architecture.md)
-- [Agent Integration](./agent-integration.md)
+2. Prefer differential/golden tests before broadening syntax.
+3. Keep temporary host-backed stores behind explicit boundaries.
+4. Do not claim direct execution until the harness proves self-hosted code ran.
+5. Keep the Rust compiler usable while self-hosting evolves.
+6. Keep public claims narrower than internal aspirations.
+
+## Definition Of Done
+
+Self-hosting is not complete until:
+
+- `compiler/*.gr` performs real lexer/parser/checker/IR/codegen/pipeline work for a documented source subset
+- parity gates compare self-hosted results against Rust host results for that subset
+- bootstrap trust checks prove the path does not silently fall back to Rust implementations
+- remaining Rust kernel responsibilities are listed, measured, and intentionally retained
+- public docs, CI jobs, and issue tracker state all describe the same boundary

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -210,7 +210,7 @@ fn main() -> !{IO} ():
 
 ## What Works Today
 
-Gradient has a working compiler (Phases 0-7 complete). Here is the current state:
+Gradient has a working Rust host compiler. Self-hosting is tracked separately in `docs/SELF_HOSTING.md` and remains in progress. Current host-compiler state:
 
 - **`gradient new <name>`** -- Creates a new project with `gradient.toml` and `src/main.gr`.
 - **`gradient build`** -- Compiles `src/main.gr` to a native binary via the full pipeline: lexer, parser, type checker, IR builder, Cranelift codegen, system linker.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,226 +2,211 @@
 
 Gradient is an alpha-stage programming language and compiler stack built for AI-assisted software development.
 
-The roadmap below reflects the current repository state and the April 2026 research synthesis.
+The April 2026 research direction remains current:
 
-The main conclusion from that research is straightforward:
-
-- self-hosting remains the highest-leverage long-term investment
-- the parser is the immediate compiler bottleneck
-- comptime is the best short-term advanced-types task
+- self-hosting is the highest-leverage long-term investment
+- parser/checker parity gates are the immediate compiler bottleneck
 - Cranelift remains the default backend for fast iteration
 - LLVM is optional medium-term release work, not the current blocker
 - production-grade WASM needs a deliberate backend plan, not assumption drift
+- public claims must stay narrower than internal aspirations
 
 ## Current Product Shape
 
-What is stable today:
+Stable today:
 
 - native compilation through the Rust host compiler and Cranelift
 - type checking with effects, contracts, generics, pattern matching, modules, traits, actors, lists, maps, and test support
-- compiler-as-library query APIs
-- LSP support
+- compiler-as-library query APIs in the Rust implementation
+- LSP support backed by the Rust implementation
+- CI-gated compiler, security, WASM, and end-to-end checks
 
-What is still in-progress or experimental:
+In progress or experimental:
 
-- the self-hosted compiler in `compiler/*.gr`
+- self-hosted compiler modules in `compiler/*.gr`
+- direct self-hosted parser execution
+- self-hosted checker/IR/codegen/pipeline parity
 - production-grade WASM strategy
 - LLVM backend completion
 - refinement types and session types
 - registry-backed package distribution
 
-## Roadmap Principles
+## Current Self-Hosting Baseline
 
-Every roadmap decision below follows five constraints:
+The active self-hosted compiler tree is `compiler/*.gr`.
+
+Recent bootstrap substrate:
+
+- #236: runtime-backed bootstrap collection handles
+- #237: `lexer.gr` emits real `TokenList` values
+- #238: `parser.gr` token access reads runtime-backed `TokenList` data
+- #239: `parser.gr` stores real AST nodes/lists
+- #240: `checker.gr` uses runtime-backed env storage and AST dispatch
+- #242/#244: stale duplicate/dead code cleanup
+
+This means the project has moved beyond pure stubs for lexer/parser/checker substrate. It does not mean the compiler is fully self-hosted.
+
+Known current blockers:
+
+- token payload access for identifiers/literals/errors
+- newline/`INDENT`/`DEDENT` lexer parity
+- direct `parser.gr` invocation through the Gradient runtime path
+- checker differential parity against the Rust checker
+- executable IR lowering, codegen, and compiler pipeline phases
+- usable self-hosted driver, query service, and LSP backing
+- end-to-end bootstrap trust checks and Rust-kernel boundary metrics
+
+## Roadmap Principles
 
 1. Protect the working Rust compiler.
 2. Prioritize steps that unblock self-hosting.
 3. Prefer verification and differential testing before broadening surface area.
-4. Separate "near-term compiler execution" from "long-term agent-language theory."
+4. Separate near-term compiler execution from long-term agent-language theory.
 5. Keep public claims narrower than internal aspirations.
 
-## Step-By-Step Roadmap
+## Near-Term Roadmap
 
-### Step 1: Lock the self-hosted parser bootstrap subset
-
-Status: `Now`
-
-Goal:
-
-- define the exact source forms the first self-hosted parser must accept
-
-Deliverables:
-
-- parser subset specification
-- explicit statement on temporary collection/list workaround strategy
-- decision on initial scannerless strategy versus token-stream staging
-
-Why first:
-
-- current research converges on parser work as the immediate bottleneck
-- the bootstrap parser should be intentionally smaller than full Rust-parser parity
-
-Exit criteria:
-
-- one written bootstrap scope doc
-- one accepted temporary AST-sequence representation
-- one first-milestone acceptance corpus
-
-### Step 2: Implement the self-hosted parser milestone
+### Step 1: Direct parser execution and parser corpus expansion
 
 Status: `Now`
 
+Issues:
+
+- #223: invoke `parser.gr` directly in the differential gate
+- #224: expand parser parity corpus beyond bootstrap basics
+
 Goal:
 
-- make `compiler/parser.gr` handle a constrained but useful program subset
+- prove self-hosted parser code runs through the intended Gradient runtime/comptime path
+- prevent silent fallback to Rust-side bridge behavior
+- expand corpus coverage to syntax used by `compiler/*.gr`
 
-Target milestone:
+Required work:
 
-- function definitions
-- let-bindings
-- literals
-- arithmetic expressions
-- module-level structure needed for early compiler files
-
-Implementation guidance from research:
-
-- immutable state threading
-- `(result, state)` style parser functions
-- recursive descent first
-- fail-fast error behavior first
-- defer richer recovery until later
+- expose token payload accessors for identifiers, literals, strings, and errors
+- add newline/indentation-sensitive lexer coverage
+- distinguish real self-hosted execution from bridge fallback in test output
+- add canonical normalized baselines for representative syntax families
 
 Exit criteria:
 
-- parser accepts the bootstrap subset
-- outputs are stable enough for comparison testing
-- temporary list workaround remains localized
+- parser direct-exec gate fails if it silently falls back for the corpus
+- corpus covers the current bootstrap subset plus representative compiler-module syntax
 
-### Step 3: Build the parser testing bridge early
+### Step 2: Checker differential parity
 
 Status: `Now`
 
-Goal:
+Issue:
 
-- reduce risk before downstream self-hosting work multiplies it
-
-Deliverables:
-
-- shared parser corpus between Rust and self-hosted implementations
-- AST serialization or comparable normalized output
-- golden tests for representative syntax families
-- initial differential tests against the host parser
-
-Why this early:
-
-- the research strongly supports differential testing as high ROI
-- parser confidence should not depend on manual spot checks
-
-Exit criteria:
-
-- at least one automated Rust-vs-self-hosted parser comparison path
-- golden output checked in for the bootstrap subset
-
-### Step 4: Finish comptime polish
-
-Status: `Now`
+- #226: add checker differential parity gate
 
 Goal:
 
-- close the remaining comptime quality gaps without expanding scope
+- compare self-hosted checker results against the Rust checker for a bounded corpus
 
-Deliverables:
+Current substrate:
 
-- improved error reporting for runtime values passed to comptime parameters
-- explicit compile-time failure surfaces
-- evaluation budget or termination guardrails
+- #240 added runtime-backed checker env/fn/var storage
+- #240 added AST dispatch via bootstrap expression/statement accessors
 
-Why now:
+Required work:
 
-- comptime is the shortest advanced-types task with direct compiler value
-- it improves the language without destabilizing the self-hosting critical path
+- normalize checker output into comparable type/diagnostic results
+- add positive and negative fixtures
+- ensure the gate detects placeholder success and diagnostic drift
 
 Exit criteria:
 
-- current TODOs closed
-- tests updated
-- comptime documented as complete enough for current roadmap purposes
+- bounded Rust-vs-self-hosted checker parity gate is CI-visible
 
-### Step 5: Complete self-hosted semantic passes
+### Step 3: IR lowering and IR parity
 
 Status: `Next`
 
+Issues:
+
+- #227: make `ir_builder.gr` lower real AST to IR
+- #228: add IR differential/golden parity tests
+
 Goal:
 
-- move from parser bootstrap to a useful self-hosted compiler front end
-
-Scope:
-
-- `compiler/checker.gr`
-- `compiler/ir.gr`
-- `compiler/ir_builder.gr`
-- `compiler/codegen.gr`
-
-Dependency note:
-
-- this step should start only once parser shape and comparison testing are credible
+- turn parsed/checked bootstrap AST into real self-hosted IR for a bounded subset
 
 Exit criteria:
 
-- self-hosted compiler can process meaningful Gradient programs beyond tokenization/parsing
-- bootstrap flow is documented and repeatable
+- self-hosted IR output can be compared against the Rust host for selected fixtures
 
-### Step 6: Harden the public compiler workflow
+### Step 4: Codegen and compiler pipeline execution
 
 Status: `Next`
 
+Issues:
+
+- #229: implement executable codegen/emission slice
+- #230: make `compiler.gr` pipeline execute real phases
+
 Goal:
 
-- keep the Rust host compiler clearly production-leading while self-hosting advances
-
-Deliverables:
-
-- clearer CI expectations
-- stronger local-vs-CI parity
-- improved docs for supported versus experimental features
-- regression tracking for parser, typechecker, and build-system workflows
+- connect self-hosted front-end work to an executable compilation pipeline
 
 Exit criteria:
 
-- stable public docs
-- fewer ambiguous "works locally but not in CI" claims
-- public roadmap and README remain aligned
+- a bounded source subset flows through parser/checker/IR/codegen orchestration without placeholder phase returns
 
-### Step 7: Revisit backend expansion in the right order
+### Step 5: Driver, query, and LSP backing
+
+Status: `Next`
+
+Issues:
+
+- #231: make `main.gr` a usable bootstrap compiler driver
+- #232: back `query.gr` with real sessions and diagnostics
+- #233: back `lsp.gr` with query/session data
+
+Goal:
+
+- make self-hosted compiler services useful to users and agents
+
+Exit criteria:
+
+- driver behavior, query diagnostics, and LSP responses come from real session state for the documented subset
+
+### Step 6: Bootstrap trust and Rust-kernel boundary
+
+Status: `Next`
+
+Issues:
+
+- #234: add end-to-end bootstrap trust checks
+- #235: define and shrink the Rust kernel boundary
+
+Goal:
+
+- measure what is still Rust-owned and prevent accidental host fallback
+
+Exit criteria:
+
+- trust checks prove which self-hosted phases executed
+- Rust-kernel responsibilities are listed, measured, and intentionally retained
+
+## Backend Track
 
 Status: `Later`
 
 Priority order:
 
-1. Cranelift remains the default development backend.
-2. LLVM is an optional bounded release-backend completion project.
-3. production WASM is a separate backend initiative with an explicit design choice.
+1. Keep Cranelift as the default development backend.
+2. Treat LLVM as an optional bounded release-backend completion project.
+3. Treat production WASM as a separate backend initiative with an explicit design choice.
 
-What this means in practice:
+This track must not displace parser/checker/IR self-hosting work.
 
-- do not let LLVM displace parser/self-hosting work
-- do not market WASM as fully mature until the backend path is hardened
-- treat backend comparison as an engineering track, not the main narrative
-
-Exit criteria:
-
-- written backend strategy update
-- explicit decision between direct WASM emission, LLVM-to-WASM reuse, or another dedicated route
-
-### Step 8: Formalize Gradient's agent-native language core
+## Agent-Native Language Research Track
 
 Status: `Parallel research track`
 
-Goal:
-
-- turn the broader research thesis into coherent language design direction
-
-Core themes from research:
+Research themes:
 
 - typed tool and capability interfaces
 - effect and authority tracking
@@ -230,46 +215,27 @@ Core themes from research:
 - executable semantics
 - multi-agent coordination primitives
 
-Important boundary:
+Boundary:
 
-- this work should inform naming and design decisions now
-- it should not block parser and self-hosting execution
-
-Exit criteria:
-
-- one design memo for agent-native language primitives
-- clear distinction between current features, near-term plans, and long-term research
+- this should inform naming and design decisions
+- it should not block parser/checker/IR execution work
 
 ## Milestone View
 
-### Near-Term
+Near-term:
 
-- parser bootstrap scope locked
-- first self-hosted parser milestone implemented
-- parser differential testing started
-- comptime polished
+- direct parser execution prerequisites
+- parser corpus expansion
+- checker differential parity
 
-### Mid-Term
+Mid-term:
 
-- self-hosted checker and IR work meaningfully underway
-- public docs and CI status tightened
-- backend strategy clarified without derailing self-hosting
+- executable self-hosted IR and codegen slices
+- real compiler pipeline execution
+- driver/query/LSP backing
 
-### Long-Term
+Long-term:
 
 - self-hosted compiler becomes the center of the Gradient development loop
-- production-grade WASM strategy lands
-- agent-native language features move from theory into concrete design and implementation
-
-## Notable Non-Goals Right Now
-
-- broadening the language surface before self-hosting bottlenecks are reduced
-- marketing LLVM as imminent
-- treating experimental WASM support as production-ready
-- starting refinement or session types ahead of parser/comptime/testing priorities
-
-## Related Documents
-
-- [Self-Hosting Roadmap](./SELF_HOSTING.md)
-- [Agent Integration](./agent-integration.md)
-- [Architecture](./architecture.md)
+- Rust kernel is measured, explicit, and small
+- backend strategy is clarified without derailing self-hosting

--- a/examples/todo-app/src/main.gr
+++ b/examples/todo-app/src/main.gr
@@ -39,9 +39,9 @@ fn parse_task_line(line: String) -> Option[Task]:
         let done: Bool = done_str == "true"
         ret Some(Task(id, title, done))
 
-/// Load tasks from ~/.gradient_todos.txt
+/// Load tasks from a local demo data file.
 fn load_tasks() -> !{FS} List[Task]:
-    let path: String = "/home/" + "gray" + "/.gradient_todos.txt"
+    let path: String = "gradient_todos.txt"
     if file_exists(path) == false:
         ret []
     else:
@@ -59,9 +59,9 @@ fn load_tasks() -> !{FS} List[Task]:
                         ()
         ret tasks
 
-/// Save tasks to ~/.gradient_todos.txt
+/// Save tasks to a local demo data file.
 fn save_tasks(tasks: List[Task]) -> !{IO, FS} ():
-    let path: String = "/home/" + "gray" + "/.gradient_todos.txt"
+    let path: String = "gradient_todos.txt"
     let mut content: String = ""
     for t in tasks:
         content = content + serialize_task(t) + "\n"


### PR DESCRIPTION
## Summary
- refresh self-hosting and roadmap docs after bootstrap substrate PRs #236-#240 and cleanup PRs #242/#244
- clarify Rust host compiler status versus in-progress self-hosting status
- remove internal/local path references from public docs/examples
- update stale self-hosting bootstrap test header comment
- update issue bodies for #116, #226, and #234 with current state

## Testing
- cargo test -p gradient-compiler --test self_hosting_bootstrap
- cargo clippy --workspace -- -D warnings
- git diff --check
- repo hygiene search: no /home/gray matches remain

Fixes #245