### PR TITLE
feat(lsp): flip completion to delegate via bootstrap_lsp_completion_count (#287)

### DIFF
--- a/codebase/compiler/tests/self_hosting_smoke.rs
+++ b/codebase/compiler/tests/self_hosting_smoke.rs
@@ -836,6 +836,9 @@ fn lsp_gr_standalone_exposes_richer_handlers() {
         // #285: document_symbol delegates to
         // bootstrap_lsp_document_symbol_count; second richer-LSP handler.
         "document_symbol",
+        // #287: completion delegates to bootstrap_lsp_completion_count;
+        // third richer-LSP handler.
+        "completion",
     ];
 
     for sym in expected {

--- a/compiler/lsp.gr
+++ b/compiler/lsp.gr
@@ -332,6 +332,12 @@ mod lsp:
     /// uri, index)`. Per #285 wider-LSP delegation flip.
     fn bootstrap_lsp_document_symbol_count(server_id: Int, uri: String) -> Int
 
+    /// Number of completion items the kernel proposes for the document at
+    /// `uri` (currently document-wide, not position-sensitive). Per-index
+    /// data is read via `bootstrap_lsp_completion_label/_kind/_detail(
+    /// server_id, uri, index)`. Per #287 wider-LSP delegation flip.
+    fn bootstrap_lsp_completion_count(server_id: Int, uri: String) -> Int
+
     /// Create a new LSP server instance.
     ///
     /// Delegates to `bootstrap_lsp_new_server` for a real kernel-backed
@@ -428,14 +434,19 @@ mod lsp:
             is_markdown: true
         }
 
-    /// Handle completion request
+    /// Handle completion request.
+    ///
+    /// Delegates to `bootstrap_lsp_completion_count` (#287 wider-LSP
+    /// delegation flip). The returned `Int` is the completion-item count
+    /// for the document at `uri`; per-index label/kind/detail data is read
+    /// from the kernel via `bootstrap_lsp_completion_*(server_id, uri,
+    /// index)` accessors (already exposed in env.rs per #259, exercised by
+    /// `tests/self_hosted_lsp.rs::completion_includes_symbols_keywords_and_builtins`).
+    /// `position` is currently unused — the kernel produces document-wide
+    /// completion items per #233; the parameter is preserved for
+    /// forward-compatibility with a future position-aware kernel surface.
     fn completion(server: LspServer, uri: String, position: LspPosition) -> Int:
-        // Returns handle to completion item list
-        // In full implementation:
-        // 1. Get document content
-        // 2. Determine context at position
-        // 3. Return appropriate completions
-        ret 0
+        ret bootstrap_lsp_completion_count(server.documents, uri)
 
     /// Handle document symbol request.
     ///


### PR DESCRIPTION
## Summary

Third richer-LSP-handler flip following #283/#284 (`hover`) and #285/#286 (`document_symbol`), within the already-`SelfHostedDefault` lsp row.

## Changes

- Added bodyless extern declaration `bootstrap_lsp_completion_count(server_id: Int, uri: String) -> Int` inside `mod lsp:`.
- Rewrote `completion(server, uri, position) -> Int` body to delegate via `bootstrap_lsp_completion_count(server.documents, uri)`. The returned `Int` is the completion-item count; per-index label/kind/detail data is read by callers via `bootstrap_lsp_completion_*(server_id, uri, index)`.
- `position` is currently unused — the kernel produces document-wide completion items per #233; preserved for forward compatibility.
- Locked `completion` as an exported symbol in the smoke test.

## What stays the same

- `kernel_boundary.rs` — lsp row already `SelfHostedDefault` per #272.
- `docs/SELF_HOSTING.md` — boundary table unchanged.
- `env.rs` — extern already registered per #259.

## Validation

- `cargo build -p gradient-compiler`: green
- `cargo test -p gradient-compiler --test self_hosting_smoke`: 23 passed
- `cargo test -p gradient-compiler --test self_hosted_lsp`: 13 passed
- `cargo test --workspace`: green
- `cargo clippy --workspace -- -D warnings`: clean

Fixes #287
