### PR TITLE
feat(lsp): flip hover to delegate via bootstrap_lsp_hover (#283)

### DIFF
--- a/codebase/compiler/tests/self_hosting_smoke.rs
+++ b/codebase/compiler/tests/self_hosting_smoke.rs
@@ -817,3 +817,30 @@ fn lsp_gr_standalone_exposes_lifecycle_handlers() {
         );
     }
 }
+
+/// `compiler/lsp.gr` exports the richer-record LSP request handlers
+/// (`hover` so far) per #283 as expected top-level symbols. Locks
+/// `hover` so a regression that drops the symbol or renames it fails CI.
+#[test]
+fn lsp_gr_standalone_exposes_richer_handlers() {
+    let path = compiler_path("lsp.gr");
+    let session = Session::from_file(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
+
+    let names: Vec<String> = session.symbols().into_iter().map(|s| s.name).collect();
+
+    let expected = [
+        // #283: hover delegates to bootstrap_lsp_hover; first richer-record
+        // handler in lsp.gr.
+        "hover",
+    ];
+
+    for sym in expected {
+        assert!(
+            names.iter().any(|n| n == sym),
+            "expected lsp.gr to export `{}`, but symbols() returned: {:?}",
+            sym,
+            names,
+        );
+    }
+}

--- a/compiler/lsp.gr
+++ b/compiler/lsp.gr
@@ -321,6 +321,11 @@ mod lsp:
     /// Per #275 lifecycle flip.
     fn bootstrap_lsp_did_save(server_id: Int, uri: String, text: String) -> Int
 
+    /// Markdown-formatted hover content at the given 0-based LSP position
+    /// (`line`, `character`). Returns "" when nothing is hoverable. Per
+    /// #283 wider-LSP delegation flip.
+    fn bootstrap_lsp_hover(server_id: Int, uri: String, line: Int, character: Int) -> String
+
     /// Create a new LSP server instance.
     ///
     /// Delegates to `bootstrap_lsp_new_server` for a real kernel-backed
@@ -404,17 +409,16 @@ mod lsp:
     // LSP Request Handlers
     // =========================================================================
 
-    /// Handle hover request
+    /// Handle hover request.
+    ///
+    /// Delegates to `bootstrap_lsp_hover` (#283 wider-LSP delegation flip).
+    /// The kernel returns markdown content already (`"```gradient\n…\n```"`)
+    /// or "" if nothing is hoverable; the .gr-side body just wraps the
+    /// returned String in a `Hover` record.
     fn hover(server: LspServer, uri: String, position: LspPosition) -> Hover:
-        // In full implementation:
-        // 1. Get document content
-        // 2. Find identifier at position
-        // 3. Resolve type/signature
-        // 4. Return hover info
-
-        // For now, return empty hover
+        let markdown = bootstrap_lsp_hover(server.documents, uri, position.line, position.character)
         ret Hover {
-            contents: "",
+            contents: markdown,
             is_markdown: true
         }
 


### PR DESCRIPTION
## Summary

Flips `compiler/lsp.gr::hover` from a placeholder body returning an empty `Hover` to a real delegating body that calls `bootstrap_lsp_hover` (#283 wider-LSP delegation).

This is the **first richer-record LSP request handler** to delegate. The kernel returns markdown content directly, so the .gr-side body is a one-line wrap of the returned String into a `Hover { contents, is_markdown: true }` record. Establishes the multi-call pattern for follow-ups (`completion`, `document_symbol`, `run_diagnostics`).

## Changes

- **`compiler/lsp.gr`**:
  - New bodyless extern `fn bootstrap_lsp_hover(server_id: Int, uri: String, line: Int, character: Int) -> String` inside `mod lsp:` (alongside the existing #271/#275/#277 lifecycle externs).
  - `hover(server: LspServer, uri: String, position: LspPosition) -> Hover` body rewritten:
    ```gradient
    let markdown = bootstrap_lsp_hover(server.documents, uri, position.line, position.character)
    ret Hover {
        contents: markdown,
        is_markdown: true
    }
    ```
- **`codebase/compiler/tests/self_hosting_smoke.rs`**: added `lsp_gr_standalone_exposes_richer_handlers` standalone test locking `hover` as an exported symbol.

## Out of scope

- `kernel_boundary.rs` — lsp row already `SelfHostedDefault` per #272; no change needed.
- `docs/SELF_HOSTING.md` — table unchanged.
- `env.rs` — `bootstrap_lsp_hover` already registered per #259 (line 3016).
- `completion` / `document_symbol` / `run_diagnostics` flips — separate follow-ups; each requires iterating `_count` + per-index accessors.

## Testing

```
cd codebase
cargo test -p gradient-compiler --test self_hosting_smoke    # 23 passed (was 22)
cargo test --workspace                                        # green
cargo clippy --workspace -- -D warnings                       # clean
```

## Related

Fixes #283.

Builds on:
- #259/#260 (env.rs registration of all 146 kernel externs)
- #261/#262 (ModBlock first-pass ExternFn arm)
- #271/#272 (lsp row → SelfHostedDefault, predicates flipped)
- #275/#276 (lifecycle handlers flipped)
- #277/#278 (did_change signature shape adjustment)

Pattern reference: `references/gradient-self-hosted-body-flip-pattern.md` § "Follow-up flip sub-pattern".
