### PR TITLE
fix(typechecker): register ExternFn declarations inside mod blocks (Fixes #261)

### DIFF
--- a/codebase/compiler/src/typechecker/checker.rs
+++ b/codebase/compiler/src/typechecker/checker.rs
@@ -603,6 +603,52 @@ impl TypeChecker {
                                 // Also register unqualified for internal use
                                 self.env.define_fn(fn_def.name.clone(), sig);
                             }
+                            ItemKind::ExternFn(decl) => {
+                                // Issue #261: register `extern fn` declarations
+                                // inside `mod` blocks so calls from the same (and
+                                // other) modules resolve. Mirrors the top-level
+                                // `ExternFn` registration at ~line 243 plus the
+                                // qualified+unqualified pattern used by `FnDef`
+                                // above. Capability-ceiling validation also runs
+                                // here so a mod-block extern can't escape its
+                                // module's `@cap` ceiling.
+                                //
+                                // Critical: do NOT override an existing
+                                // registration. The same `bootstrap_*` extern is
+                                // often pre-registered in `TypeEnv::new()` with
+                                // explicit effects: vec![] (no effects); a
+                                // mod-block re-declaration without explicit
+                                // effects defaults to the conservative
+                                // EXTERN_DEFAULT_EFFECTS set, which would break
+                                // pure callers. Preserve the existing entry.
+                                if let Some(ref caps) = self.module_capabilities {
+                                    for eff in self.extern_decl_effects(decl) {
+                                        if !caps.contains(&eff) {
+                                            self.errors.push(
+                                                TypeError::new(
+                                                    format!(
+                                                        "extern function `{}` declares effect `{}` which exceeds the module capability ceiling",
+                                                        decl.name, eff
+                                                    ),
+                                                    mod_item.span,
+                                                )
+                                                .with_note(format!(
+                                                    "module @cap allows: {}",
+                                                    caps.join(", ")
+                                                )),
+                                            );
+                                        }
+                                    }
+                                }
+                                let sig = self.extern_fn_to_sig(decl);
+                                let qualified_name = format!("{}::{}", mod_name, decl.name);
+                                if self.env.lookup_fn(&qualified_name).is_none() {
+                                    self.env.define_fn(qualified_name, sig.clone());
+                                }
+                                if self.env.lookup_fn(&decl.name).is_none() {
+                                    self.env.define_fn(decl.name.clone(), sig);
+                                }
+                            }
                             _ => {}
                         }
                     }

--- a/codebase/compiler/tests/modblock_extern_resolution.rs
+++ b/codebase/compiler/tests/modblock_extern_resolution.rs
@@ -1,0 +1,139 @@
+//! Integration gate for #261: ExternFn declarations inside `mod` blocks
+//! must be registered by the typechecker's `ModBlock` first-pass.
+//!
+//! Companion to #259's `TypeEnv::new()` registration: where #259 wires
+//! known kernel surfaces in unconditionally, this gate verifies that
+//! arbitrary `.gr` modules can declare their own externs locally and
+//! the typechecker resolves calls to them within the same `mod` block.
+//!
+//! Pre-#261 symptom: AST parses cleanly (`ItemKind::ExternFn` lands
+//! inside the `ModBlock`), but the typechecker reports
+//! `undefined variable my_extern` at every call site because the
+//! `ModBlock` first-pass only handles `TypeDecl`/`EnumDecl`/`FnDef`.
+
+use gradient_compiler::lexer::Lexer;
+use gradient_compiler::parser;
+use gradient_compiler::typechecker;
+
+fn typecheck_errors(src: &str) -> Vec<String> {
+    let mut lex = Lexer::new(src, 0);
+    let tokens = lex.tokenize();
+    let (module, parse_errors) = parser::parse(tokens, 0);
+    assert!(parse_errors.is_empty(), "parse errors: {:?}", parse_errors);
+    let type_errors = typechecker::check_module(&module, 0);
+    type_errors
+        .into_iter()
+        .filter(|e| !e.is_warning)
+        .map(|e| e.message)
+        .collect()
+}
+
+/// Returns true if the error list mentions any `undefined variable` /
+/// `unknown function` style failure for `name`. Used so the test gates
+/// only on the actual ModBlock-resolution bug, not on unrelated
+/// effect-system errors which can vary based on extern defaults.
+fn unresolved(errors: &[String], name: &str) -> bool {
+    errors.iter().any(|e| {
+        e.contains(&format!("undefined variable `{}`", name))
+            || e.contains(&format!("unknown function `{}`", name))
+    })
+}
+
+/// Minimal repro from `references/gradient-modblock-externfn-resolution.md`.
+/// Pre-#261 this fails with `undefined variable my_extern`; post-#261 it
+/// must resolve (effect-related errors do not count — they reflect a
+/// separate concern around extern default-effects).
+#[test]
+fn extern_in_mod_block_resolves_within_module() {
+    let src = "\
+mod scratch:
+
+    fn my_extern(x: Int) -> Int
+
+    fn caller(x: Int) -> Int:
+        ret my_extern(x)
+";
+    let errors = typecheck_errors(src);
+    assert!(
+        !unresolved(&errors, "my_extern"),
+        "expected `my_extern` to resolve after #261, got: {:#?}",
+        errors
+    );
+}
+
+/// Multiple externs of different return types should all resolve.
+#[test]
+fn multiple_externs_in_mod_block_resolve() {
+    let src = "\
+mod multi:
+
+    fn ext_int(x: Int) -> Int
+    fn ext_str(s: String) -> String
+    fn ext_bool(b: Int) -> Int
+
+    fn caller(x: Int) -> Int:
+        let a = ext_int(x)
+        let s = ext_str(\"hi\")
+        let b = ext_bool(1)
+        ret a + b
+";
+    let errors = typecheck_errors(src);
+    for name in ["ext_int", "ext_str", "ext_bool"] {
+        assert!(
+            !unresolved(&errors, name),
+            "expected `{}` to resolve, got: {:#?}",
+            name,
+            errors
+        );
+    }
+}
+
+/// Sanity: top-level externs (which were always registered) still
+/// resolve after the ModBlock first-pass change. Effect errors are
+/// expected (extern defaults to all effects); we only assert resolution.
+#[test]
+fn top_level_extern_still_resolves() {
+    let src = "\
+fn top_ext(x: Int) -> Int
+
+fn caller(x: Int) -> Int:
+    ret top_ext(x)
+";
+    let errors = typecheck_errors(src);
+    assert!(
+        !unresolved(&errors, "top_ext"),
+        "top-level extern should resolve, got: {:#?}",
+        errors
+    );
+}
+
+/// A `mod` block with both a `FnDef` and an `ExternFn`: both kinds of
+/// declaration must coexist. Pre-#261 the `FnDef` resolved but the
+/// `ExternFn` did not.
+#[test]
+fn mod_block_mixes_fn_def_and_extern_fn() {
+    let src = "\
+mod mixed:
+
+    fn helper_extern(x: Int) -> Int
+
+    fn helper(x: Int) -> Int:
+        ret x + 1
+
+    fn caller(x: Int) -> Int:
+        let a = helper(x)
+        let b = helper_extern(x)
+        ret a + b
+";
+    let errors = typecheck_errors(src);
+    assert!(
+        !unresolved(&errors, "helper"),
+        "regular fn should still resolve: {:#?}",
+        errors
+    );
+    assert!(
+        !unresolved(&errors, "helper_extern"),
+        "extern in mod block should resolve after #261: {:#?}",
+        errors
+    );
+}


### PR DESCRIPTION
## Summary

Extends the typechecker's `ModBlock` first-pass at `codebase/compiler/src/typechecker/checker.rs:472` to register `ItemKind::ExternFn` declarations, mirroring the top-level handling at `~line 243` plus the qualified+unqualified registration pattern used for `FnDef`.

Pre-#261, declaring `extern fn` inside a `mod` block silently dropped the binding: the AST contained `ItemKind::ExternFn`, but the typechecker only handled `TypeDecl`/`EnumDecl`/`FnDef` in the ModBlock first pass. Calls inside the same module hit "undefined variable".

This is the proper fix #3 from `references/gradient-modblock-externfn-resolution.md` and Pitfall #20 in the `gradient-project-development` skill.

## Why "if-not-already-registered" matters

The fix only registers if no entry exists. The same `bootstrap_*` extern is often pre-registered in `TypeEnv::new()` (see #259 / #260) with explicit `effects: vec![]` (no effects). A mod-block redeclaration without explicit `!{...}` effects defaults to `EXTERN_DEFAULT_EFFECTS = [IO, Net, FS, Mut, Time]`. Overwriting the entry would break pure callers in `self_hosting_smoke`.

## Together with #259/#260

This completes the `ModBlock`-ExternFn unblocker:

| | Pre-#259 | Post-#259 | Post-#261 |
|---|---|---|---|
| Bootstrap kernel externs visible to `.gr` | no | yes (registered in `TypeEnv::new()`) | yes |
| Arbitrary mod-block externs resolve | no | no | yes |
| Self-hosted modules can declare AND call kernel externs locally | no | half | yes |

Self-hosted `.gr` modules can now both declare and call kernel externs locally, opening the path to flipping `query.gr` / `lsp.gr` / `compiler.gr` / `main.gr` / `codegen.gr` stubs to delegating bodies.

## Capability ceiling

Capability-ceiling validation runs alongside registration so a mod-block extern cannot escape its module's `@cap` ceiling. Same logic as the top-level pass.

## Tests

New CI gate `tests/modblock_extern_resolution.rs` (4 tests):

- `extern_in_mod_block_resolves_within_module` — minimal repro from the skill reference.
- `multiple_externs_in_mod_block_resolve` — different return types, all resolve.
- `top_level_extern_still_resolves` — sanity that the existing top-level path is untouched.
- `mod_block_mixes_fn_def_and_extern_fn` — both kinds coexist in the same `mod`.

The test predicate (`unresolved`) deliberately checks for "undefined variable" / "unknown function" only, since extern-default-effects errors are a separate concern that should not gate this PR.

## Verification

- `cargo test -p gradient-compiler --test modblock_extern_resolution` — 4/4 passed
- `cargo test -p gradient-compiler --test self_hosting_smoke` — 15/15 passed (including the previously-failing concatenated typecheck-clean tests)
- `cargo test --workspace` — green
- `cargo clippy --workspace -- -D warnings` — clean

Fixes #261
