### PR TITLE
chore(kernel-boundary): sync kernel_extern_count for driver/query/lsp (#279)

### DIFF
--- a/codebase/compiler/src/kernel_boundary.rs
+++ b/codebase/compiler/src/kernel_boundary.rs
@@ -138,7 +138,7 @@ pub const KERNEL_BOUNDARY: &[PhaseRow] = &[
         gr_module: "compiler/main.gr",
         rust_kernel: "bootstrap_driver.rs",
         ownership: PhaseOwnership::SelfHostedGated,
-        kernel_extern_count: 7,
+        kernel_extern_count: 8,
         gates: &["self_hosted_driver"],
     },
     PhaseRow {
@@ -146,7 +146,7 @@ pub const KERNEL_BOUNDARY: &[PhaseRow] = &[
         gr_module: "compiler/query.gr",
         rust_kernel: "bootstrap_query.rs",
         ownership: PhaseOwnership::SelfHostedDefault,
-        kernel_extern_count: 27,
+        kernel_extern_count: 32,
         gates: &["self_hosted_query", "self_hosting_smoke"],
     },
     PhaseRow {
@@ -154,7 +154,7 @@ pub const KERNEL_BOUNDARY: &[PhaseRow] = &[
         gr_module: "compiler/lsp.gr",
         rust_kernel: "bootstrap_lsp.rs",
         ownership: PhaseOwnership::SelfHostedDefault,
-        kernel_extern_count: 28,
+        kernel_extern_count: 33,
         gates: &["self_hosted_lsp", "self_hosting_smoke"],
     },
     PhaseRow {


### PR DESCRIPTION
## Summary
Catalog counts in `KERNEL_BOUNDARY` had drifted from the actual kernel function counts:

| Phase | Before | After | Source |
|---|---|---|---|
| driver | 7 | **8** | `bootstrap_driver.rs` has 8 `pub fn bootstrap_driver_*` |
| query | 27 | **32** | `bootstrap_query.rs` has 32 `pub fn bootstrap_query_*` |
| lsp | 28 | **33** | `bootstrap_lsp.rs` has 33 `pub fn bootstrap_lsp_*` |

The handoff comment in `tests/bootstrap_extern_registration.rs` already cites driver=8, query=32, lsp=33 — this PR brings the canonical catalog into agreement.

The metrics gate's floor check (`>= 100` total externs) wasn't tripped, but the public catalog is now accurate.

## No structural changes
Only the integer counts move. Ownership classification, gate lists, and the row set are unchanged.

## Validation
- `cargo test -p gradient-compiler --lib kernel_boundary`: 5 passed
- `cargo test -p gradient-compiler --test kernel_boundary_metrics`: 6 passed
- `cargo test --workspace`: green
- `cargo clippy --workspace -- -D warnings`: clean

Fixes #279