### PR TITLE
feat(self-hosting): flip query.gr public entry points to delegate via bootstrap_query_* (#269)

### DIFF
--- a/codebase/compiler/src/kernel_boundary.rs
+++ b/codebase/compiler/src/kernel_boundary.rs
@@ -145,9 +145,9 @@ pub const KERNEL_BOUNDARY: &[PhaseRow] = &[
         phase: "query",
         gr_module: "compiler/query.gr",
         rust_kernel: "bootstrap_query.rs",
-        ownership: PhaseOwnership::SelfHostedGated,
+        ownership: PhaseOwnership::SelfHostedDefault,
         kernel_extern_count: 27,
-        gates: &["self_hosted_query"],
+        gates: &["self_hosted_query", "self_hosting_smoke"],
     },
     PhaseRow {
         phase: "lsp",

--- a/codebase/compiler/tests/self_hosting_smoke.rs
+++ b/codebase/compiler/tests/self_hosting_smoke.rs
@@ -691,3 +691,55 @@ fn compiler_gr_exposes_pipeline_entry_points() {
         );
     }
 }
+
+/// `compiler/query.gr` is self-contained inside `mod query:` (it
+/// re-declares its own `Severity`, `Phase`, `SymbolKind`, and `Session`
+/// types so it can be type-checked alone). Per #269, the public query
+/// entry points (`new_session`, `check`, `has_errors`, `error_count`)
+/// now delegate to the `bootstrap_query_*` kernel surface; locking the
+/// standalone clean-typecheck + symbol presence here keeps the
+/// SelfHostedDefault classification on the `query` row honest.
+#[test]
+fn query_gr_standalone_parses_and_typechecks_clean() {
+    let path = compiler_path("query.gr");
+    let session = Session::from_file(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
+    let result = session.check();
+    assert!(
+        result.ok && result.error_count == 0,
+        "query.gr should type-check cleanly:\n{}",
+        render_errors(&session),
+    );
+}
+
+/// Lock the public query entry points as expected top-level symbols of
+/// `compiler/query.gr`. After #269 these all delegate to
+/// `bootstrap_query_*`; if a future refactor renames or removes one of
+/// them the SelfHostedDefault `query` row in `kernel_boundary.rs`
+/// would silently drift.
+#[test]
+fn query_gr_standalone_exposes_session_entry_points() {
+    let path = compiler_path("query.gr");
+    let session = Session::from_file(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
+
+    let names: Vec<String> = session.symbols().into_iter().map(|s| s.name).collect();
+
+    let expected = [
+        // #269: these now delegate to bootstrap_query_* kernel externs.
+        "new_session",
+        "new_session_from_file",
+        "check",
+        "has_errors",
+        "error_count",
+    ];
+
+    for sym in expected {
+        assert!(
+            names.iter().any(|n| n == sym),
+            "expected query.gr to export `{}`, but symbols() returned: {:?}",
+            sym,
+            names,
+        );
+    }
+}

--- a/compiler/query.gr
+++ b/compiler/query.gr
@@ -176,46 +176,91 @@ mod query:
     // Session Management
     // =========================================================================
 
+    // -------------------------------------------------------------------------
+    // Bootstrap query kernel externs (#232)
+    //
+    // The Rust kernel `bootstrap_query.rs` exposes 27 free functions backed
+    // by a process-wide session table keyed by integer id. Each extern is
+    // pre-registered as effect-free in `codebase/compiler/src/typechecker/
+    // env.rs` (#259). The bodyless `fn` lines below redeclare the slice of
+    // that surface this module needs so the public query entry points can
+    // delegate locally — same pattern proven by codegen.gr (#263) and
+    // compiler.gr (#267).
+    // -------------------------------------------------------------------------
+
+    /// Allocate a real query session for `source`, run lex/parse/check
+    /// eagerly inside the kernel, and return the session id.
+    fn bootstrap_query_new_session(source: String) -> Int
+
+    /// Number of recorded parse errors for `session_id`.
+    fn bootstrap_query_parse_error_count(session_id: Int) -> Int
+
+    /// Number of recorded type errors for `session_id`.
+    fn bootstrap_query_type_error_count(session_id: Int) -> Int
+
+    /// 1 if the session's typechecker ran (regardless of error count), 0 if
+    /// it short-circuited (e.g. earlier parse failure).
+    fn bootstrap_query_is_type_checked(session_id: Int) -> Int
+
+    /// 1 if the session's check ran without error, 0 otherwise.
+    fn bootstrap_query_check_ok(session_id: Int) -> Int
+
+    /// Total error count across all phases for `session_id`.
+    fn bootstrap_query_error_count(session_id: Int) -> Int
+
+    /// Diagnostic count for `session_id`.
+    fn bootstrap_query_diagnostic_count(session_id: Int) -> Int
+
     /// Create a new query engine
     fn new_query_engine() -> QueryEngine:
         ret QueryEngine { sessions: 0, next_id: 1 }
 
-    /// Create a new compilation session from source code
-    /// Runs lexer, parser, and type checker eagerly
+    /// Create a new compilation session from source code.
+    ///
+    /// Delegates to `bootstrap_query_new_session`, which runs lex/parse/
+    /// check eagerly inside the kernel and returns a session id. The id
+    /// is stored in the `Session.tokens` slot (re-purposed as the kernel
+    /// handle — same session-id-as-handle pattern documented in #230).
+    /// Subsequent queries (`check`, `has_errors`, `error_count`) read
+    /// counters back through that handle.
     fn new_session(source: String) -> Session:
-        // In full implementation:
-        // 1. Run lexer to get tokens
-        // 2. Run parser to get AST
-        // 3. Run type checker
-        // For now, return empty session
+        let session_id = bootstrap_query_new_session(source)
+        let parse_errs = bootstrap_query_parse_error_count(session_id)
+        let type_errs = bootstrap_query_type_error_count(session_id)
+        let checked = bootstrap_query_is_type_checked(session_id) > 0
         ret Session {
             source: source,
-            tokens: 0,
+            tokens: session_id,
             ast: 0,
-            parse_errors: 0,
-            type_errors: 0,
-            type_checked: false
+            parse_errors: parse_errs,
+            type_errors: type_errs,
+            type_checked: checked
         }
 
-    /// Create session from a file
+    /// Create session from a file.
+    /// (No FS-effect extern is declared at this layer yet, so the file
+    /// read happens upstream via the existing kernel surfaces; for now
+    /// fall back to an empty source.)
     fn new_session_from_file(path: String) -> Session:
-        // In full implementation, would read file content
         ret new_session("")
 
     // =========================================================================
     // Core Queries
     // =========================================================================
 
-    /// Check the source and return structured diagnostics
+    /// Check the source and return structured diagnostics.
+    ///
+    /// Delegates to the kernel `bootstrap_query_check_ok` / `_error_count`
+    /// / `_diagnostic_count` over the cached session id stored in
+    /// `session.tokens`.
     fn check(session: Session) -> CheckResult:
-        // In full implementation:
-        // 1. Collect parse errors
-        // 2. Collect type errors
-        // 3. Build diagnostic list
+        let ok = bootstrap_query_check_ok(session.tokens) > 0
+        let errors = bootstrap_query_error_count(session.tokens)
+        let diags = bootstrap_query_diagnostic_count(session.tokens)
         ret CheckResult {
-            ok: true,
-            error_count: 0,
-            diagnostics: 0
+            ok: ok,
+            error_count: errors,
+            diagnostics: diags
         }
 
     /// Return all top-level symbols defined in the source
@@ -304,10 +349,13 @@ mod query:
             ImplSymbol:
                 ret "impl"
 
-    /// Check if session has errors
+    /// Check if session has errors.
+    /// Delegates to `bootstrap_query_error_count` so the answer reflects
+    /// the live kernel diagnostic state, not the stale snapshot fields.
     fn has_errors(session: Session) -> Bool:
-        ret session.parse_errors > 0 or session.type_errors > 0
+        ret bootstrap_query_error_count(session.tokens) > 0
 
-    /// Get error count from session
+    /// Get error count from session.
+    /// Delegates to `bootstrap_query_error_count`.
     fn error_count(session: Session) -> Int:
-        ret session.parse_errors + session.type_errors
+        ret bootstrap_query_error_count(session.tokens)

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -58,7 +58,7 @@ The full Rust kernel boundary is enumerated programmatically in
 | emit | `compiler/codegen.gr` | `bootstrap_ir_emit.rs` | SelfHostedDefault | `self_hosted_codegen_text`, `self_hosting_smoke` |
 | pipeline | `compiler/compiler.gr` | `bootstrap_pipeline.rs` | SelfHostedDefault | `self_hosted_pipeline`, `self_hosting_smoke` |
 | driver | `compiler/main.gr` | `bootstrap_driver.rs` | SelfHostedGated | `self_hosted_driver` |
-| query | `compiler/query.gr` | `bootstrap_query.rs` | SelfHostedGated | `self_hosted_query` |
+| query | `compiler/query.gr` | `bootstrap_query.rs` | SelfHostedDefault | `self_hosted_query`, `self_hosting_smoke` |
 | lsp | `compiler/lsp.gr` | `bootstrap_lsp.rs` | SelfHostedGated | `self_hosted_lsp` |
 | trust | (meta — exercises every phase) | (no new kernel) | SelfHostedGated | `bootstrap_trust_checks` |
 


### PR DESCRIPTION
## Summary

Flip the public entry points of `compiler/query.gr` (`new_session`, `check`, `has_errors`, `error_count`) to delegate end-to-end through the `bootstrap_query_*` kernel surface. Third delegating self-hosted module after codegen (#263/#264) and pipeline (#267/#268).

## Changes

- `compiler/query.gr`:
  - Declare 7 `bootstrap_query_*` externs inside `mod query:` as bodyless `fn` lines.
  - `new_session(source)` allocates a real kernel session via `bootstrap_query_new_session`, stores id in `Session.tokens` (re-purposed as kernel handle — session-id-as-handle pattern from #230), populates parse/type counters from kernel queries.
  - `check(session)` chains `bootstrap_query_check_ok` / `_error_count` / `_diagnostic_count`.
  - `has_errors` / `error_count` delegate to `bootstrap_query_error_count` for live diagnostic reads.

- `codebase/compiler/src/kernel_boundary.rs`: query row → `SelfHostedDefault`, gates list adds `self_hosting_smoke`.

- `docs/SELF_HOSTING.md`: query boundary table row updated.

- `codebase/compiler/tests/self_hosting_smoke.rs`: standalone parses-and-typechecks test + symbol-presence lock for query.gr (mirrors the compiler.gr pattern from #267).

## Why

The unblocker (#259/#260/#261/#262) plus the proven mod-block extern declaration syntax (#263) make this flip a one-line surface declaration per extern. `bootstrap_query.rs` was always production-ready (#232/#255 landed it with the integration gate); this PR finally has the .gr-side actually call it.

## Verification

```
cargo test -p gradient-compiler --test self_hosting_smoke   19 passed (was 17)
cargo test -p gradient-compiler --test self_hosted_query    11 passed
cargo test -p gradient-compiler --test kernel_boundary_metrics 6 passed
cargo test -p gradient-compiler --test bootstrap_trust_checks 12 passed
cargo test --workspace                                      green
cargo clippy --workspace -- -D warnings                     clean
```

Boundary catalog now has 3 rows at `SelfHostedDefault` (emit, pipeline, query), 6 at `SelfHostedGated`, 4 at `Hybrid`.

## Out of scope

- LSP body flip (separate follow-on PR).
- Full delegation of `get_symbols` / `type_at` / `symbol_at` (need richer return-handle plumbing).

Fixes #269
