### PR TITLE
docs(README): reframe self-hosting as philosophy + trust artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 Gradient is a programming language designed for AI-assisted development.
 
-It combines a typed language, a compiler with structured query surfaces, and a roadmap toward self-hosting so that agents can generate, inspect, verify, and eventually improve the language in the language itself.
+It combines a typed language, a compiler with structured query surfaces, and an active commitment to writing the compiler in itself — self-hosting as proof that the language is real for systems work, not a feature aimed at end users.
 
 ## What Gradient Is For
 
@@ -50,7 +50,7 @@ Gradient is built to reduce that waste through:
 | **Effect tracking** | makes side effects explicit instead of implicit |
 | **Contracts** | supports generate-check-verify workflows |
 | **Structured compiler queries** | gives agents machine-readable diagnostics and symbol data |
-| **Self-hosting roadmap** | turns the compiler into a dogfooded agent-facing system |
+| **Self-hosting (philosophy + trust artifact)** | the compiler is being written in Gradient — proof the language is real for systems work, and a live dogfooding loop that pressures the design |
 
 ## What Works Today
 
@@ -224,6 +224,18 @@ Detailed docs:
 
 - [Project Roadmap](docs/roadmap.md)
 - [Self-Hosting Roadmap](docs/SELF_HOSTING.md)
+
+## Self-Hosting as Philosophy
+
+Gradient is being written in Gradient. The Rust host compiler is the trusted kernel today; `compiler/*.gr` is the active self-hosted tree, and the kernel boundary is being progressively shrunk.
+
+We treat self-hosting as **philosophy + trust artifact**, not a user-facing feature:
+
+- if a language is going to claim systems-tier credibility, the compiler should be expressible in it
+- writing the compiler in Gradient is the most aggressive dogfooding loop available: every effect, capability, contract, and ergonomic decision has to survive use in the compiler itself before it ships to anyone else
+- the Rust-vs-Gradient lines-of-code ratio is a public metric that tracks the trajectory honestly (planned, see Epic #116)
+
+This is **not** the same claim as "agents will edit the compiler." Self-hosting is a discipline we apply to ourselves; it is not something we expect downstream agents or users to depend on.
 
 ## Intended Positioning
 


### PR DESCRIPTION
## Summary

Resolves E1 sub #309 (parent epic #294). Per Q10 of the 2026-05-02 alignment session, self-hosting is reframed as **philosophy + trust artifact**, not a user-facing feature. The "agents will edit the compiler" framing was overclaim cosplay aimed at a thin researcher audience (persona C from Q16).

## Changes

1. **Opening prose** (line 24):
   - Old: "...a roadmap toward self-hosting so that agents can generate, inspect, verify, and eventually improve the language in the language itself."
   - New: "...an active commitment to writing the compiler in itself — self-hosting as proof that the language is real for systems work, not a feature aimed at end users."

2. **"Why Gradient Exists" table** (line 53):
   - Row label: "Self-hosting roadmap" → "Self-hosting (philosophy + trust artifact)"
   - Description shifts from "turns the compiler into a dogfooded agent-facing system" to dogfooding pressure on every design decision (effects, caps, contracts, ergonomics).

3. **New top-level section "Self-Hosting as Philosophy"** between "Detailed docs" and "Intended Positioning". Three explicit framings:
   - Systems credibility argument (compiler should be expressible in the language)
   - Aggressive dogfooding loop (features must survive use in the compiler before shipping)
   - Public LoC ratio metric as honest trajectory tracker (planned, Epic #116)

4. **Explicit disclaimer**: *"This is **not** the same claim as 'agents will edit the compiler.' Self-hosting is a discipline we apply to ourselves; it is not something we expect downstream agents or users to depend on."*

## Acceptance (per #309)

- [x] Drop "agents will edit the compiler" framing (replaced with honest discipline framing + explicit disclaimer)
- [x] Add language about self-host as proof-of-realness for systems work
- [x] Reference public LoC metric (Epic #116) for trajectory tracking

## Out of scope

- Stale `.gr` tree deletion (#310)
- Roadmap doc rewrite (#311)
- Encrypted handoff backup (#312)
- LoC dashboard implementation (tracked under #116 / #381)

Closes #309
Part of Epic #294
