### PR TITLE
feat(self-hosting): flip lsp.gr bootstrap and predicates to delegate via bootstrap_lsp_* (#271)

### DIFF
--- a/codebase/compiler/src/kernel_boundary.rs
+++ b/codebase/compiler/src/kernel_boundary.rs
@@ -153,9 +153,9 @@ pub const KERNEL_BOUNDARY: &[PhaseRow] = &[
         phase: "lsp",
         gr_module: "compiler/lsp.gr",
         rust_kernel: "bootstrap_lsp.rs",
-        ownership: PhaseOwnership::SelfHostedGated,
+        ownership: PhaseOwnership::SelfHostedDefault,
         kernel_extern_count: 28,
-        gates: &["self_hosted_lsp"],
+        gates: &["self_hosted_lsp", "self_hosting_smoke"],
     },
     PhaseRow {
         phase: "trust",

--- a/codebase/compiler/tests/self_hosting_smoke.rs
+++ b/codebase/compiler/tests/self_hosting_smoke.rs
@@ -743,3 +743,48 @@ fn query_gr_standalone_exposes_session_entry_points() {
         );
     }
 }
+
+/// `compiler/lsp.gr` is self-contained inside `mod lsp:`. Per #271 the
+/// LSP server bootstrap and `is_builtin` / `is_keyword` predicates now
+/// delegate to `bootstrap_lsp_*` kernel externs; locking the standalone
+/// clean-typecheck + symbol presence here keeps the SelfHostedDefault
+/// classification on the `lsp` row honest.
+#[test]
+fn lsp_gr_standalone_parses_and_typechecks_clean() {
+    let path = compiler_path("lsp.gr");
+    let session = Session::from_file(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
+    let result = session.check();
+    assert!(
+        result.ok && result.error_count == 0,
+        "lsp.gr should type-check cleanly:\n{}",
+        render_errors(&session),
+    );
+}
+
+/// Lock the LSP entry points that now delegate to `bootstrap_lsp_*` as
+/// expected top-level symbols of `compiler/lsp.gr`.
+#[test]
+fn lsp_gr_standalone_exposes_server_entry_points() {
+    let path = compiler_path("lsp.gr");
+    let session = Session::from_file(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
+
+    let names: Vec<String> = session.symbols().into_iter().map(|s| s.name).collect();
+
+    let expected = [
+        // #271: these now delegate to bootstrap_lsp_* kernel externs.
+        "new_lsp_server",
+        "is_builtin",
+        "is_keyword",
+    ];
+
+    for sym in expected {
+        assert!(
+            names.iter().any(|n| n == sym),
+            "expected lsp.gr to export `{}`, but symbols() returned: {:?}",
+            sym,
+            names,
+        );
+    }
+}

--- a/compiler/lsp.gr
+++ b/compiler/lsp.gr
@@ -276,10 +276,45 @@ mod lsp:
     // LSP Server Functions
     // =========================================================================
 
-    /// Create a new LSP server instance
+    // -------------------------------------------------------------------------
+    // Bootstrap LSP kernel externs (#233)
+    //
+    // The Rust kernel `bootstrap_lsp.rs` exposes 28 free functions backed
+    // by a per-server document store keyed by integer id. Each extern is
+    // pre-registered as effect-free in `codebase/compiler/src/typechecker/
+    // env.rs` (#259). The bodyless `fn` lines below redeclare the slice of
+    // that surface this module needs so the public LSP entry points can
+    // delegate locally — same pattern proven by codegen.gr (#263),
+    // compiler.gr (#267), and query.gr (#269).
+    // -------------------------------------------------------------------------
+
+    /// Allocate a real LSP server in the kernel and return its id. The id
+    /// is stored in `LspServer.documents` (re-purposed as the kernel
+    /// handle — same session-id-as-handle pattern as #230).
+    fn bootstrap_lsp_new_server() -> Int
+
+    /// Mark the server `server_id` as initialized. Returns 1 on success.
+    fn bootstrap_lsp_initialize(server_id: Int) -> Int
+
+    /// 1 if the server has been initialized, 0 otherwise.
+    fn bootstrap_lsp_is_initialized(server_id: Int) -> Int
+
+    /// 1 if `word` is a Gradient keyword, 0 otherwise.
+    fn bootstrap_lsp_is_keyword(word: String) -> Int
+
+    /// 1 if `word` is a Gradient builtin, 0 otherwise.
+    fn bootstrap_lsp_is_builtin(word: String) -> Int
+
+    /// Create a new LSP server instance.
+    ///
+    /// Delegates to `bootstrap_lsp_new_server` for a real kernel-backed
+    /// server id; the id is stored in the `documents` field which is
+    /// re-purposed as the kernel handle (same pattern as #269 query.gr's
+    /// session.tokens).
     fn new_lsp_server() -> LspServer:
+        let server_id = bootstrap_lsp_new_server()
         ret LspServer {
-            documents: 0,
+            documents: server_id,
             client_capabilities: 0,
             initialized: false
         }
@@ -434,15 +469,15 @@ mod lsp:
         // Keywords: fn, let, if, else, for, in, ret, type, etc.
         ret 0
 
-    /// Check if word is a builtin
+    /// Check if word is a builtin.
+    /// Delegates to `bootstrap_lsp_is_builtin`.
     fn is_builtin(word: String) -> Bool:
-        // Check against builtin function list
-        ret false
+        ret bootstrap_lsp_is_builtin(word) > 0
 
-    /// Check if word is a keyword
+    /// Check if word is a keyword.
+    /// Delegates to `bootstrap_lsp_is_keyword`.
     fn is_keyword(word: String) -> Bool:
-        // Check against keyword list
-        ret false
+        ret bootstrap_lsp_is_keyword(word) > 0
 
     // =========================================================================
     // Utilities

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -59,7 +59,7 @@ The full Rust kernel boundary is enumerated programmatically in
 | pipeline | `compiler/compiler.gr` | `bootstrap_pipeline.rs` | SelfHostedDefault | `self_hosted_pipeline`, `self_hosting_smoke` |
 | driver | `compiler/main.gr` | `bootstrap_driver.rs` | SelfHostedGated | `self_hosted_driver` |
 | query | `compiler/query.gr` | `bootstrap_query.rs` | SelfHostedDefault | `self_hosted_query`, `self_hosting_smoke` |
-| lsp | `compiler/lsp.gr` | `bootstrap_lsp.rs` | SelfHostedGated | `self_hosted_lsp` |
+| lsp | `compiler/lsp.gr` | `bootstrap_lsp.rs` | SelfHostedDefault | `self_hosted_lsp`, `self_hosting_smoke` |
 | trust | (meta — exercises every phase) | (no new kernel) | SelfHostedGated | `bootstrap_trust_checks` |
 
 **Ownership classifications:**


### PR DESCRIPTION
## Summary

Flip `compiler/lsp.gr` LSP server bootstrap (`new_lsp_server`) and the `is_builtin` / `is_keyword` predicates to delegate via the `bootstrap_lsp_*` kernel surface. Fourth delegating self-hosted module.

## Changes

- `compiler/lsp.gr`:
  - Declare 5 `bootstrap_lsp_*` externs inside `mod lsp:` (`new_server`, `initialize`, `is_initialized`, `is_keyword`, `is_builtin`).
  - `new_lsp_server()` allocates real kernel server, stores id in `LspServer.documents`.
  - `is_builtin` / `is_keyword` chain through the kernel truth-table predicates.

- `codebase/compiler/src/kernel_boundary.rs`: lsp row → `SelfHostedDefault`, gates list adds `self_hosting_smoke`.

- `docs/SELF_HOSTING.md`: lsp boundary table row updated.

- `codebase/compiler/tests/self_hosting_smoke.rs`: standalone parses-and-typechecks test + symbol-presence lock for lsp.gr (mirrors the query.gr pattern from #269).

## Why

This completes the four-module flip arc started by #263 (codegen) — every kernel-backed self-hosted module (codegen, pipeline, query, lsp) now has a real `.gr`-side delegating body. Driver remains the only `SelfHostedGated` row, and `compiler/main.gr` needs a separate larger refactor to wrap in a `mod main:` block before its body can flip cleanly.

## Verification

```
cargo test -p gradient-compiler --test self_hosting_smoke   21 passed (was 19)
cargo test -p gradient-compiler --test self_hosted_lsp      13 passed
cargo test -p gradient-compiler --test kernel_boundary_metrics 6 passed
cargo test -p gradient-compiler --test bootstrap_trust_checks 12 passed
cargo test --workspace                                      green
cargo clippy --workspace -- -D warnings                     clean
```

Boundary catalog now has 4 rows at `SelfHostedDefault` (emit, pipeline, query, lsp), 5 at `SelfHostedGated`, 4 at `Hybrid`.

## Out of scope

- Full delegation of `did_open` / `did_change` / `hover` / `completion` / `document_symbol` (need richer return-handle plumbing).
- Cleanup of duplicate `is_builtin(name)` / `is_keyword(name)` definitions later in lsp.gr (separate refactor).
- main.gr driver flip (needs `mod main:` wrap first).

Fixes #271
