### PR TITLE
feat(lsp): flip document_symbol to delegate via bootstrap_lsp_document_symbol_count (#285)

### DIFF
--- a/codebase/compiler/tests/self_hosting_smoke.rs
+++ b/codebase/compiler/tests/self_hosting_smoke.rs
@@ -833,6 +833,9 @@ fn lsp_gr_standalone_exposes_richer_handlers() {
         // #283: hover delegates to bootstrap_lsp_hover; first richer-record
         // handler in lsp.gr.
         "hover",
+        // #285: document_symbol delegates to
+        // bootstrap_lsp_document_symbol_count; second richer-LSP handler.
+        "document_symbol",
     ];
 
     for sym in expected {

--- a/compiler/lsp.gr
+++ b/compiler/lsp.gr
@@ -326,6 +326,12 @@ mod lsp:
     /// #283 wider-LSP delegation flip.
     fn bootstrap_lsp_hover(server_id: Int, uri: String, line: Int, character: Int) -> String
 
+    /// Number of document symbols (functions, types, etc.) the kernel has
+    /// recorded for the document at `uri`. Per-index data is then read via
+    /// `bootstrap_lsp_document_symbol_name/_kind/_line/_character(server_id,
+    /// uri, index)`. Per #285 wider-LSP delegation flip.
+    fn bootstrap_lsp_document_symbol_count(server_id: Int, uri: String) -> Int
+
     /// Create a new LSP server instance.
     ///
     /// Delegates to `bootstrap_lsp_new_server` for a real kernel-backed
@@ -431,14 +437,16 @@ mod lsp:
         // 3. Return appropriate completions
         ret 0
 
-    /// Handle document symbol request
+    /// Handle document symbol request.
+    ///
+    /// Delegates to `bootstrap_lsp_document_symbol_count` (#285 wider-LSP
+    /// delegation flip). The returned `Int` is the symbol count for the
+    /// document at `uri`; per-index name/kind/line/character data is read
+    /// from the kernel via `bootstrap_lsp_document_symbol_*(server_id, uri,
+    /// index)` accessors (already exposed in env.rs per #259, exercised by
+    /// `tests/self_hosted_lsp.rs`).
     fn document_symbol(server: LspServer, uri: String) -> Int:
-        // Returns handle to document symbol list
-        // In full implementation:
-        // 1. Parse document
-        // 2. Extract all symbols (functions, types, variables)
-        // 3. Return symbol list
-        ret 0
+        ret bootstrap_lsp_document_symbol_count(server.documents, uri)
 
     /// Handle go-to-definition request
     fn goto_definition(server: LspServer, uri: String, position: LspPosition) -> LspRange:


### PR DESCRIPTION
## Summary

Second richer-LSP-handler flip following #283/#284 (`hover`), within the already-`SelfHostedDefault` lsp row. Establishes the multi-call kernel surface usage on the .gr side — the `_count + per-index accessor` shape that `completion`, `goto_definition`, and `run_diagnostics` will reuse.

## Changes

- Added bodyless extern declaration `bootstrap_lsp_document_symbol_count(server_id: Int, uri: String) -> Int` inside `mod lsp:`.
- Rewrote `document_symbol(server, uri) -> Int` body to delegate via `bootstrap_lsp_document_symbol_count(server.documents, uri)`. The returned `Int` is the symbol count; per-index name/kind/line/character data is read by callers via `bootstrap_lsp_document_symbol_*(server_id, uri, index)` (already in env.rs per #259).
- Locked `document_symbol` as an exported symbol in the smoke test `lsp_gr_standalone_exposes_richer_handlers`.

## What stays the same

- `kernel_boundary.rs` — lsp row already `SelfHostedDefault` per #272.
- `docs/SELF_HOSTING.md` — boundary table unchanged.
- `env.rs` — extern already registered per #259.

## Validation

- `cargo build -p gradient-compiler`: green
- `cargo test -p gradient-compiler --test self_hosting_smoke`: 23 passed
- `cargo test -p gradient-compiler --test self_hosted_lsp`: 13 passed
- `cargo test --workspace`: green
- `cargo clippy --workspace -- -D warnings`: clean

Fixes #285
