### PR TITLE
feat(self-hosting): flip lsp.gr did_change to delegate via bootstrap_lsp_did_change (#277)

### DIFF
--- a/codebase/compiler/tests/self_hosting_smoke.rs
+++ b/codebase/compiler/tests/self_hosting_smoke.rs
@@ -800,15 +800,12 @@ fn lsp_gr_standalone_exposes_lifecycle_handlers() {
     let names: Vec<String> = session.symbols().into_iter().map(|s| s.name).collect();
 
     let expected = [
-        // #275: these now delegate to bootstrap_lsp_* kernel externs.
+        // #275 / #277: these now delegate to bootstrap_lsp_* kernel externs.
         "initialize",
         "did_open",
+        "did_change",
         "did_close",
         "did_save",
-        // did_change still stubbed — its .gr signature uses `changes: Int`
-        // instead of `new_text: String`, so the kernel signature does not
-        // line up. Tracked as a follow-up signature-shape PR.
-        "did_change",
     ];
 
     for sym in expected {

--- a/compiler/lsp.gr
+++ b/compiler/lsp.gr
@@ -309,6 +309,10 @@ mod lsp:
     /// Per #275 lifecycle flip.
     fn bootstrap_lsp_did_open(server_id: Int, uri: String, language_id: String, version: Int, text: String) -> Int
 
+    /// Update an open text document on the kernel server. Returns 1 on
+    /// success. Per #277 lifecycle flip.
+    fn bootstrap_lsp_did_change(server_id: Int, uri: String, version: Int, new_text: String) -> Int
+
     /// Close a text document on the kernel server. Returns 1 on success.
     /// Per #275 lifecycle flip.
     fn bootstrap_lsp_did_close(server_id: Int, uri: String) -> Int
@@ -372,12 +376,12 @@ mod lsp:
             initialized: server.initialized
         }
 
-    /// Handle didChange notification
-    fn did_change(server: LspServer, uri: String, version: Int, changes: Int) -> LspServer:
-        // In full implementation:
-        // 1. Update document content
-        // 2. Re-run diagnostics
-        // 3. Publish updated diagnostics
+    /// Handle didChange notification.
+    ///
+    /// Delegates to `bootstrap_lsp_did_change` so the kernel updates the
+    /// document content and re-runs diagnostics. Per #277.
+    fn did_change(server: LspServer, uri: String, version: Int, new_text: String) -> LspServer:
+        let _ok = bootstrap_lsp_did_change(server.documents, uri, version, new_text)
         ret server
 
     /// Handle didClose notification.


### PR DESCRIPTION
## Summary
Completes the LSP lifecycle delegation surface from #272/#276 by flipping the last stubbed handler. Adjusts the .gr-side signature of `did_change` to take `new_text: String` instead of `changes: Int` so it lines up with the kernel signature, then delegates the body via `bootstrap_lsp_did_change(server.documents, uri, version, new_text)`.

Adds a bodyless extern declaration for `bootstrap_lsp_did_change` inside `mod lsp:`.

## Safety
`did_change` has no callers in any other .gr file (verified). The signature change is contained.

## Test
- Updates `self_hosting_smoke::lsp_gr_standalone_exposes_lifecycle_handlers` to drop the did_change caveat — it now passes alongside the other four handlers
- `cargo test -p gradient-compiler --test self_hosting_smoke`: 22 passed
- `cargo test --workspace`: green
- `cargo clippy --workspace -- -D warnings`: clean

## No catalog / env changes
- `kernel_boundary.rs` lsp row already `SelfHostedDefault` (#272)
- `env.rs` already registers `bootstrap_lsp_did_change` (#259)

After this PR every lifecycle handler in `mod lsp:` (initialize, did_open, did_change, did_close, did_save) delegates to its kernel counterpart.

Fixes #277