### PR TITLE
docs: add STATUS banners to all docs/*.md

### DIFF
--- a/docs/RUNTIME_AUTHORITY.md
+++ b/docs/RUNTIME_AUTHORITY.md
@@ -1,5 +1,7 @@
 # Gradient Runtime Authority
 
+> **STATUS:** partial — Architectural reference. The runtime ambiguity it documents is partially resolved; the COW/refcount path is implemented, the modular runtime split (Epic #298) is planned.
+
 **Date:** 2026-04-05  
 **Status:** Critical Architecture Documentation  
 **Purpose:** Resolve runtime ambiguity identified in adversarial synthesis

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,5 +1,7 @@
 # Self-Hosting Roadmap
 
+> **STATUS:** partial — Self-hosting is in active bootstrap stage. Several modules delegate via `bootstrap_*` kernel surfaces; full self-host (~95% Gradient) is roadmapped under Epic #116.
+
 Gradient is moving compiler ownership from the Rust host compiler into `compiler/*.gr` while keeping a small, explicit Rust kernel for runtime/platform primitives and backend machinery.
 
 Status: active bootstrap-stage work, not fully self-hosted.

--- a/docs/WASM.md
+++ b/docs/WASM.md
@@ -1,5 +1,7 @@
 # WebAssembly Backend
 
+> **STATUS:** partial — WASM backend exists behind the `wasm` Cargo feature. Cranelift is the default production-path backend; WASM is experimental and not the primary deployment story.
+
 The Gradient WASM backend compiles Gradient IR to WebAssembly binary format and
 is available via the `wasm` Cargo feature.
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,5 +1,7 @@
 # Agent Integration Guide
 
+> **STATUS:** partial — Grammar-constrained decoding, runtime contracts, effects, and the Query API are implemented. Static `@verified` SMT discharge, `@untrusted` source mode, and capability-scoped manifests are planned (Epics #297, #302, #303).
+
 This document is the primary reference for AI agents integrating Gradient into their tool chains. It covers structured output formats, typed holes, the LSP server with agent-specific extensions, and recommended integration patterns.
 
 For Gradient's design principles and research foundation, see [README.md](../README.md). This guide focuses on practical integration details.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Gradient Architecture Guide
 
+> **STATUS:** partial — Pipeline, Cranelift backend, type system, contracts, effects, Query API, LSP are implemented. LLVM backend split, modular runtime, capability/arena memory model, and tiered contracts are planned (Epics #299, #298, #296, #297).
+
 This document describes the internals of the Gradient compiler and toolchain. It is intended for AI agents working on or integrating with Gradient.
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,7 @@
 # Gradient CLI Reference
 
+> **STATUS:** partial — Documented commands `build`, `run`, `check`, `test`, `fmt`, `repl`, and dependency workflows are implemented. `bench`, `doc`, `asm`, `bindgen`, cross-compile via `--target`, and DWARF emit are planned (Epics #304, #299).
+
 `gradient` is the unified CLI for the Gradient programming language. All toolchain operations -- build, run, test, format -- go through this single command.
 
 ## Installation (from source)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,7 @@
 # Getting Started with Gradient
 
+> **STATUS:** implemented — Walkthrough reflects the current build flow. Examples compile against today's compiler.
+
 Gradient is an LLM-first programming language designed for autonomous AI agents. This guide walks you through building Gradient from source, creating your first project, and understanding the core syntax. If you are an AI agent or LLM learning Gradient for the first time, read this document end to end before attempting to generate Gradient code.
 
 ## Prerequisites

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -1,5 +1,7 @@
 # Gradient v0.1 Language Guide
 
+> **STATUS:** partial — Surface syntax (functions, contracts, effects, generics, ADTs, modules, traits, actors) is implemented. Effect-tier expansion (`!{Heap}`/`!{Stack}`/`!{Static}`/`!{Async}`/`!{Atomic}`/`!{Volatile}`/`!{Throws}`), capability tokens, and arenas are planned (Epics #295, #296).
+
 > **Audience:** AI agents and LLMs that need to read, write, and reason about Gradient code.
 > After one pass through this document, you should be able to produce correct Gradient programs.
 

--- a/docs/language-model-card.md
+++ b/docs/language-model-card.md
@@ -1,5 +1,7 @@
 # Gradient Language Model Card
 
+> **STATUS:** partial — Reference card covers today's surface. Effect-tier and capability surface are roadmapped (Epics #295, #296). Treat any annotation not appearing in this card as planned, not implemented.
+
 > Target: ~10K tokens for agent context windows
 > Version: v0.1
 > Purpose: Complete quick reference for AI agents generating Gradient code

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,5 +1,7 @@
 # Gradient Monitoring & Observability
 
+> **STATUS:** implemented — CI/build observability documented matches the running setup. Web-service monitoring section is forward-looking and labelled as such.
+
 ## Overview
 
 Gradient is a CLI compiler tool — not a web service. Observability means tracking **CI pipeline health**, **build performance**, and **code quality gates**, not uptime or HTTP latency.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,7 @@
 # Gradient Roadmap
 
+> **STATUS:** partial — Roadmap reflects current alpha state and locked vision. Epic-level details now tracked in GitHub Epics #294-#304 + #116; this doc summarizes.
+
 Gradient is an alpha-stage programming language and compiler stack built for AI-assisted software development.
 
 The April 2026 research direction remains current:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,5 +1,7 @@
 # Gradient On-Call Runbook
 
+> **STATUS:** implemented — Procedures cover today's CI/dev failure modes. Web-service runbook section is explicitly forward-looking.
+
 ## Purpose
 
 This runbook covers the most common failure scenarios for the Gradient project. It is scoped to the CI pipeline and local development toolchain for the pre-production phase. Add a web-service section when a hosted component is deployed.

--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -1,5 +1,7 @@
 # Secrets Management
 
+> **STATUS:** implemented — Inventory and rotation policy reflect current repo state. Sigstore-signed registry workflow (Epic #303) will extend this when shipped.
+
 ## Audit Status
 
 **Last audited:** 2026-03-30


### PR DESCRIPTION
## Summary

Resolves E1 sub #307 (parent epic #294).

Per Q19 of the 2026-05-02 alignment session, every doc gets a `STATUS:` banner so readers can immediately distinguish today's implementation from partial/planned behavior. This is the cheapest, highest-leverage doc-honesty change — single line per file, no content rewrite.

## Format

```
# <Title>

> **STATUS:** <level> — <one-line caveat>
```

Levels: `implemented` | `partial` | `planned`.

## Status assignments

| Doc | Status | Why |
|---|---|---|
| `getting-started.md` | implemented | Walkthrough matches today's build flow |
| `monitoring.md` | implemented | CI/build observability matches running setup |
| `runbook.md` | implemented | Procedures cover today's failure modes |
| `secrets-management.md` | implemented | Inventory matches current repo state |
| `agent-integration.md` | partial | Grammar/runtime contracts/effects/Query API ✅; static `@verified`, `@untrusted`, manifests planned (#297, #302, #303) |
| `architecture.md` | partial | Cranelift/types/contracts/effects/LSP ✅; LLVM split, modular runtime, capabilities planned (#296, #298, #299) |
| `cli-reference.md` | partial | `build`/`run`/`check`/`test`/`fmt`/`repl` ✅; `bench`/`doc`/`asm`/`bindgen`/`--target`/DWARF planned (#304, #299) |
| `language-guide.md` | partial | Surface syntax ✅; effect-tier expansion + capabilities planned (#295, #296) |
| `language-model-card.md` | partial | Today's surface ✅; effect/capability surface roadmapped |
| `roadmap.md` | partial | Reflects current alpha; epic-level details now in #294-#304 + #116 |
| `RUNTIME_AUTHORITY.md` | partial | Current refcount/COW path ✅; modular runtime split planned (#298) |
| `SELF_HOSTING.md` | partial | Bootstrap stage active; full ~95% Gradient roadmapped (#116) |
| `WASM.md` | partial | WASM behind `wasm` feature; experimental, not primary deployment |

## Acceptance (per #307)

- [x] Every file in `docs/*.md` has a `STATUS:` banner
- [x] Banner placed near top, after the H1 title
- [x] `STATUS: implemented` only for files whose claims are CI-verifiable today
- [x] `STATUS: partial` for files mixing implemented + planned (most of the doc set)
- [x] No file marked `STATUS: planned` (no all-planned docs exist yet — the `roadmap.md` itself describes mixed state)

## Out of scope

- Rewriting any prose. This PR is banner-only.
- Tagline + systems use case in README (#308).
- Self-host reframing (#309).
- Stale `.gr` tree deletion (#310).

Closes #307
Part of Epic #294
