### PR TITLE
feat(lsp): flip run_diagnostics via did_save + diagnostic_count (#289)

### DIFF
--- a/codebase/compiler/tests/self_hosting_smoke.rs
+++ b/codebase/compiler/tests/self_hosting_smoke.rs
@@ -839,6 +839,9 @@ fn lsp_gr_standalone_exposes_richer_handlers() {
         // #287: completion delegates to bootstrap_lsp_completion_count;
         // third richer-LSP handler.
         "completion",
+        // #289: run_diagnostics chains bootstrap_lsp_did_save +
+        // bootstrap_lsp_diagnostic_count; fourth richer-LSP handler.
+        "run_diagnostics",
     ];
 
     for sym in expected {

--- a/compiler/lsp.gr
+++ b/compiler/lsp.gr
@@ -338,6 +338,12 @@ mod lsp:
     /// server_id, uri, index)`. Per #287 wider-LSP delegation flip.
     fn bootstrap_lsp_completion_count(server_id: Int, uri: String) -> Int
 
+    /// Number of diagnostics the kernel has accumulated for the document
+    /// at `uri`. Per-index data is read via `bootstrap_lsp_diagnostic_
+    /// severity/_message/_line/_character(server_id, uri, index)`. Per
+    /// #289 wider-LSP delegation flip.
+    fn bootstrap_lsp_diagnostic_count(server_id: Int, uri: String) -> Int
+
     /// Create a new LSP server instance.
     ///
     /// Delegates to `bootstrap_lsp_new_server` for a real kernel-backed
@@ -474,15 +480,20 @@ mod lsp:
     // Diagnostics
     // =========================================================================
 
-    /// Run diagnostics on a document
+    /// Run diagnostics on a document.
+    ///
+    /// Delegates to `bootstrap_lsp_did_save` (which updates the kernel
+    /// document content and re-runs lex/parse/type-check diagnostics)
+    /// then returns the diagnostic count via
+    /// `bootstrap_lsp_diagnostic_count` (#289 wider-LSP delegation flip).
+    /// Per-index severity/message/line/character data is read by callers
+    /// via `bootstrap_lsp_diagnostic_*(server_id, uri, index)` accessors
+    /// (already exposed in env.rs per #259, exercised by
+    /// `tests/self_hosted_lsp.rs::diagnostics_track_parse_errors_real_time`
+    /// and friends).
     fn run_diagnostics(server: LspServer, uri: String, text: String) -> Int:
-        // Returns handle to diagnostic list
-        // In full implementation:
-        // 1. Run lexer
-        // 2. Run parser
-        // 3. Run type checker
-        // 4. Collect all errors as diagnostics
-        ret 0
+        let _ok = bootstrap_lsp_did_save(server.documents, uri, text)
+        ret bootstrap_lsp_diagnostic_count(server.documents, uri)
 
     /// Publish diagnostics to client
     fn publish_diagnostics(uri: String, diagnostics: Int) -> ():


### PR DESCRIPTION
## Summary

Fourth (and final richer-record) LSP-handler flip in `lsp.gr`, completing the wider-LSP delegation series after #283/#284 (`hover`), #285/#286 (`document_symbol`), and #287/#288 (`completion`). Within the already-`SelfHostedDefault` lsp row.

## Changes

- Added bodyless extern declaration `bootstrap_lsp_diagnostic_count(server_id: Int, uri: String) -> Int` inside `mod lsp:`. (`bootstrap_lsp_did_save` was already declared per #275.)
- Rewrote `run_diagnostics(server, uri, text) -> Int` body to chain `bootstrap_lsp_did_save` (which updates the kernel document content and re-runs lex/parse/type-check diagnostics) then `bootstrap_lsp_diagnostic_count` to return the resulting count.
- Locked `run_diagnostics` as an exported symbol in the smoke test.

## Notes

- `goto_definition` is intentionally NOT flipped in this PR — the kernel exposes no symbol-position resolution surface yet; that would need new `bootstrap_lsp.rs` plumbing (separate effort).
- `kernel_boundary.rs` / `docs/SELF_HOSTING.md` / `env.rs` unchanged.

## Validation

- `cargo build -p gradient-compiler`: green
- `cargo test -p gradient-compiler --test self_hosting_smoke`: 23 passed
- `cargo test -p gradient-compiler --test self_hosted_lsp`: 13 passed
- `cargo test --workspace`: green
- `cargo clippy --workspace -- -D warnings`: clean

Fixes #289
