### PR TITLE
test: enable parser direct execution gate

### DIFF
--- a/codebase/compiler/src/bootstrap_lexer_bridge.rs
+++ b/codebase/compiler/src/bootstrap_lexer_bridge.rs
@@ -181,6 +181,7 @@ fn read_identifier(lex: &mut LexerState<'_>) -> TokenKind {
 }
 
 fn read_number(lex: &mut LexerState<'_>) -> TokenKind {
+    let start = lex.pos;
     while is_digit(lex.current_char()) {
         lex.advance();
     }
@@ -190,10 +191,17 @@ fn read_number(lex: &mut LexerState<'_>) -> TokenKind {
             lex.advance();
         }
     }
-    // Mirror lexer.gr: numeric value parsing is deferred (#220 scope keeps the
-    // current self-hosted contract — IntLit(0) — until float/int literal
-    // primitives are added in a follow-up issue).
-    TokenKind::IntLit(0)
+    let end = lex.pos;
+    let digits = lex.substring(start, end);
+
+    // #223 direct parser execution needs token payloads, not shape-only tags.
+    // The bootstrap lexer still keeps float syntax outside the parser corpus;
+    // decimal inputs map to IntLit(0), matching the prior safe fallback.
+    if digits.contains('.') {
+        return TokenKind::IntLit(0);
+    }
+
+    TokenKind::IntLit(digits.parse::<i64>().unwrap_or(0))
 }
 
 fn read_string(lex: &mut LexerState<'_>) -> TokenKind {

--- a/codebase/compiler/src/bootstrap_parser_bridge.rs
+++ b/codebase/compiler/src/bootstrap_parser_bridge.rs
@@ -17,12 +17,14 @@
 //!   * `bootstrap_token_list_get_end_offset(handle, index) -> Int`
 //!
 //! Each accessor encodes the same out-of-bounds-as-Eof / zero-span semantics
-//! used by `parser.gr::current_token` / `peek_token`. Token *payloads*
-//! (identifier names, literal values) are intentionally lossy — the
-//! self-hosted parser cannot recover them through the primitive FFI yet, so
-//! parser direct execution remains gated until payload access lands.
+//! used by `parser.gr::current_token` / `peek_token`. Payload accessors carry
+//! identifier names, string/error payloads, and integer literals so parser.gr's
+//! direct path can build normalized AST output without falling back to the Rust
+//! parser bridge.
 
-use crate::bootstrap_collections::{BootstrapCollectionStore, BootstrapHandle};
+use crate::bootstrap_collections::{
+    BootstrapCollectionKind, BootstrapCollectionStore, BootstrapHandle,
+};
 use crate::bootstrap_lexer_bridge::{tokenize_via_bootstrap_store, BootstrapTokenList};
 use crate::lexer::token::{Position, Span, Token, TokenKind};
 
@@ -72,6 +74,9 @@ pub fn token_kind_tag(kind: &TokenKind) -> i64 {
         // emits it under tag 38 only when token.gr's `Semi` variant is wired.
         // Keep the tag stable for round-trip even if we never emit it here.
         TokenKind::Dot => 39,
+        TokenKind::Indent => 80,
+        TokenKind::Dedent => 81,
+        TokenKind::Newline => 82,
         TokenKind::Fn => 50,
         TokenKind::Let => 51,
         TokenKind::Mut => 52,
@@ -99,25 +104,24 @@ pub fn token_kind_tag(kind: &TokenKind) -> i64 {
 }
 
 /// Inverse of [`token_kind_tag`] for tags the self-hosted parser actually
-/// inspects.
-///
-/// Payload-bearing kinds (`Ident`, `IntLit`, `FloatLit`, `StringLit`,
-/// `BoolLit`, `Error`) lose their payload across the FFI boundary and are
-/// reconstructed with placeholder data. This matches the bootstrap-stage
-/// contract: parser execution can advance over a real token stream and
-/// branch on token kind, but cannot yet recover identifier names or literal
-/// values until a future issue widens the FFI.
+/// inspects when no payload is available.
 pub fn token_kind_from_tag(tag: i64) -> TokenKind {
+    token_kind_from_parts(tag, 0, String::new())
+}
+
+/// Reconstruct a [`TokenKind`] from primitive FFI fields exposed to
+/// `parser.gr::kind_tag_to_token_kind_with_payload`.
+pub fn token_kind_from_parts(tag: i64, int_value: i64, text: String) -> TokenKind {
     match tag {
         1 => TokenKind::Eof,
-        2 => TokenKind::Error(String::new()),
-        3 => TokenKind::Ident(String::new()),
-        4 => TokenKind::IntLit(0),
+        2 => TokenKind::Error(text),
+        3 => TokenKind::Ident(text),
+        4 => TokenKind::IntLit(int_value),
         5 => TokenKind::FloatLit(0.0),
-        6 => TokenKind::StringLit(String::new()),
+        6 => TokenKind::StringLit(text),
         // Tag 7 is reserved by the self-hosted lexer for BoolLit but the Rust
         // TokenKind models booleans as the `True` / `False` keyword variants.
-        // Map it to `Eof` defensively until the FFI carries payloads.
+        // Map it to `Eof` defensively until bool payload tags are emitted.
         7 => TokenKind::Eof,
         10 => TokenKind::Plus,
         11 => TokenKind::Minus,
@@ -141,6 +145,9 @@ pub fn token_kind_from_tag(tag: i64) -> TokenKind {
         36 => TokenKind::Colon,
         37 => TokenKind::Comma,
         39 => TokenKind::Dot,
+        80 => TokenKind::Indent,
+        81 => TokenKind::Dedent,
+        82 => TokenKind::Newline,
         50 => TokenKind::Fn,
         51 => TokenKind::Let,
         52 => TokenKind::Mut,
@@ -179,6 +186,44 @@ pub fn bootstrap_token_list_get_kind(
     match store.get(handle, index as usize) {
         Ok(tok) => token_kind_tag(&tok.kind),
         Err(_) => EOF_KIND_TAG,
+    }
+}
+
+/// FFI-primitive accessor: integer payload for IntLit, or `0` otherwise.
+pub fn bootstrap_token_list_get_int_value(
+    store: &BootstrapCollectionStore<Token>,
+    handle: BootstrapHandle<Token>,
+    index: i64,
+) -> i64 {
+    if index < 0 {
+        return 0;
+    }
+    match store.get(handle, index as usize) {
+        Ok(tok) => match &tok.kind {
+            TokenKind::IntLit(value) => *value,
+            _ => 0,
+        },
+        Err(_) => 0,
+    }
+}
+
+/// FFI-primitive accessor: text payload for Ident/StringLit/Error, or empty.
+pub fn bootstrap_token_list_get_text(
+    store: &BootstrapCollectionStore<Token>,
+    handle: BootstrapHandle<Token>,
+    index: i64,
+) -> String {
+    if index < 0 {
+        return String::new();
+    }
+    match store.get(handle, index as usize) {
+        Ok(tok) => match &tok.kind {
+            TokenKind::Ident(value) | TokenKind::StringLit(value) | TokenKind::Error(value) => {
+                value.clone()
+            }
+            _ => String::new(),
+        },
+        Err(_) => String::new(),
     }
 }
 
@@ -247,6 +292,23 @@ impl BootstrapParser {
         }
     }
 
+    /// Construct a parser over a runtime-backed TokenList populated by the
+    /// caller. Used by the #223 parser differential gate to feed the Rust
+    /// lexer's layout-aware stream into parser.gr-shaped direct execution.
+    pub fn from_tokens(tokens: Vec<Token>, file_id: u32) -> Self {
+        let mut store = BootstrapCollectionStore::new();
+        let handle = store.alloc(BootstrapCollectionKind::TokenList);
+        for token in tokens {
+            store.append(handle, token).expect("append bootstrap token");
+        }
+        Self {
+            store,
+            handle,
+            pos: 0,
+            file_id,
+        }
+    }
+
     /// Mirror of `parser.gr::current_token`. Reads the kind tag and span at
     /// `pos`, then reconstructs a [`Token`]. Out-of-bounds reads synthesize
     /// a zero-span Eof token at the parser's `file_id`, matching the
@@ -274,7 +336,9 @@ impl BootstrapParser {
 
     fn token_at(&self, index: i64) -> Token {
         let tag = bootstrap_token_list_get_kind(&self.store, self.handle, index);
-        let kind = token_kind_from_tag(tag);
+        let int_value = bootstrap_token_list_get_int_value(&self.store, self.handle, index);
+        let text = bootstrap_token_list_get_text(&self.store, self.handle, index);
+        let kind = token_kind_from_parts(tag, int_value, text);
 
         // OOB lookups (tag == EOF_KIND_TAG via the OOB sentinel path) get a
         // zero-offset span at the parser's file_id. Real tokens get their
@@ -372,12 +436,29 @@ mod tests {
 
     #[test]
     fn drain_kinds_walks_the_real_stream() {
-        let p = BootstrapParser::from_source("x + 1", 0);
+        let p = BootstrapParser::from_source("x + 123", 0);
         let ks = p.drain_kinds();
-        assert!(matches!(ks[0], TokenKind::Ident(_)));
+        assert_eq!(ks[0], TokenKind::Ident("x".into()));
         assert!(matches!(ks[1], TokenKind::Plus));
-        assert!(matches!(ks[2], TokenKind::IntLit(_)));
+        assert_eq!(ks[2], TokenKind::IntLit(123));
         assert!(matches!(ks.last(), Some(TokenKind::Eof)));
+    }
+
+    #[test]
+    fn payload_accessors_round_trip_parser_visible_values() {
+        let p = BootstrapParser::from_source("let name = \"gradient\"", 0);
+        assert_eq!(bootstrap_token_list_get_text(&p.store, p.handle, 1), "name");
+        assert_eq!(
+            bootstrap_token_list_get_text(&p.store, p.handle, 3),
+            "gradient"
+        );
+
+        let q = BootstrapParser::from_source("ret 42", 0);
+        assert_eq!(
+            bootstrap_token_list_get_int_value(&q.store, q.handle, 1),
+            42
+        );
+        assert_eq!(q.peek_token(1).kind, TokenKind::IntLit(42));
     }
 
     #[test]

--- a/codebase/compiler/src/typechecker/env.rs
+++ b/codebase/compiler/src/typechecker/env.rs
@@ -1050,6 +1050,36 @@ impl TypeEnv {
             },
         );
 
+        // bootstrap_token_list_get_int_value(handle, index) -> Int
+        // Returns the IntLit payload, or 0 for non-int/OOB tokens.
+        self.define_fn(
+            "bootstrap_token_list_get_int_value".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("handle".into(), Ty::Int, false),
+                    ("index".into(), Ty::Int, false),
+                ],
+                ret: Ty::Int,
+                effects: vec![],
+            },
+        );
+
+        // bootstrap_token_list_get_text(handle, index) -> String
+        // Returns Ident/StringLit/Error payload text, or empty for other/OOB tokens.
+        self.define_fn(
+            "bootstrap_token_list_get_text".into(),
+            FnSig {
+                type_params: vec![],
+                params: vec![
+                    ("handle".into(), Ty::Int, false),
+                    ("index".into(), Ty::Int, false),
+                ],
+                ret: Ty::String,
+                effects: vec![],
+            },
+        );
+
         // bootstrap_token_list_get_file_id(handle, index) -> Int
         // Returns the token's span file_id, or 0 when `index` is out of
         // bounds.

--- a/codebase/compiler/tests/parser_differential_tests.rs
+++ b/codebase/compiler/tests/parser_differential_tests.rs
@@ -47,6 +47,7 @@ use gradient_compiler::ast::{
     stmt::{Stmt, StmtKind},
     types::TypeExpr,
 };
+use gradient_compiler::bootstrap_parser_bridge::BootstrapParser;
 use gradient_compiler::lexer::{Lexer, TokenKind};
 use gradient_compiler::parser;
 use serde::{Deserialize, Serialize};
@@ -570,11 +571,10 @@ fn assert_self_hosted_parser_export_contract() {
 fn direct_parser_gr_parse_source_to_canonical_json(src: &str) -> Option<String> {
     assert_self_hosted_parser_export_contract();
 
-    // Issue #207 direct-exec bridge: feed real lexer tokens into a minimal
-    // runtime-backed mirror of compiler/parser.gr's parse_module + normalized
-    // export entry point. Unsupported corpus snippets return None and continue
-    // through the host-adapter contract gate; the gated bootstrap corpus must
-    // all pass through this direct path.
+    // Issue #223 direct path: feed a real runtime-backed TokenList into a
+    // parser.gr-shaped invocation path. Token access goes exclusively through
+    // BootstrapParser, which mirrors parser.gr::current_token/peek_token over
+    // bootstrap_token_list_get_* accessors, including payload recovery.
     let mut bridge = ParserGrDirectBridge::from_source(src);
     bridge
         .parse_module_to_normalized_ast()
@@ -582,20 +582,15 @@ fn direct_parser_gr_parse_source_to_canonical_json(src: &str) -> Option<String> 
 }
 
 struct ParserGrDirectBridge {
-    tokens: Vec<TokenKind>,
-    pos: usize,
+    parser: BootstrapParser,
 }
 
 impl ParserGrDirectBridge {
     fn from_source(src: &str) -> Self {
         let mut lexer = Lexer::new(src, 0);
+        let tokens = lexer.tokenize();
         Self {
-            tokens: lexer
-                .tokenize()
-                .into_iter()
-                .map(|token| token.kind)
-                .collect(),
-            pos: 0,
+            parser: BootstrapParser::from_tokens(tokens, 0),
         }
     }
 
@@ -614,14 +609,12 @@ impl ParserGrDirectBridge {
         Some(NormalizedAst { items })
     }
 
-    fn current(&self) -> &TokenKind {
-        self.tokens.get(self.pos).unwrap_or(&TokenKind::Eof)
+    fn current(&self) -> TokenKind {
+        self.parser.current_token().kind
     }
 
     fn advance(&mut self) {
-        if self.pos < self.tokens.len() {
-            self.pos += 1;
-        }
+        self.parser = self.parser.advance();
     }
 
     fn skip_newlines(&mut self) {
@@ -640,7 +633,7 @@ impl ParserGrDirectBridge {
     }
 
     fn expect_simple(&mut self, expected: TokenKind) -> bool {
-        if std::mem::discriminant(self.current()) == std::mem::discriminant(&expected) {
+        if std::mem::discriminant(&self.current()) == std::mem::discriminant(&expected) {
             self.advance();
             true
         } else {

--- a/codebase/compiler/tests/self_hosted_parser_token_access.rs
+++ b/codebase/compiler/tests/self_hosted_parser_token_access.rs
@@ -11,7 +11,8 @@
 
 use gradient_compiler::bootstrap_parser_bridge::{
     bootstrap_token_list_get_end_offset, bootstrap_token_list_get_file_id,
-    bootstrap_token_list_get_kind, bootstrap_token_list_get_start_offset, BootstrapParser,
+    bootstrap_token_list_get_int_value, bootstrap_token_list_get_kind,
+    bootstrap_token_list_get_start_offset, bootstrap_token_list_get_text, BootstrapParser,
     EOF_KIND_TAG,
 };
 use gradient_compiler::lexer::token::TokenKind;
@@ -41,8 +42,8 @@ enum TokenShape {
     Error,
 }
 
-/// Coarse parity shape: parser.gr loses ident names / literal payloads across
-/// the FFI boundary, so parity is asserted on the discriminant only.
+/// Payload parity: #223 widens token access beyond discriminants so the
+/// parser direct path can recover names and literal values.
 fn shape(kind: &TokenKind) -> TokenShape {
     match kind {
         TokenKind::Ident(_) => TokenShape::Ident,
@@ -187,6 +188,25 @@ fn span_offsets_round_trip_for_real_tokens() {
         assert_eq!(end_extern as u32, stored.span.end.offset);
         assert_eq!(file_id_extern as u32, stored.span.file_id);
     }
+}
+
+#[test]
+fn payload_accessors_round_trip_names_and_literals() {
+    let p = BootstrapParser::from_source("let answer = 42", 0);
+    assert_eq!(
+        bootstrap_token_list_get_text(&p.store, p.handle, 1),
+        "answer"
+    );
+    assert_eq!(
+        bootstrap_token_list_get_int_value(&p.store, p.handle, 3),
+        42
+    );
+    assert_eq!(p.peek_token(1).kind, TokenKind::Ident("answer".into()));
+    assert_eq!(p.peek_token(3).kind, TokenKind::IntLit(42));
+
+    let s = BootstrapParser::from_source("let msg = \"ok\"", 0);
+    assert_eq!(bootstrap_token_list_get_text(&s.store, s.handle, 3), "ok");
+    assert_eq!(s.peek_token(3).kind, TokenKind::StringLit("ok".into()));
 }
 
 #[test]

--- a/codebase/compiler/tests/self_hosting_bootstrap.rs
+++ b/codebase/compiler/tests/self_hosting_bootstrap.rs
@@ -311,17 +311,20 @@ fn parser_gr_token_access_reads_real_token_list() {
         );
     }
 
-    // The shared lookup helper must hit all four reader externs so token
-    // identity (kind + span) round-trips through the runtime store.
+    // The shared lookup helper must hit all payload/span reader externs so
+    // token identity (kind + parser-visible payload + span) round-trips through
+    // the runtime store.
     let token_at_body =
         parser_gr_function_body(&parser_src, "fn token_at(p: Parser, index: Int) -> Token:")
             .expect("parser.gr must define a runtime-backed token_at lookup helper");
     for required in [
         "bootstrap_token_list_get_kind(p.tokens.handle",
+        "bootstrap_token_list_get_int_value(p.tokens.handle",
+        "bootstrap_token_list_get_text(p.tokens.handle",
         "bootstrap_token_list_get_file_id(p.tokens.handle",
         "bootstrap_token_list_get_start_offset(p.tokens.handle",
         "bootstrap_token_list_get_end_offset(p.tokens.handle",
-        "kind_tag_to_token_kind(",
+        "kind_tag_to_token_kind_with_payload(",
     ] {
         assert!(
             token_at_body.contains(required),
@@ -741,8 +744,14 @@ fn parser_gr_exposes_direct_execution_readiness_metadata() {
     )
     .expect("parser.gr should expose explicit direct-execution readiness metadata");
     assert!(
-        readiness_body.contains("ret false") && !readiness_body.contains("ret true"),
-        "parser.gr direct execution must remain false until TokenList/list storage is real"
+        readiness_body.contains("ret true") && !readiness_body.contains("ret false"),
+        "parser.gr direct execution should be marked ready after #223 TokenList payload accessors landed"
+    );
+    assert!(
+        parser_content.contains("fn bootstrap_token_list_get_int_value(handle: Int, index: Int) -> Int")
+            && parser_content.contains("fn bootstrap_token_list_get_text(handle: Int, index: Int) -> String")
+            && parser_content.contains("fn kind_tag_to_token_kind_with_payload"),
+        "parser.gr should recover parser-visible token payloads through bootstrap_token_list_get_* accessors"
     );
 }
 

--- a/compiler/parser.gr
+++ b/compiler/parser.gr
@@ -201,6 +201,8 @@ mod parser:
     // kind tag plus span offsets. Out-of-bounds reads return Eof / zero
     // span so parser execution never underflows past end-of-stream.
     fn bootstrap_token_list_get_kind(handle: Int, index: Int) -> Int
+    fn bootstrap_token_list_get_int_value(handle: Int, index: Int) -> Int
+    fn bootstrap_token_list_get_text(handle: Int, index: Int) -> String
     fn bootstrap_token_list_get_file_id(handle: Int, index: Int) -> Int
     fn bootstrap_token_list_get_start_offset(handle: Int, index: Int) -> Int
     fn bootstrap_token_list_get_end_offset(handle: Int, index: Int) -> Int
@@ -879,9 +881,9 @@ mod parser:
         ret "canonical-json-v2"
 
     fn parser_direct_execution_ready() -> Bool:
-        // Flip to true only when TokenList/list-backed parser state is runtime-backed
-        // and parse_module + normalized_module_to_json execute over real tokens.
-        ret false
+        // TokenList/list-backed parser state and parser-visible token payloads
+        // are runtime-backed for the #223 direct differential gate.
+        ret true
 
     // =========================================================================
     // Parser Construction
@@ -897,25 +899,23 @@ mod parser:
     // Token access reads through the runtime-backed TokenList store using the
     // `bootstrap_token_list_get_*` extern primitives. Each token is identified
     // by its position inside the list; the kind tag matches the encoding in
-    // `lexer.gr::token_kind_tag`, and span offsets round-trip the writer-side
-    // span. Payload-bearing kinds (Ident / *Lit / Error) lose their payload
-    // across the FFI boundary today — `kind_tag_to_token_kind` returns
-    // placeholder payload data and `parser_direct_execution_ready` stays
-    // false until the FFI is widened to carry token payloads.
+    // `lexer.gr::token_kind_tag`, span offsets round-trip the writer-side
+    // span, and payload accessors recover parser-visible Ident/IntLit/
+    // StringLit/Error values.
 
-    fn kind_tag_to_token_kind(kind_tag: Int) -> TokenKind:
+    fn kind_tag_to_token_kind_with_payload(kind_tag: Int, int_value: Int, text_value: String) -> TokenKind:
         if kind_tag == 1:
             ret Eof
         if kind_tag == 2:
-            ret Error("")
+            ret Error(text_value)
         if kind_tag == 3:
-            ret Ident("")
+            ret Ident(text_value)
         if kind_tag == 4:
-            ret IntLit(0)
+            ret IntLit(int_value)
         if kind_tag == 5:
             ret FloatLit(0.0)
         if kind_tag == 6:
-            ret StringLit("")
+            ret StringLit(text_value)
         if kind_tag == 7:
             ret BoolLit(false)
         if kind_tag == 10:
@@ -964,6 +964,12 @@ mod parser:
             ret Semi
         if kind_tag == 39:
             ret Dot
+        if kind_tag == 80:
+            ret Indent
+        if kind_tag == 81:
+            ret Dedent
+        if kind_tag == 82:
+            ret Newline
         if kind_tag == 50:
             ret Fn
         if kind_tag == 51:
@@ -1013,7 +1019,9 @@ mod parser:
 
     fn token_at(p: Parser, index: Int) -> Token:
         let kind_tag = bootstrap_token_list_get_kind(p.tokens.handle, index)
-        let kind = kind_tag_to_token_kind(kind_tag)
+        let int_value = bootstrap_token_list_get_int_value(p.tokens.handle, index)
+        let text_value = bootstrap_token_list_get_text(p.tokens.handle, index)
+        let kind = kind_tag_to_token_kind_with_payload(kind_tag, int_value, text_value)
         let file_id = bootstrap_token_list_get_file_id(p.tokens.handle, index)
         let start_offset = bootstrap_token_list_get_start_offset(p.tokens.handle, index)
         let end_offset = bootstrap_token_list_get_end_offset(p.tokens.handle, index)


### PR DESCRIPTION
Fixes #223

## Summary
- add TokenList payload accessors for identifier/string/error text and integer literals
- reconstruct parser-visible TokenKind payloads through BootstrapParser and parser.gr
- route parser differential direct path through a runtime-backed TokenList/BootstrapParser
- mark parser_direct_execution_ready true and update bootstrap/token-access tests

## Validation
- cargo test -p gradient-compiler bootstrap_parser_bridge --quiet
- cargo test -p gradient-compiler --test self_hosted_parser_token_access --quiet
- cargo test -p gradient-compiler --test parser_differential_tests --quiet
- cargo test -p gradient-compiler --test self_hosting_bootstrap --quiet
- cargo test -p gradient-compiler --quiet
- cargo test --workspace --quiet