### PR TITLE
test(bootstrap-trust): expand happy-path corpus with if/else and mutual recursion (#281)

### DIFF
--- a/codebase/compiler/tests/bootstrap_trust_checks.rs
+++ b/codebase/compiler/tests/bootstrap_trust_checks.rs
@@ -369,6 +369,22 @@ fn trust_nested_let() {
 }
 
 #[test]
+fn trust_if_else() {
+    let _g = lock();
+    reset_all();
+    let src = fixture("09_if_else.gr");
+    assert_full_compile_trust("09_if_else.gr", &src, &["fn abs_value", "fn signum"]);
+}
+
+#[test]
+fn trust_mutual_recursion() {
+    let _g = lock();
+    reset_all();
+    let src = fixture("10_mutual_recursion.gr");
+    assert_full_compile_trust("10_mutual_recursion.gr", &src, &["fn is_even", "fn is_odd"]);
+}
+
+#[test]
 fn trust_parse_error_caught() {
     let _g = lock();
     reset_all();
@@ -401,6 +417,8 @@ fn trust_phase_coverage_report() {
         "06_comparisons.gr",
         "07_unary_ops.gr",
         "08_nested_let.gr",
+        "09_if_else.gr",
+        "10_mutual_recursion.gr",
     ];
 
     for name in &happy_path_fixtures {

--- a/codebase/compiler/tests/bootstrap_trust_corpus/09_if_else.gr
+++ b/codebase/compiler/tests/bootstrap_trust_corpus/09_if_else.gr
@@ -1,0 +1,14 @@
+fn abs_value(x: Int) -> Int:
+    if x < 0:
+        ret 0 - x
+    else:
+        ret x
+
+fn signum(x: Int) -> Int:
+    if x > 0:
+        ret 1
+    else:
+        if x < 0:
+            ret 0 - 1
+        else:
+            ret 0

--- a/codebase/compiler/tests/bootstrap_trust_corpus/10_mutual_recursion.gr
+++ b/codebase/compiler/tests/bootstrap_trust_corpus/10_mutual_recursion.gr
@@ -1,0 +1,11 @@
+fn is_even(n: Int) -> Bool:
+    if n == 0:
+        ret true
+    else:
+        ret is_odd(n - 1)
+
+fn is_odd(n: Int) -> Bool:
+    if n == 0:
+        ret false
+    else:
+        ret is_even(n - 1)


### PR DESCRIPTION
## Summary
Mechanical expansion of the bootstrap trust corpus from 8 to 10 happy-path fixtures, per the handoff doc's call for further expansion (#266 set the corpus at 8/2; #281 takes it to 10/2).

## New fixtures
- `09_if_else.gr` — `abs_value` and `signum` exercise `if`/`else` plus nested `if`/`else`. Confirms `BrCond`-shaped lowering still flows end-to-end through the bootstrap pipeline + driver + query.
- `10_mutual_recursion.gr` — `is_even` / `is_odd` exercise forward-reference resolution in the host typechecker and cross-function call-site lowering through the IR builder.

## Test wiring
`bootstrap_trust_checks.rs` gains:
- `trust_if_else` and `trust_mutual_recursion` (using `assert_full_compile_trust`)
- both fixtures appended to `happy_path_fixtures` so `trust_phase_coverage_report` covers them too

## Validation
- `cargo test -p gradient-compiler --test bootstrap_trust_checks`: **14 passed** (was 12)
- `cargo test --workspace`: green
- `cargo clippy --workspace -- -D warnings`: clean

No kernel changes — pure corpus expansion within the existing trust gate's contract.

Fixes #281