### PR TITLE
test(self-hosting): expand bootstrap trust corpus with comparison/unary/nested-let fixtures (#265)

### DIFF
--- a/codebase/compiler/tests/bootstrap_trust_checks.rs
+++ b/codebase/compiler/tests/bootstrap_trust_checks.rs
@@ -345,6 +345,30 @@ fn trust_boolean_logic() {
 }
 
 #[test]
+fn trust_comparisons() {
+    let _g = lock();
+    reset_all();
+    let src = fixture("06_comparisons.gr");
+    assert_full_compile_trust("06_comparisons.gr", &src, &["fn lt", "fn ge", "fn eq"]);
+}
+
+#[test]
+fn trust_unary_ops() {
+    let _g = lock();
+    reset_all();
+    let src = fixture("07_unary_ops.gr");
+    assert_full_compile_trust("07_unary_ops.gr", &src, &["fn negate", "fn invert"]);
+}
+
+#[test]
+fn trust_nested_let() {
+    let _g = lock();
+    reset_all();
+    let src = fixture("08_nested_let.gr");
+    assert_full_compile_trust("08_nested_let.gr", &src, &["fn polynomial", "ret"]);
+}
+
+#[test]
 fn trust_parse_error_caught() {
     let _g = lock();
     reset_all();
@@ -374,6 +398,9 @@ fn trust_phase_coverage_report() {
         "03_let_bindings.gr",
         "04_function_calls.gr",
         "05_boolean_logic.gr",
+        "06_comparisons.gr",
+        "07_unary_ops.gr",
+        "08_nested_let.gr",
     ];
 
     for name in &happy_path_fixtures {

--- a/codebase/compiler/tests/bootstrap_trust_corpus/06_comparisons.gr
+++ b/codebase/compiler/tests/bootstrap_trust_corpus/06_comparisons.gr
@@ -1,0 +1,8 @@
+fn lt(x: Int, y: Int) -> Bool:
+    ret x < y
+
+fn ge(x: Int, y: Int) -> Bool:
+    ret x >= y
+
+fn eq(x: Int, y: Int) -> Bool:
+    ret x == y

--- a/codebase/compiler/tests/bootstrap_trust_corpus/07_unary_ops.gr
+++ b/codebase/compiler/tests/bootstrap_trust_corpus/07_unary_ops.gr
@@ -1,0 +1,5 @@
+fn negate(x: Int) -> Int:
+    ret -x
+
+fn invert(b: Bool) -> Bool:
+    ret not b

--- a/codebase/compiler/tests/bootstrap_trust_corpus/08_nested_let.gr
+++ b/codebase/compiler/tests/bootstrap_trust_corpus/08_nested_let.gr
@@ -1,0 +1,6 @@
+fn polynomial(x: Int) -> Int:
+    let a = x + 1
+    let b = a * x
+    let c = b - x
+    let d = c + a
+    ret d


### PR DESCRIPTION
## Summary

Expand the bootstrap trust corpus from 5 happy-path + 2 sad-path fixtures to 8 happy-path + 2 sad-path. The new fixtures exercise patterns the bootstrap pipeline already supports end-to-end (per the IR differential corpus) but the trust gate did not previously lock at the higher bar (driver OK exit + non-empty captured output + query agreement + IR text containing expected `fn` names).

## Why this is the right next step

Per the post-#262 strategic plan in the handoff doc, option (4) is "trust corpus expansion: add fixtures exercising patterns the bootstrap pipeline supports but the current trust corpus doesn't (e.g. nested let bindings, mutual recursion, more comparison operators)." This PR delivers three of those.

## Changes

- `codebase/compiler/tests/bootstrap_trust_corpus/06_comparisons.gr` (new) — `lt`, `ge`, `eq` returning Bool via `<`, `>=`, `==`.
- `codebase/compiler/tests/bootstrap_trust_corpus/07_unary_ops.gr` (new) — `negate(-x)`, `invert(not b)`.
- `codebase/compiler/tests/bootstrap_trust_corpus/08_nested_let.gr` (new) — 4-step let chain with mixed `+ - *`.
- `codebase/compiler/tests/bootstrap_trust_checks.rs`
  - new tests: `trust_comparisons`, `trust_unary_ops`, `trust_nested_let`.
  - extended `trust_phase_coverage_report` happy-path list to include the three new fixtures.

## Verification

```
cargo test -p gradient-compiler --test bootstrap_trust_checks    12 passed (was 9)
cargo test --workspace                                           green
cargo clippy --workspace -- -D warnings                          clean
```

## Related Issues

Fixes #265
