### PR TITLE
chore(lsp): remove duplicate predicate definitions in lsp.gr (#273)

### DIFF
--- a/compiler/lsp.gr
+++ b/compiler/lsp.gr
@@ -513,23 +513,3 @@ mod lsp:
     fn format_signature(name: String, params: Int, ret_type: String, effects: Int) -> String:
         // Format: fn name(params) -> ret_type !{effects}
         ret name
-
-    /// Get list of built-in functions
-    fn get_builtin_functions() -> Int:
-        // Returns Int as placeholder for Vec<String>
-        ret 0
-
-    /// Get list of keywords
-    fn get_keywords() -> Int:
-        // Returns Int as placeholder for Vec<String>
-        ret 0
-
-    /// Check if name is a built-in function
-    fn is_builtin(name: String) -> Bool:
-        // In full implementation: check against built-in list
-        ret false
-
-    /// Check if name is a keyword
-    fn is_keyword(name: String) -> Bool:
-        // In full implementation: check against keyword list
-        ret false


### PR DESCRIPTION
## Summary
Removes the four shadowed duplicate definitions at the bottom of `compiler/lsp.gr` (lines ~517-535):

- `get_builtin_functions()`
- `get_keywords()`
- `is_builtin(name)`
- `is_keyword(name)`

These were dead code from before #272 — the canonical versions at lines ~461-480 already delegate via `bootstrap_lsp_*` and are the ones picked up by symbol resolution.

## Why
Pre-cleanup before further LSP delegation work (`did_open` / `did_change` / etc.). Single canonical predicate set keeps the file honest.

## Validation
- `cargo test --workspace`: green
- `cargo clippy --workspace -- -D warnings`: clean
- `cargo test -p gradient-compiler --test self_hosting_smoke`: 21 passed (still locks the four symbols)

No kernel-boundary or env.rs changes.

Fixes #273