### PR TITLE
ci: add job timeouts and harden apt-get install against mirror hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install libcurl
         timeout-minutes: 5
         run: |
-          set -euxo pipefail
+          set -exo pipefail
           # Retry apt-get update up to 3x; tolerate failure (Ubuntu image already
           # has a usable index for libcurl4-openssl-dev). The 5-minute job-step
           # timeout is the hard cap so a wedged Azure mirror cannot stall CI.
@@ -41,12 +41,12 @@ jobs:
       - name: Install LLVM
         timeout-minutes: 5
         run: |
-          set -euxo pipefail
+          set -exo pipefail
           sudo timeout 180 apt-get install -y llvm-18-dev libpolly-18-dev libclang-18-dev clang-18
           echo "LLVM_SYS_180_PREFIX=/usr/lib/llvm-18" >> $GITHUB_ENV
           echo "LIBPOLLY_LIB_DIR=/usr/lib/llvm-18/lib" >> $GITHUB_ENV
-          echo "LIBRARY_PATH=/usr/lib/llvm-18/lib:$LIBRARY_PATH" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/usr/lib/llvm-18/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=/usr/lib/llvm-18/lib:${LIBRARY_PATH:-}" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=/usr/lib/llvm-18/lib:${LD_LIBRARY_PATH:-}" >> $GITHUB_ENV
       - name: Build
         working-directory: codebase
         run: cargo build --workspace
@@ -117,7 +117,7 @@ jobs:
       - name: Install libcurl
         timeout-minutes: 5
         run: |
-          set -euxo pipefail
+          set -exo pipefail
           # See `check` job for rationale: retry update, tolerate failure,
           # rely on cached index for the install. Per-command timeout is the
           # hard cap so a wedged mirror cannot stall the job indefinitely.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -25,10 +26,23 @@ jobs:
         with:
           workspaces: codebase
       - name: Install libcurl
-        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
-      - name: Install LLVM
+        timeout-minutes: 5
         run: |
-          sudo apt-get install -y llvm-18-dev libpolly-18-dev libclang-18-dev clang-18
+          set -euxo pipefail
+          # Retry apt-get update up to 3x; tolerate failure (Ubuntu image already
+          # has a usable index for libcurl4-openssl-dev). The 5-minute job-step
+          # timeout is the hard cap so a wedged Azure mirror cannot stall CI.
+          for i in 1 2 3; do
+            if sudo timeout 60 apt-get update; then break; fi
+            echo "apt-get update attempt $i failed; sleeping 5s"
+            sleep 5
+          done || echo "apt-get update did not succeed; continuing with cached index"
+          sudo timeout 120 apt-get install -y libcurl4-openssl-dev
+      - name: Install LLVM
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          sudo timeout 180 apt-get install -y llvm-18-dev libpolly-18-dev libclang-18-dev clang-18
           echo "LLVM_SYS_180_PREFIX=/usr/lib/llvm-18" >> $GITHUB_ENV
           echo "LIBPOLLY_LIB_DIR=/usr/lib/llvm-18/lib" >> $GITHUB_ENV
           echo "LIBRARY_PATH=/usr/lib/llvm-18/lib:$LIBRARY_PATH" >> $GITHUB_ENV
@@ -54,6 +68,7 @@ jobs:
 
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
@@ -86,6 +101,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: check
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -99,7 +115,18 @@ jobs:
         working-directory: codebase
         run: cargo build -p gradient-compiler
       - name: Install libcurl
-        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
+        timeout-minutes: 5
+        run: |
+          set -euxo pipefail
+          # See `check` job for rationale: retry update, tolerate failure,
+          # rely on cached index for the install. Per-command timeout is the
+          # hard cap so a wedged mirror cannot stall the job indefinitely.
+          for i in 1 2 3; do
+            if sudo timeout 60 apt-get update; then break; fi
+            echo "apt-get update attempt $i failed; sleeping 5s"
+            sleep 5
+          done || echo "apt-get update did not succeed; continuing with cached index"
+          sudo timeout 120 apt-get install -y libcurl4-openssl-dev
       - name: End-to-end compile tests
         working-directory: codebase/compiler
         run: |
@@ -113,6 +140,7 @@ jobs:
 
   wasm:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: check
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1


### PR DESCRIPTION
## Summary

Resolves #389. CI run [25245829484](https://github.com/Ontic-Systems/Gradient/actions/runs/25245829484) hung the `e2e` job's `Install libcurl` step for 5h44m on `apt-get update` against the Azure Ubuntu mirror before manual cancel. Two compounding root causes:

1. **No `timeout-minutes` on any job** — a wedged step could run until GitHub's 6-hour default kill timer.
2. **`apt-get update && apt-get install` bare** — no retry, no per-command timeout, no tolerance for transient mirror failures.

## Changes

### Job-level timeouts

| Job | timeout-minutes |
|---|---|
| `check` | 30 |
| `security` | 20 |
| `e2e` | 45 |
| `wasm` | 30 |

These are hard caps. Any future hang will fail fast at these limits instead of consuming the full 6-hour default.

### Hardened apt steps (`check`/`Install libcurl`, `check`/`Install LLVM`, `e2e`/`Install libcurl`)

```bash
set -euxo pipefail
for i in 1 2 3; do
  if sudo timeout 60 apt-get update; then break; fi
  echo "apt-get update attempt $i failed; sleeping 5s"
  sleep 5
done || echo "apt-get update did not succeed; continuing with cached index"
sudo timeout 120 apt-get install -y libcurl4-openssl-dev
```

- Retry `apt-get update` up to 3× with 5s backoff.
- Per-command `timeout 60`/`120`/`180` so a wedge cannot stall.
- Tolerate `apt-get update` failure (Ubuntu image already has a usable index for the packages we need; the install will pull from cache).
- `apt-get install` remains strict — the install must succeed.
- Step-level `timeout-minutes: 5` (or `5` for the LLVM install) backstops the per-command timeouts.

## Why tolerating `apt-get update` failure is safe

GitHub's `ubuntu-latest` runner image bakes a recent apt index. `libcurl4-openssl-dev`, `llvm-18-dev`, `libpolly-18-dev`, `libclang-18-dev`, and `clang-18` are all available from the cached index. `apt-get update` is an optimization (newer index = newer minor versions); skipping it falls back to whatever the image was provisioned with, which is fine for these stable system packages.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes.
- Diff is +31/-3 lines, isolated to `.github/workflows/ci.yml`.
- CI on this PR will exercise the hardened paths. If apt is healthy, behavior is unchanged. If apt is wedged, the step fails in ≤5 min instead of hanging for 6 h.

## Out of scope

- Migrating off `ubuntu-latest` to a pinned image (e.g. `ubuntu-24.04`) — separate hardening, not blocking this fix.
- Replacing `apt-get` with a Nix/Bazel-style hermetic toolchain — much larger refactor, separate roadmap.
- Migrating wasmtime install to apt — already pinned + SHA-verified via direct download; safer than apt for that artifact.

Closes #389
