### PR TITLE
feat(self-hosting): flip codegen.gr emit_module to delegate to bootstrap_ir_emit_text (#263)

### DIFF
--- a/codebase/compiler/src/kernel_boundary.rs
+++ b/codebase/compiler/src/kernel_boundary.rs
@@ -49,7 +49,6 @@ pub enum PhaseOwnership {
     /// Self-hosted code is the production path; Rust has either
     /// been removed or kept only as a fallback. This is the
     /// 95%+ target state.
-    #[allow(dead_code)]
     SelfHostedDefault,
 }
 
@@ -122,9 +121,9 @@ pub const KERNEL_BOUNDARY: &[PhaseRow] = &[
         phase: "emit",
         gr_module: "compiler/codegen.gr",
         rust_kernel: "bootstrap_ir_emit.rs",
-        ownership: PhaseOwnership::SelfHostedGated,
+        ownership: PhaseOwnership::SelfHostedDefault,
         kernel_extern_count: 1,
-        gates: &["self_hosted_codegen_text"],
+        gates: &["self_hosted_codegen_text", "self_hosting_smoke"],
     },
     PhaseRow {
         phase: "pipeline",

--- a/codebase/compiler/tests/self_hosting_smoke.rs
+++ b/codebase/compiler/tests/self_hosting_smoke.rs
@@ -619,6 +619,11 @@ fn codegen_gr_concatenated_exposes_expected_symbols() {
         "set_current_block",
         "is_terminator",
         "has_result",
+        // #263: emit_module is the first delegating self-hosted body in
+        // codegen.gr — it must remain present and discoverable as a
+        // top-level symbol after concatenation. Locking it here keeps
+        // the SelfHostedDefault classification on the `emit` row honest.
+        "emit_module",
     ];
 
     for sym in expected {

--- a/compiler/codegen.gr
+++ b/compiler/codegen.gr
@@ -378,6 +378,26 @@ mod codegen:
     // Code Generation
     // =========================================================================
 
+    /// Kernel extern: walk the runtime IR store for `mod_id` and produce
+    /// canonical textual IR. Implemented in `bootstrap_ir_emit.rs`. Pure:
+    /// reads the process-wide IR store, returns a String. The .gr-side
+    /// `emit_module` delegates to this directly.
+    fn bootstrap_ir_emit_text(mod_id: Int) -> String
+
+    /// Emit canonical textual IR for the given runtime IR module id.
+    ///
+    /// Delegates to the Rust kernel `bootstrap_ir_emit_text`. The kernel
+    /// walks the runtime IR store (allocated upstream by `lower_module`
+    /// in `compiler/ir_builder.gr`) and produces a stable, target-
+    /// independent textual form. Returns an empty string for `mod_id == 0`.
+    ///
+    /// This is the first self-hosted codegen entry point that produces
+    /// real output end-to-end; flipping this row in the kernel boundary
+    /// catalog to SelfHostedDefault marks the emit phase as production
+    /// self-hosted.
+    fn emit_module(mod_id: Int) -> String:
+        ret bootstrap_ir_emit_text(mod_id)
+
     /// Create a code generator for a target
     fn new_code_generator(target: String, module: IrModule) -> CodeGenerator:
         ret CodeGenerator { target: target, module: module }

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -55,7 +55,7 @@ The full Rust kernel boundary is enumerated programmatically in
 | parse | `compiler/parser.gr` | `bootstrap_parser_bridge.rs + bootstrap_ast_bridge.rs` | Hybrid | `parser_differential_tests`, `parser_boundary_tests`, `self_hosted_parser_token_access`, `self_hosted_parser_ast_storage` |
 | check | `compiler/checker.gr` | `bootstrap_checker_env.rs` | Hybrid | `self_hosted_checker_env` |
 | lower | `compiler/ir_builder.gr` | `bootstrap_ir_bridge.rs` | Hybrid | `ir_differential_tests`, `self_hosted_ir_builder` |
-| emit | `compiler/codegen.gr` | `bootstrap_ir_emit.rs` | SelfHostedGated | `self_hosted_codegen_text` |
+| emit | `compiler/codegen.gr` | `bootstrap_ir_emit.rs` | SelfHostedDefault | `self_hosted_codegen_text`, `self_hosting_smoke` |
 | pipeline | `compiler/compiler.gr` | `bootstrap_pipeline.rs` | SelfHostedGated | `self_hosted_pipeline` |
 | driver | `compiler/main.gr` | `bootstrap_driver.rs` | SelfHostedGated | `self_hosted_driver` |
 | query | `compiler/query.gr` | `bootstrap_query.rs` | SelfHostedGated | `self_hosted_query` |


### PR DESCRIPTION
## Summary

First self-hosted `.gr`-side body to delegate to a Rust kernel extern after the ModBlock-ExternFn unblocker (#260/#262). `compiler/codegen.gr::emit_module` declares `bootstrap_ir_emit_text(mod_id: Int) -> String` inside its `mod` block and returns the kernel result directly.

Flips the `emit` row in the kernel-boundary catalog from `SelfHostedGated` to `SelfHostedDefault` — the first row at the 95%+ target ownership level.

## Changes

- `compiler/codegen.gr`
  - declare `bootstrap_ir_emit_text(mod_id: Int) -> String` inside `mod codegen` (resolves locally via the #261 ModBlock first-pass; the env.rs effect-free signature is preserved by the if-not-already-registered guard from #261)
  - add `emit_module(mod_id: Int) -> String` body that returns `bootstrap_ir_emit_text(mod_id)`
- `codebase/compiler/src/kernel_boundary.rs`
  - `emit` row ownership → `SelfHostedDefault`
  - gates list extended with `self_hosting_smoke`
  - removed `#[allow(dead_code)]` from `SelfHostedDefault` (live row now)
- `codebase/compiler/tests/self_hosting_smoke.rs`
  - lock `emit_module` as expected concatenated symbol so the smoke gate keeps the SelfHostedDefault classification honest
- `docs/SELF_HOSTING.md`
  - update boundary table row for `emit` to match the catalog

## Why this is the right next step

Per the post-#262 plan: smallest possible flip, single kernel extern, no state, pure `Int -> String`. Proves the unblocker works end-to-end for a real `.gr`-side delegation. Driver / pipeline / query / LSP flips can follow in dedicated PRs.

## Verification

```
cargo test --workspace                                                       green
cargo clippy --workspace -- -D warnings                                      clean
cargo test -p gradient-compiler --test self_hosting_smoke                    15 passed (incl. emit_module symbol assertion)
cargo test -p gradient-compiler --test kernel_boundary_metrics               6 passed (progress ≥ 50% holds)
cargo test -p gradient-compiler --test self_hosted_codegen_text              3 passed + 1 ignored regen
cargo test -p gradient-compiler --test bootstrap_extern_registration         7 passed
cargo test -p gradient-compiler --test modblock_extern_resolution            4 passed
```

## Related Issues

Fixes #263
