### PR TITLE
docs(README): add 'Systems-grade. Agent-native.' tagline + systems use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 **An agent-native programming language and compiler stack.**
 
+**Systems-grade. Agent-native.**
+
 <br/>
 
 [![Status](https://img.shields.io/badge/status-alpha-blueviolet?style=flat-square&labelColor=0d0d17)](https://github.com/Ontic-Systems/Gradient)
@@ -25,12 +27,13 @@ It combines a typed language, a compiler with structured query surfaces, and a r
 
 ## What Gradient Is For
 
-Gradient targets four overlapping use cases:
+Gradient targets five overlapping use cases:
 
 1. **Agent-assisted coding.** Give coding agents a language with explicit effects, contracts, and a machine-readable compiler surface instead of relying on fragile prompt-only loops.
 2. **Compiler-verified automation.** Move from generate-compile-fix toward generate-check-verify by making syntax, type expectations, and side effects more explicit.
 3. **Tooling for agent workflows.** Expose compiler services, diagnostics, and query APIs that are easier for agents and IDEs to consume than raw terminal text.
-4. **Research on agent-native languages.** Explore how tools, authority, effects, contracts, and eventually memory/protocol abstractions can become first-class language concepts.
+4. **Agent-emitted systems code.** Provide a systems-tier surface — effects gating allocation and concurrency, capability tokens for resources, arenas instead of borrow-checker dialogue — so agents can emit infra, runtime, and lower-stack code without the LLM-hostile failure modes that block them on Rust today. Systems-tier features (effect-gated `!{Heap}`/`!{Stack}`/`!{Static}`, atomics with memory ordering, `core`/`alloc`/`std` split, LLVM release backend, cross-compile, DWARF) are roadmapped under Epics #295, #296, #298, #299, #300.
+5. **Research on agent-native languages.** Explore how tools, authority, effects, contracts, and eventually memory/protocol abstractions can become first-class language concepts.
 
 ## Why Gradient Exists
 


### PR DESCRIPTION
## Summary

Resolves E1 sub #308 (parent epic #294). Per Q16/Q17 of the 2026-05-02 alignment session and the locked tagline `Systems-grade. Agent-native.`, the README must reflect the agent-native + systems-first generalist positioning, not just the agent-native subset.

## Changes

1. **Tagline added** beneath the existing strapline:
   - Existing: "An agent-native programming language and compiler stack."
   - New tagline: "Systems-grade. Agent-native."
   - Tiered messaging — strapline keeps the prose pitch, tagline serves as the wedge per Q16.

2. **New use case** in "What Gradient Is For" (4 → 5):
   - **Agent-emitted systems code.** Names the systems-tier surface (effects gating allocation/concurrency, capability tokens, arenas, no borrow-checker dialogue) and the LLM-hostile failure modes Gradient avoids vs Rust.
   - Calls out that systems-tier features (`!{Heap}`/`!{Stack}`/`!{Static}`, atomics with memory ordering, `core`/`alloc`/`std` split, LLVM release backend, cross-compile, DWARF) are **roadmapped** under Epics #295, #296, #298, #299, #300 — honest and traceable.

## No false claims

- Tagline is positional, not technical (does not assert any feature).
- New use case explicitly labels every systems-tier feature as "roadmapped" with epic numbers, so a hostile reviewer cannot mistake it for an implemented-now claim.
- Existing implemented features in "What Works Today" remain unchanged.

## Acceptance (per #308)

- [x] README header includes "Systems-grade. Agent-native." tagline
- [x] "What Gradient Is For" lists at least one systems-tier use case
- [x] No marketing claim contradicts implementation reality (every new claim explicitly labelled as roadmapped)
- [x] Cross-link to roadmap doc / epic numbers (#295, #296, #298, #299, #300 inline)

## Out of scope

- Self-host reframing as philosophy + trust artifact (#309)
- Stale `.gr` tree deletion (#310)
- Roadmap doc rewrite (#311)

Closes #308
Part of Epic #294
